### PR TITLE
Fix README install instructions pointing to previous versions of zgrab

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Once you have a working `$GOPATH`, run:
 $ go get github.com/zmap/zgrab2
 ```
 
-This will install zgrab under `$GOPATH/src/github.com/zmap/zgrab`
+This will install zgrab under `$GOPATH/src/github.com/zmap/zgrab2`
 
 ```
-$ cd $GOPATH/src/github.com/zmap/zgrab
+$ cd $GOPATH/src/github.com/zmap/zgrab2
 $ make
 ```
 


### PR DESCRIPTION
This is a small change to the `README`. I'm honestly not sure if this is incorrect documentation or not since _technically_ zgrab2 has zgrab as a dependency so you _can_ go into the old zmap directory and build it.

But my guess was that y'all meant to reference the new version?

## How to Test

No changes

## Notes & Caveats

None

## Issue Tracking

Didn't think this really deserved an issue 😄 