### PR TITLE
Fix Init per Sender

### DIFF
--- a/module.go
+++ b/module.go
@@ -5,7 +5,7 @@ type Scanner interface {
 	// Init runs once for this module at library init time
 	Init(flags ScanFlags) error
 
-	// InitPerSender runs once per Goroutine. A single Goroutine will scan some non-deterministics
+	// InitPerSender runs once per Goroutine. A single Goroutine will scan some non-deterministic
 	// subset of the input scan targets
 	InitPerSender(senderID int) error
 

--- a/processing.go
+++ b/processing.go
@@ -91,6 +91,10 @@ func Process(mon *Monitor) {
 	//Start all the workers
 	for i := 0; i < workers; i++ {
 		go func() {
+			for _, scannerName := range orderedScanners {
+				scanner := *scanners[scannerName]
+				scanner.InitPerSender(i)
+			}
 			for obj := range processQueue {
 				for run := uint(0); run < uint(config.ConnectionsPerHost); run++ {
 					result := grabTarget(obj, mon)

--- a/processing.go
+++ b/processing.go
@@ -90,7 +90,7 @@ func Process(mon *Monitor) {
 	}()
 	//Start all the workers
 	for i := 0; i < workers; i++ {
-		go func() {
+		go func(i int) {
 			for _, scannerName := range orderedScanners {
 				scanner := *scanners[scannerName]
 				scanner.InitPerSender(i)
@@ -102,7 +102,7 @@ func Process(mon *Monitor) {
 				}
 			}
 			workerDone.Done()
-		}()
+		}(i)
 	}
 
 	// Read the input, send to workers


### PR DESCRIPTION
Actually call Init Per Sender for every registered scanner for each goroutine. 