### PR TITLE
Add information on running integration tests to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,22 @@ This will add stub shell scripts in `integration_tests/your_new_protocol_name`; 
 See [integration_tests/mysql/*](integration_tests/mysql) for an example.
 The only hard requirement is that the `test.sh` script drops its output in `$ZGRAB_OUTPUT/[your-module]/*.json`, so that it can be validated against the schema.
 
+#### How to Run Integration Tests
+
+To run integration tests, you must have [Docker](https://www.docker.com/) installed. Then, you can follow the following steps to run integration tests:
+
+```
+$ go get github.com/jmespath/jp && go build github.com/jmespath/jp
+$ pip install --user zschema
+$ make integration-test
+```
+
+Running the integration tests will generate quite a bit of debug output. To ensure that tests completed successfully, you can check for a successful exit code after the tests complete:
+
+```
+$ echo $?
+0
+```
+
 ## License
 ZGrab2.0 is licensed under Apache 2.0 and ISC. For more information, see the LICENSE file.


### PR DESCRIPTION
This just adds some preliminary information on how to run integration tests. It might not be perfect - I was just going by what I saw in the Travis build logs.

## How to Test

Exactly 😉 

## Notes & Caveats

_N/A_

## Issue Tracking

Fixes #50 