### PR TITLE
remove integration test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ jp.exe
 schemas/*.pyc
 
 # Marker files for make
-.integration-test-setup
 docker-runner/*.id

--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,11 @@ zgrab2: $(GO_FILES)
 docker-runner: zgrab2
 	make -C docker-runner
 
-.integration-test-setup: | docker-runner
-	./integration_tests/setup.sh
-	touch .integration-test-setup
-
-integration-test: docker-runner .integration-test-setup
+integration-test: docker-runner
 	rm -rf zgrab-output
 	./integration_tests/test.sh
 
 integration-test-clean:
-	rm -f .integration-test-setup
 	rm -rf zgrab-output
 	./integration_tests/cleanup.sh
 	make -C docker-runner clean
@@ -40,5 +35,4 @@ container-clean:
 
 clean:
 	cd cmd/zgrab2 && go clean
-	rm -f .integration-test-setup
 	rm -f zgrab2

--- a/integration_tests/mysql/setup.sh
+++ b/integration_tests/mysql/setup.sh
@@ -21,7 +21,10 @@ function waitFor() {
     echo -n "."
     sleep 1
   done
-  sleep 1
+  for i in `seq 1 5` do;
+    echo -n "*"
+    sleep 1
+  done
   echo "...ok."
 }
 

--- a/integration_tests/mysql/setup.sh
+++ b/integration_tests/mysql/setup.sh
@@ -21,6 +21,7 @@ function waitFor() {
     echo -n "."
     sleep 1
   done
+  sleep 1
   echo "...ok."
 }
 

--- a/integration_tests/mysql/setup.sh
+++ b/integration_tests/mysql/setup.sh
@@ -21,7 +21,7 @@ function waitFor() {
     echo -n "."
     sleep 1
   done
-  for i in `seq 1 5` do;
+  for i in `seq 1 5`; do
     echo -n "*"
     sleep 1
   done

--- a/integration_tests/mysql/test.sh
+++ b/integration_tests/mysql/test.sh
@@ -22,9 +22,11 @@ function doTest() {
   CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh mysql --timeout 10 > $OUTPUT_FILE
   SERVER_VERSION=$($ZGRAB_ROOT/jp -u data.mysql.result.handshake.parsed.server_version < $OUTPUT_FILE)
   if [[ "$SERVER_VERSION" == "$MYSQL_VERSION."* ]]; then
-    echo "Server version matches expected version: $SERVER_VERSION == $MYSQL_VERSION.*"
+    echo "mysql/test: Server version matches expected version: $SERVER_VERSION == $MYSQL_VERSION.*"
   else
-    echo "Server version mismatch: Got $SERVER_VERSION, expected $MYSQL_VERSION.*"
+    echo "mysql/test: Server version mismatch: Got $SERVER_VERSION, expected $MYSQL_VERSION.*. Full output: [["
+    cat $OUTPUT_FILE
+    echo "]]"
     status=1
   fi
   echo "mysql/test: BEGIN docker+mysql logs from $CONTAINER_NAME [{("

--- a/integration_tests/postgres/setup.sh
+++ b/integration_tests/postgres/setup.sh
@@ -46,6 +46,7 @@ function waitFor() {
       sleep 1
     done
   fi
+  sleep 1
   echo "...postgres is up."
 }
 


### PR DESCRIPTION
Removes the integration-test-setup target. Setup will now be per-module, rather than all up front (to cut down on the number of containers that need to be running simultaneously).

## How to Test

Run `make integration-test` (or watch Travis do so) -- it should still work; it used to have `.integration-test-setup` as a dependency, but now it does not.

## Notes & Caveats

This is part of the larger task of refactoring the integration tests to require fewer simultaneous running containers.

The destination branch (https://github.com/zmap/zgrab2/pull/46) updates the test scripts, while this actually removes the call to `integration-tests/setup.sh` from the `integration-test` target.
