### PR TITLE
Changed tools/keys dependencies to point to zgrab2.

### DIFF
--- a/lib/ssh/kex.go
+++ b/lib/ssh/kex.go
@@ -17,7 +17,7 @@ import (
 	"io"
 	"math/big"
 
-	ztoolsKeys "github.com/zmap/zgrab/ztools/keys"
+	ztoolsKeys "github.com/zmap/zgrab2/tools/keys"
 
 	"golang.org/x/crypto/curve25519"
 )

--- a/lib/ssh/kex_gex.go
+++ b/lib/ssh/kex_gex.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"math/big"
 
-	ztoolsKeys "github.com/zmap/zgrab/ztools/keys"
+	ztoolsKeys "github.com/zmap/zgrab2/tools/keys"
 )
 
 const (

--- a/lib/ssh/keys.go
+++ b/lib/ssh/keys.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/crypto/ed25519"
 
 	ztoolsX509 "github.com/zmap/zcrypto/x509"
-	ztoolsKeys "github.com/zmap/zgrab/ztools/keys"
+	ztoolsKeys "github.com/zmap/zgrab2/tools/keys"
 )
 
 // These constants represent the algorithm names for key types supported by this


### PR DESCRIPTION
This is the first step towards removing the dependency on zgrab.

## How to Test

Same way as always.

## Notes & Caveats

*Note: I'm sure y'all are on it without me mentioning it, but we should wait until Travis runs the integration tests here... I was having issues getting the integration tests to complete successfully even from a clean build (I'll make an issue for that).*

Unfortunately, even without these changes there will still be nested dependencies on the original `zgrab/ztools/keys` package through `github.com/zmap/zcrypto` https://godoc.org/github.com/zmap/zgrab/ztools/keys?importers

Changes will be needed to zcrypto to fully remove the dependency on zgrab.

## Issue Tracking

Doesn't fully fix #48, but this at least starts to address it.