### PR TITLE
Use fewer simultaneous containers

### DIFF
--- a/integration_tests/ftp/setup.sh
+++ b/integration_tests/ftp/setup.sh
@@ -7,16 +7,15 @@ CONTAINER_NAME="zgrab_ftp"
 
 # TODO FIXME: find a pre-built container with ftpd already running? This works, but if it has to build the container image, the apt-get update can be very slow.
 
-if docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME; then
-  echo "ftp/setup: Container $CONTAINER_NAME already running -- stopping..."
-  docker stop $CONTAINER_NAME
-  echo "...stopped."
+if docker ps --filter "name=$CONTAINER_NAME" | grep -q $CONTAINER_NAME; then
+    echo "ftp/setup: Container $CONTAINER_NAME already running -- nothing to do."
+    exit 0
 fi
 
 # First attempt: just launch the container
-if ! docker run --rm --name $CONTAINER_NAME -itd $CONTAINER_TAG; then
+if ! docker run --rm --name $CONTAINER_NAME -td $CONTAINER_TAG; then
     # If it fails, build it from ./container/Dockerfile
     docker build -t $CONTAINER_TAG ./container
     # Try again
-    docker run --rm --name $CONTAINER_NAME -itd $CONTAINER_TAG
+    docker run --rm --name $CONTAINER_NAME -td $CONTAINER_TAG
 fi

--- a/integration_tests/setup.sh
+++ b/integration_tests/setup.sh
@@ -5,13 +5,15 @@ set -e
 # Set up the integration tests for all modules.
 # Drop your setup script(s) in integration_tests/<protocol>/setup(.*).sh
 
+# You can run this script, then run...
+#   NOSETUP=1 ./test.sh
+# ...to run the integration tests without setting up and tearing down the
+# containers after each run.
+
 # Run from root of project
 TEST_DIR=$(dirname "$0")
 ZGRAB_ROOT="$TEST_DIR/.."
 cd "$ZGRAB_ROOT"
-
-echo "Building zgrab2_runner docker image..."
-make -C ./docker-runner
 
 echo "Setting up integration tests..."
 

--- a/integration_tests/ssh/setup.sh
+++ b/integration_tests/ssh/setup.sh
@@ -7,16 +7,15 @@ CONTAINER_NAME="zgrab_ssh"
 
 # TODO FIXME: find a pre-built container with sshd already running? This works, but if it has to build the container image, the apt-get update is very slow.
 
-if docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME; then
-  echo "ssh/setup: Container $CONTAINER_NAME already running -- stopping..."
-  docker stop $CONTAINER_NAME
-  echo "...stopped."
+if docker ps --filter "name=$CONTAINER_NAME" | grep -q $CONTAINER_NAME; then
+  echo "ssh/setup: Container $CONTAINER_NAME already running -- nothing to do."
+  exit 0
 fi
 
 # First attempt to just launch the container
-if ! docker run --rm --name $CONTAINER_NAME -itd $CONTAINER_TAG; then
+if ! docker run --rm --name $CONTAINER_NAME -td $CONTAINER_TAG; then
     # If it fails, build it from ./container/Dockerfile
     docker build -t $CONTAINER_TAG ./container
     # Try again
-    docker run --rm --name $CONTAINER_NAME -itd $CONTAINER_TAG
+    docker run --rm --name $CONTAINER_NAME -td $CONTAINER_TAG
 fi


### PR DESCRIPTION
Previously, the integration tests worked as follows:

1. Run the `setup.sh` for each module -- starting up one or more containers for it
2. Run the `test.sh` for each module, hitting those containers
3. Validate the output of the modules
4. Run the `cleanup.sh` for each module

This was convenient, since you could skip steps 1 & 3 to repeatedly run the tests; also, it also had the side effect of giving plenty of time for most of the containers to come up before they needed to be used (while the others were being started).

But, as the number of containers grows, this becomes less tractable. This PR changes the behavior to

1. For each module:
  a. Run its `setup.sh`
  b. Run its `test.sh`
  c. Run its `cleanup.sh`
2. Validate the output

There is a new flag (`NOSETUP`) that will allow you to keep the old behavior, but it is no longer the default.

## How to Test

Run `make integration-test`.

## Notes and Caveats

This only updates the test scripts; https://github.com/zmap/zgrab2/pull/45, which merges into this feature branch, actually removes the pre-setup from the Makefile.

## Issue Tracking

Other pieces of this -- 

 * https://github.com/zmap/zgrab2/pull/44

 * https://github.com/zmap/zgrab2/pull/45
