### PR TITLE
Remove pointer-to-interface in zgrab2 framework

### DIFF
--- a/cmd/zgrab2/main.go
+++ b/cmd/zgrab2/main.go
@@ -42,13 +42,13 @@ func main() {
 		}
 		for i, fl := range flagsReturned {
 			f, _ := fl.(zgrab2.ScanFlags)
-			mod := *zgrab2.GetModule(modTypes[i])
+			mod := zgrab2.GetModule(modTypes[i])
 			s := mod.NewScanner()
 			s.Init(f)
 			zgrab2.RegisterScan(s.GetName(), s)
 		}
 	} else {
-		mod := *zgrab2.GetModule(moduleType)
+		mod := zgrab2.GetModule(moduleType)
 		s := mod.NewScanner()
 		s.Init(flag)
 		zgrab2.RegisterScan(moduleType, s)

--- a/module.go
+++ b/module.go
@@ -62,12 +62,12 @@ func (b *BaseFlags) GetName() string {
 
 // GetModule returns the registered module that corresponds to the given name
 // or nil otherwise
-func GetModule(name string) *ScanModule {
+func GetModule(name string) ScanModule {
 	return modules[name]
 }
 
-var modules map[string]*ScanModule
+var modules map[string]ScanModule
 
 func init() {
-	modules = make(map[string]*ScanModule)
+	modules = make(map[string]ScanModule)
 }

--- a/utility.go
+++ b/utility.go
@@ -31,7 +31,7 @@ func AddCommand(command string, shortDescription string, longDescription string,
 	}
 	cmd.FindOptionByLongName("port").Default = []string{strconv.FormatUint(uint64(port), 10)}
 	cmd.FindOptionByLongName("name").Default = []string{command}
-	modules[command] = &m
+	modules[command] = m
 	return cmd, nil
 }
 


### PR DESCRIPTION
Interfaces are effectively already pointers, see
https://research.swtch.com/interfaces.