### PR TITLE
Implement TLS module

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package zgrab2
+
+import "errors"
+
+var ErrMismatchedFlags = errors.New("mismatched flag/module")

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -7,15 +7,7 @@ import (
 
 type TLSFlags struct {
 	zgrab2.BaseFlags
-	Heartbleed           bool        `long:"heartbleed" description:"Check if server is vulnerable to Heartbleed"`
-	Version              int         `long:"version" description:"Max TLS version to use"`
-	Verbose              bool        `long:"verbose" description:"Add extra TLS information to JSON output (client hello, client KEX, key material, etc)" json:"verbose"`
-	SessionTicket        bool        `long:"session-ticket" description:"Send support for TLS Session Tickets and output ticket if presented" json:"session"`
-	ExtendedMasterSecret bool        `long:"extended-master-secret" description:"Offer RFC 7627 Extended Master Secret extension" json:"extended"`
-	ExtendedRandom       bool        `long:"extended-random" description:"Send TLS Extended Random Extension" json:"extran"`
-	NoSNI                bool        `long:"no-sni" description:"Do not send domain name in TLS Handshake regardless of whether known" json:"sni"`
-	SCTExt               bool        `long:"sct" description:"Request Signed Certificate Timestamps during TLS Handshake" json:"sct"`
-	HTTP                 HTTPOptions `json:"http"`
+	zgrab2.TLSFlags
 }
 
 type TLSModule struct {
@@ -50,7 +42,10 @@ func (f *TLSFlags) Help() string {
 }
 
 func (s *TLSScanner) Init(flags zgrab2.ScanFlags) error {
-	f, _ := flags.(*TLSFlags)
+	f, ok := flags.(*TLSFlags)
+	if !ok {
+		return zgrab2.ErrMismatchedFlags
+	}
 	s.config = f
 	return nil
 }
@@ -64,5 +59,17 @@ func (s *TLSScanner) InitPerSender(senderID int) error {
 }
 
 func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
-	return zgrab2.SCAN_SUCCESS, s, nil
+	tcpConn, err := t.Open(&s.config.BaseFlags)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), &zgrab2.TLSLog{}, err
+	}
+	var conn *zgrab2.TLSConnection
+	if conn, err = s.config.TLSFlags.GetTLSConnection(tcpConn); err != nil {
+		return zgrab2.TryGetScanStatus(err), &zgrab2.TLSLog{}, err
+	}
+	result := conn.GetLog()
+	if err = conn.Handshake(); err != nil {
+		return zgrab2.TryGetScanStatus(err), result, err
+	}
+	return zgrab2.SCAN_SUCCESS, result, nil
 }


### PR DESCRIPTION
This module just uses zgrab2.BaseTLSFlags to implement a simple TLS
module.

## How to Test

I haven't updated TravsCI or added any integration tests yet. I'm wondering if they should really be HTTP(S) tests. @justinbastress, thoughts?

## Notes & Caveats

I'm not sure what an HTTPS scan that actually fetches a page would look like under the current framework. Is `zgrab tls` going to do this, or is there some way to combine `zgrab http` and `zgrab tls`, or do we need to add a `zgrab https`? Regardless of what we choose to do with that, we'll still probably want just a raw TLS handshake mode that can be run on any port, since many protocols (that we might not implement immediately) begin with a TLS handshake (e.g. IMAPS, POP3S, etc.)

## Issue Tracking

