### PR TITLE
if `docker build` fails, fail the build after deleting the *.id file

### DIFF
--- a/docker-runner/Makefile
+++ b/docker-runner/Makefile
@@ -9,13 +9,13 @@ all: docker-runner.id
 .PHONY: clean clean-all
 
 service-base-image.id: service-base.Dockerfile
-	docker build -t zgrab2_service_base:latest -f service-base.Dockerfile -q . > service-base-image.id || rm -f service-base-image.id
+	docker build -t zgrab2_service_base:latest -f service-base.Dockerfile -q . > service-base-image.id || (rm -f service-base-image.id && exit 1)
 
 runner-base-image.id: runner-base.Dockerfile
-	docker build -t zgrab2_runner_base:latest -f runner-base.Dockerfile -q . > runner-base-image.id || rm -f runner-base-image.id
+	docker build -t zgrab2_runner_base:latest -f runner-base.Dockerfile -q . > runner-base-image.id || (rm -f runner-base-image.id && exit 1)
 
 docker-runner.id: Dockerfile ../cmd/zgrab2/zgrab2$(EXECUTABLE_EXTENSION) runner-base-image.id service-base-image.id
-	docker build -t zgrab2_runner:latest -f Dockerfile -q .. > docker-runner.id || rm -f docker-runner.id
+	docker build -t zgrab2_runner:latest -f Dockerfile -q .. > docker-runner.id || (rm -f docker-runner.id && exit 1)
 
 clean:
 	if [ -f docker-runner.id ]; then docker rmi -f $$(cat docker-runner.id) && rm -f docker-runner.id; fi


### PR DESCRIPTION
Previously, a failed `make docker-runner` would continue merrily along, either with no docker-runner or worse, with an out-of-date one.

The problem was, on failure, it needed to clean up a *.id file -- but the successful exit code from `rm` was clobbering the failing exit code from `docker build`.

## How to Test

Remove `docker` from your path, then run `make docker-runner`.

Before the fix, it will pass.

After the fix, it will fail.
