### PR TITLE
Update MSSQL GoDocs

### DIFF
--- a/modules/mssql/connection.go
+++ b/modules/mssql/connection.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sort"
@@ -15,97 +16,197 @@ import (
 )
 
 var (
-	errTooLarge                 = errors.New("data too large")
-	errBufferTooSmall           = errors.New("buffer too small")
-	errInvalidData              = errors.New("received invalid data")
-	errNoServerEncryption       = errors.New("server doesn't support encryption")
-	errServerRequiresEncryption = errors.New("server requires encryption")
-	errInvalidState             = errors.New("operation cannot be performed in this state")
+	// ErrTooLarge is returned when a size is larger than 64k.
+	ErrTooLarge = errors.New("data too large")
+
+	// ErrBufferTooSmall is returned when a buffer is smaller than necessary.
+	ErrBufferTooSmall = errors.New("buffer too small")
+
+	// ErrInvalidData is returned when we receive data from the server that
+	// cannot be interpreted as a valid packet.
+	ErrInvalidData = errors.New("received invalid data")
+
+	// ErrNoServerEncryption is returned if the client requires encryption but
+	// the server does not support it.
+	ErrNoServerEncryption = errors.New("server doesn't support encryption")
+
+	// ErrServerRequiresEncryption is returned if the server requires encryption
+	// but the client does not support it.
+	ErrServerRequiresEncryption = errors.New("server requires encryption")
+
+	// ErrInvalidState is returned when attempting to take an action that is not
+	// allowed in the current state of the connection.
+	ErrInvalidState = errors.New("operation cannot be performed in this state")
 )
 
 // https://msdn.microsoft.com/en-us/library/dd358342.aspx
 const (
-	tdsStatusNormal                  uint8 = 0x00
-	tdsStatusEOM                           = 0x01
-	tdsStatusIgnore                        = 0x02
-	tdsStatusResetConnection               = 0x08
-	tdsStatusResetConnectionSkipTran       = 0x10
+	// TDSStatusNormal is a "Normal" message
+	TDSStatusNormal uint8 = 0x00
+
+	// TDSStatusEOM is an End of message (EOM). The packet is the last packet in
+	// the whole request.
+	TDSStatusEOM = 0x01
+
+	// TDSStatusIgnore: Ignore this event (0x01 MUST also be set).
+	// Client-to-server.
+	TDSStatusIgnore = 0x02
+
+	// TDSStatusResetConnection reset this connection before processing event.
+	// Only set for event types Batch, RPC, or Transaction Manager request.
+	// This status bit MUST NOT be set in conjunction with
+	// the RESETCONNECTIONSKIPTRAN bit.
+	// Client-to-server.
+	TDSStatusResetConnection = 0x08
+
+	// Reset the connection before processing event but do not modify the
+	// transaction state. This status bit MUST NOT be set in conjunction with
+	// the RESETCONNECTION bit.
+	// Client-to-server.
+	TDSStatusResetConnectionSkipTran = 0x10
 )
 
-type tdsPacketType uint8
+// TDSPacketType represents the Type entry in the TDSPacket.
+// Values are defined at https://msdn.microsoft.com/en-us/library/dd304214.aspx.
+type TDSPacketType uint8
 
-// https://msdn.microsoft.com/en-us/library/dd304214.aspx
 const (
-	tdsPacketTypeSQLBatch                  tdsPacketType = 0x01
-	tdsPacketTypePreTDS7Login                            = 0x02
-	tdsPacketTypeRPC                                     = 0x03
-	tdsPacketTypeTabularResult                           = 0x04
-	tdsPacketTypeAttentionSignal                         = 0x06
-	tdsPacketTypeBulkLoadData                            = 0x07
-	tdsPacketTypeFederatedAuthToken                      = 0x08
-	tdsPacketTypeTransactionManagerRequest               = 0x0E
-	tdsPacketTypeTDS7Login                               = 0x10
-	tdsPacketTypeSSPI                                    = 0x11
-	tdsPacketTypePrelogin                                = 0x12
+	// TDSPacketTypeSQLBatch identifies a SQL batch.
+	TDSPacketTypeSQLBatch TDSPacketType = 0x01
+
+	// TDSPacketTypePreTDS7Login is the packet type for clients using "legacy"
+	// pre-TDS7 logins.
+	TDSPacketTypePreTDS7Login = 0x02
+
+	// TDSPacketTypeRPC identifies an RPC packet.
+	TDSPacketTypeRPC = 0x03
+
+	// TDSPacketTypeTabularResult identifies a tabular result.
+	TDSPacketTypeTabularResult = 0x04
+
+	// TDSPacketTypeAttentionSignal identifies an attention signal.
+	// Packet does not contain data.
+	TDSPacketTypeAttentionSignal = 0x06
+
+	// TDSPacketTypeBulkLoadData identifies a bulk-load-data packet.
+	TDSPacketTypeBulkLoadData = 0x07
+
+	// TDSPacketTypeFederatedAuthToken identifies a federated authentication
+	// token.
+	TDSPacketTypeFederatedAuthToken = 0x08
+
+	// TDSPacketTypeTransactionManagerRequest identifies a transaction manager
+	// request.
+	TDSPacketTypeTransactionManagerRequest = 0x0E
+
+	// TDSPacketTypeTDS7Login identifies a TDS7 login.
+	TDSPacketTypeTDS7Login = 0x10
+
+	// TDSPacketTypeSSPI identifies an SSPI packet.
+	TDSPacketTypeSSPI = 0x11
+
+	// TDSPacketTypePrelogin identifies a PRELOGIN packet.
+	TDSPacketTypePrelogin = 0x12
 )
 
-// From https://msdn.microsoft.com/en-us/library/dd357559.aspx
-// See PL_OPTION_TOKEN values
-type preloginOptionToken uint8
+var knownTDSPacketTypes = map[TDSPacketType]bool{
+	TDSPacketTypeSQLBatch:                  true,
+	TDSPacketTypePreTDS7Login:              true,
+	TDSPacketTypeRPC:                       true,
+	TDSPacketTypeTabularResult:             true,
+	TDSPacketTypeAttentionSignal:           true,
+	TDSPacketTypeBulkLoadData:              true,
+	TDSPacketTypeFederatedAuthToken:        true,
+	TDSPacketTypeTransactionManagerRequest: true,
+	TDSPacketTypeTDS7Login:                 true,
+	TDSPacketTypeSSPI:                      true,
+	TDSPacketTypePrelogin:                  true,
+}
+
+// PreloginOptionToken represents a PL_OPTION_TOKEN value, defined at
+// https://msdn.microsoft.com/en-us/library/dd357559.aspx.
+type PreloginOptionToken uint8
 
 const (
-	preloginVersion         preloginOptionToken = 0x00
-	preloginEncryption                          = 0x01
-	preloginInstance                            = 0x02
-	preloginThreadID                            = 0x03
-	preloginMARS                                = 0x04
-	preloginTraceID                             = 0x05
-	preloginFedAuthRequired                     = 0x06
-	preloginNonce                               = 0x07
-	preloginTerminator                          = 0xFF
+	// PreloginVersion is the VERSION token. Its value is the concatenation of
+	// { major, minor, build >> 8, build & 0xff }.
+	PreloginVersion PreloginOptionToken = 0x00
+
+	// PreloginEncryption is the ENCRYPTION token. It is a single byte that
+	// specifies what encryption options the client/server support (see
+	// EncryptionMode)
+	PreloginEncryption = 0x01
+
+	// PreloginInstance is the INSTOPT token. Its value is the null-terminated
+	// instance name.
+	PreloginInstance = 0x02
+
+	// PreloginThreadID is the THREADID token. Its value is the server's
+	// internal thread ID for the connection, an unsigned long.
+	PreloginThreadID = 0x03
+
+	// PreloginMARS is the MARS token. Its value is a single byte specifying
+	// whether the sender is requesting MARS support.
+	PreloginMARS = 0x04
+
+	// PreloginTraceID is the TRACEID token. Its value is the concatenation of
+	// the server's GUID for the client (16 bytes), the server's activity GUID
+	// (16 bytes) and the sequence ID (unsigned long).
+	PreloginTraceID = 0x05
+
+	// PreloginFedAuthRequired is the FEDAUTHREQUIRED token. Its value is a
+	// byte representing whether the sender requires federated authentication.
+	PreloginFedAuthRequired = 0x06
+
+	// PreloginNonce is the NONCEOPT token. Its value is a 32-byte nonce.
+	PreloginNonce = 0x07
+
+	// PreloginTerminator is the TERMINATOR token. It is not an actual tag, but
+	// a standalone marker.
+	PreloginTerminator = 0xFF
 )
 
 // Mapping to documented names, also serves to identify unknown values for JSON
 // marshalling
-var knownPreloginOptionTokens = map[preloginOptionToken]string{
-	preloginVersion:         "VERSION",
-	preloginEncryption:      "ENCRYPTION",
-	preloginInstance:        "INSTOPT",
-	preloginThreadID:        "THREADID",
-	preloginMARS:            "MARS",
-	preloginTraceID:         "TRACEID",
-	preloginFedAuthRequired: "FEDAUTHREQUIRED",
-	preloginNonce:           "NONCE",
+var knownPreloginOptionTokens = map[PreloginOptionToken]string{
+	PreloginVersion:         "VERSION",
+	PreloginEncryption:      "ENCRYPTION",
+	PreloginInstance:        "INSTOPT",
+	PreloginThreadID:        "THREADID",
+	PreloginMARS:            "MARS",
+	PreloginTraceID:         "TRACEID",
+	PreloginFedAuthRequired: "FEDAUTHREQUIRED",
+	PreloginNonce:           "NONCE",
 }
 
-// preloginOption values are stored as byte arrays; actual types are specified
+// PreloginOption values are stored as byte arrays; actual types are specified
 // in the docs
-type preloginOption []byte
+type PreloginOption []byte
 
-// preloginOptions maps the token to the value for that option
-type preloginOptions map[preloginOptionToken]preloginOption
+// PreloginOptions maps the token to the value for that option
+type PreloginOptions map[PreloginOptionToken]PreloginOption
 
 // EncryptMode is defined at
 // https://msdn.microsoft.com/en-us/library/dd357559.aspx
 type EncryptMode byte
 
 const (
-	// encryptModeUnknown is not a valid ENCRYPTION value
-	encryptModeUnknown EncryptMode = 0xff
+	// EncryptModeUnknown is not a valid ENCRYPTION value
+	EncryptModeUnknown EncryptMode = 0xff
 
-	// encryptModeOff means that encryption will only be used for login
-	encryptModeOff = 0x00
+	// EncryptModeOff means that encryption will only be used for login
+	EncryptModeOff = 0x00
 
-	// encryptModeOn means that encryption will be used for the entire session
-	encryptModeOn = 0x01
+	// EncryptModeOn means that encryption will be used for the entire session
+	EncryptModeOn = 0x01
 
-	// encryptModeNotSupported means that the client/server does not support
+	// EncryptModeNotSupported means that the client/server does not support
 	// encryption
-	encryptModeNotSupported = 0x02
+	EncryptModeNotSupported = 0x02
 
-	// encryptModeRequired is sent by the server when the client sends
+	// EncryptModeRequired is sent by the server when the client sends
 	// EncryptModNotSupported but the server requires it
-	encryptModeRequired = 0x03
+	EncryptModeRequired = 0x03
 )
 
 // These are the macro values defined in the MSDN docs
@@ -118,37 +219,47 @@ var stringToEncryptMode = map[string]EncryptMode{
 }
 
 var encryptModeToString = map[EncryptMode]string{
-	encryptModeOff:          "ENCRYPT_OFF",
-	encryptModeOn:           "ENCRYPT_ON",
-	encryptModeNotSupported: "ENCRYPT_NOT_SUP",
-	encryptModeRequired:     "ENCRYPT_REQ",
-	encryptModeUnknown:      "UNKNOWN",
+	EncryptModeOff:          "ENCRYPT_OFF",
+	EncryptModeOn:           "ENCRYPT_ON",
+	EncryptModeNotSupported: "ENCRYPT_NOT_SUP",
+	EncryptModeRequired:     "ENCRYPT_REQ",
+	EncryptModeUnknown:      "UNKNOWN",
 }
 
-// Direct representation of the VERSION PRELOGIN token value.
-type serverVersion struct {
+// ServerVersion is a direct representation of the VERSION PRELOGIN token value.
+type ServerVersion struct {
 	Major       uint8  `json:"major"`
 	Minor       uint8  `json:"minor"`
 	BuildNumber uint16 `json:"build_number"`
 }
 
-// Decode a VERSION response and return the parsed serverVersion struct
+// Decode a VERSION response and return the parsed ServerVersion struct
 // As defined in the MSDN docs, these come from token 0:
 //	VERSION -- UL_VERSION = ((US_BUILD<<16)|(VER_SQL_MINOR<<8)|( VER_SQL_MAJOR))
-func decodeServerVersion(buf []byte) *serverVersion {
+func decodeServerVersion(buf []byte) *ServerVersion {
 	if len(buf) != 6 {
 		return nil
 	}
-	return &serverVersion{
+	return &ServerVersion{
 		Major:       buf[0],
 		Minor:       buf[1],
 		BuildNumber: binary.BigEndian.Uint16(buf[2:4]),
 	}
 }
 
-// tdsHeader: an 8-byte structure prepended to all TDS packets.
+// String returns the dotted-decimal representation of the ServerVersion:
+// "MAJOR.MINOR.BUILD_NUMBER".
+func (version *ServerVersion) String() string {
+	if version == nil {
+		return "<nil version>"
+	}
+	return fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.BuildNumber)
+}
+
+// TDSHeader is an 8-byte structure prepended to all TDS packets.
 // See https://msdn.microsoft.com/en-us/library/dd340948.aspx for details.
-type tdsHeader struct {
+type TDSHeader struct {
+	// Type is the TDSPacketType.
 	Type uint8
 
 	// Status is a bit field indicating message state.
@@ -177,12 +288,12 @@ type tdsHeader struct {
 	Window uint8
 }
 
-// decodeTDSHeader interprets the first 8 bytes of buf as a tdsHeader.
-func decodeTDSHeader(buf []byte) (*tdsHeader, error) {
+// decodeTDSHeader interprets the first 8 bytes of buf as a TDSHeader.
+func decodeTDSHeader(buf []byte) (*TDSHeader, error) {
 	if len(buf) < 8 {
-		return nil, errBufferTooSmall
+		return nil, ErrBufferTooSmall
 	}
-	return &tdsHeader{
+	return &TDSHeader{
 		Type:           buf[0],
 		Status:         buf[1],
 		Length:         binary.BigEndian.Uint16(buf[2:4]),
@@ -193,8 +304,8 @@ func decodeTDSHeader(buf []byte) (*tdsHeader, error) {
 }
 
 // readTDSHeader attempts to read 8 bytes from conn using io.ReadFull, and
-// decodes the result as a tdsHeader.
-func readTDSHeader(conn io.Reader) (*tdsHeader, error) {
+// decodes the result as a TDSHeader.
+func readTDSHeader(conn io.Reader) (*TDSHeader, error) {
 	buf := make([]byte, 8)
 	_, err := io.ReadFull(conn, buf)
 	if err != nil {
@@ -203,8 +314,8 @@ func readTDSHeader(conn io.Reader) (*tdsHeader, error) {
 	return decodeTDSHeader(buf)
 }
 
-// tdsHeader.Encode() returns the encoding of the header as a byte slice.
-func (header *tdsHeader) Encode() []byte {
+// Encode returns the encoding of the header as a byte slice.
+func (header *TDSHeader) Encode() []byte {
 	ret := make([]byte, 8)
 	ret[0] = header.Type
 	ret[1] = header.Status
@@ -215,18 +326,18 @@ func (header *tdsHeader) Encode() []byte {
 	return ret
 }
 
-// preloginOptions.HeaderSize() calculates the length of the PRELOGIN_OPTIONs /
-// the number of bytes before the payload starts.
+// HeaderSize calculates the length of the PRELOGIN_OPTIONs, i.e. the number of
+// bytes before the payload starts.
 // Each PRELOGIN_OPTION is a 1-byte token, a 2-byte length and a 2-byte offset,
 // and each is followed by a single-byte TERMINATOR, giving 5 * len(*self) + 1.
-func (options preloginOptions) HeaderSize() int {
+func (options PreloginOptions) HeaderSize() int {
 	return 5*len(options) + 1
 }
 
-// preloginOptions.Size() returns the total size of the PRELOGIN packet body (so
-// not including the tdsPacket header).
-// Specifically, the header size + the size of all of the values.
-func (options preloginOptions) Size() int {
+// Size returns the total size of the PRELOGIN packet body (so not including the
+// TDSPacket header).
+// Specifically, it is the header size + the size of all of the values.
+func (options PreloginOptions) Size() int {
 	// 5 bytes per option for token/offset/length + 1 byte for terminator
 	ret := options.HeaderSize()
 	// + actual sizes of each option
@@ -236,44 +347,44 @@ func (options preloginOptions) Size() int {
 	return ret
 }
 
-// preloginOptions.GetByteOption() returns a single-byte PRELOGIN option for the
-// given token. If there is no value for that token present, or if the value is
-// not exactly one byte long, returns an errInvalidData.
-func (options preloginOptions) GetByteOption(token preloginOptionToken) (byte, error) {
+// GetByteOption returns a single-byte PRELOGIN option for the given token. If
+// there is no value for that token present, or if the value is not exactly one
+// byte long, returns an ErrInvalidData.
+func (options PreloginOptions) GetByteOption(token PreloginOptionToken) (byte, error) {
 	ret, ok := options[token]
 	if !ok || len(ret) != 1 {
-		return 0, errInvalidData
+		return 0, ErrInvalidData
 	}
 	return ret[0], nil
 }
 
-// preloginOptions.GetByteOption() returns a big-endian uint16 PRELOGIN option
-// for the given token. If there is no value for that token present, or if the
-// value is not exactly two bytes long, returns an errInvalidData.
-func (options preloginOptions) GetUint16Option(token preloginOptionToken) (uint16, error) {
+// GetUint16Option returns a big-endian uint16 PRELOGIN option for the given
+// token. If there is no value for that token present, or if the value is not
+// exactly two bytes long, returns an ErrInvalidData.
+func (options PreloginOptions) GetUint16Option(token PreloginOptionToken) (uint16, error) {
 	ret, ok := options[token]
 	if !ok || len(ret) != 2 {
-		return 0, errInvalidData
+		return 0, ErrInvalidData
 	}
 	return binary.BigEndian.Uint16(ret[0:2]), nil
 }
 
-// preloginOptions.GetVersion() decodes the VERSION response value if present;
-// if not (or invalid), returns nil
-func (options preloginOptions) GetVersion() *serverVersion {
-	version, hasVersion := options[preloginVersion]
+// GetVersion decodes the VERSION response value if present; if not (or it is
+// invalid), returns nil.
+func (options PreloginOptions) GetVersion() *ServerVersion {
+	version, hasVersion := options[PreloginVersion]
 	if !hasVersion {
 		return nil
 	}
 	return decodeServerVersion(version)
 }
 
-// preloginOptions.Encode() returns the encoding of the PRELOGIN body as
-// described in https://msdn.microsoft.com/en-us/library/dd357559.aspx
-func (options preloginOptions) Encode() ([]byte, error) {
+// Encode returns the encoding of the PRELOGIN body as described in
+// https://msdn.microsoft.com/en-us/library/dd357559.aspx.
+func (options PreloginOptions) Encode() ([]byte, error) {
 	size := options.Size()
 	if size > 0xffff {
-		return nil, errTooLarge
+		return nil, ErrTooLarge
 	}
 	ret := make([]byte, size)
 	// cursor always points to the location for the next PL_OPTION header value
@@ -288,11 +399,11 @@ func (options preloginOptions) Encode() ([]byte, error) {
 	}
 	sort.Ints(sortedKeys)
 	for _, ik := range sortedKeys {
-		k := preloginOptionToken(ik)
+		k := PreloginOptionToken(ik)
 		v := options[k]
 		cursor[0] = byte(k)
 		if offset > 0xffff {
-			return nil, errTooLarge
+			return nil, ErrTooLarge
 		}
 		binary.BigEndian.PutUint16(cursor[1:3], uint16(offset))
 		binary.BigEndian.PutUint16(cursor[3:5], uint16(len(v)))
@@ -306,24 +417,24 @@ func (options preloginOptions) Encode() ([]byte, error) {
 	return ret, nil
 }
 
-// Decode a preloginOptions object from the given body. Any extra bytes are
+// Decode a PreloginOptions object from the given body. Any extra bytes are
 // returned in rest.
-// If body can't be decoded as a PRELOGIN body, returns nil, nil, errInvalidData
-func decodePreloginOptions(body []byte) (result *preloginOptions, rest []byte, err error) {
+// If body can't be decoded as a PRELOGIN body, returns nil, nil, ErrInvalidData
+func decodePreloginOptions(body []byte) (result *PreloginOptions, rest []byte, err error) {
 	cursor := body[:]
-	options := make(preloginOptions)
+	options := make(PreloginOptions)
 	max := 0
 	for cursor[0] != 0xff {
 		if len(cursor) < 6 {
 			// if the cursor is not pointing to the terminator, and we do not
 			// have 5 bytes + terminator remaining, it's a bad packet
-			return nil, nil, errInvalidData
+			return nil, nil, ErrInvalidData
 		}
-		token := preloginOptionToken(cursor[0])
+		token := PreloginOptionToken(cursor[0])
 		offset := binary.BigEndian.Uint16(cursor[1:3])
 		length := binary.BigEndian.Uint16(cursor[3:5])
 		if len(body) < int(offset+length) {
-			return nil, nil, errInvalidData
+			return nil, nil, ErrInvalidData
 		}
 		options[token] = body[offset : offset+length]
 
@@ -337,9 +448,9 @@ func decodePreloginOptions(body []byte) (result *preloginOptions, rest []byte, e
 }
 
 // preloginOptionsJSON is an auxiliary struct that holds the output format of
-// the preloginOptions
+// the PreloginOptions
 type preloginOptionsJSON struct {
-	Version *serverVersion `json:"version,omitempty"`
+	Version *ServerVersion `json:"version,omitempty"`
 
 	Encryption *EncryptMode `json:"encrypt_mode,omitempty"`
 	Instance   string       `json:"instance,omitempty"`
@@ -359,46 +470,46 @@ type unknownPreloginOptionJSON struct {
 	Value []byte `json:"value"`
 }
 
-// MarshalJSON() puts the map[preloginOptionToken]preloginOption into a more
+// MarshalJSON puts the map[PreloginOptionToken]PreloginOption into a more
 // database-friendly format.
-func (options preloginOptions) MarshalJSON() ([]byte, error) {
+func (options PreloginOptions) MarshalJSON() ([]byte, error) {
 	opts := options
 	aux := preloginOptionsJSON{}
 	aux.Version = options.GetVersion()
 
-	theEncryptMode, hasEncrypt := opts[preloginEncryption]
+	theEncryptMode, hasEncrypt := opts[PreloginEncryption]
 	if hasEncrypt && len(theEncryptMode) == 1 {
 		temp := EncryptMode(theEncryptMode[0])
 		aux.Encryption = &temp
 	}
 
-	instance, hasInstance := opts[preloginInstance]
+	instance, hasInstance := opts[PreloginInstance]
 	if hasInstance {
 		aux.Instance = strings.Trim(string(instance), "\x00")
 	}
 
-	threadID, hasThreadID := opts[preloginThreadID]
+	threadID, hasThreadID := opts[PreloginThreadID]
 	if hasThreadID && len(threadID) == 4 {
 		temp := binary.BigEndian.Uint32(threadID[:])
 		aux.ThreadID = &temp
 	}
 
-	mars, hasMars := opts[preloginMARS]
+	mars, hasMars := opts[PreloginMARS]
 	if hasMars && len(mars) == 1 {
 		aux.MARS = &mars[0]
 	}
 
-	traceID, hasTraceID := opts[preloginTraceID]
+	traceID, hasTraceID := opts[PreloginTraceID]
 	if hasTraceID {
 		aux.TraceID = traceID
 	}
 
-	fedAuthRequired, hasFedAuthRequired := opts[preloginFedAuthRequired]
+	fedAuthRequired, hasFedAuthRequired := opts[PreloginFedAuthRequired]
 	if hasFedAuthRequired {
 		aux.FedAuthRequired = &fedAuthRequired[0]
 	}
 
-	nonce, hasNonce := opts[preloginNonce]
+	nonce, hasNonce := opts[PreloginNonce]
 	if hasNonce {
 		aux.Nonce = nonce
 	}
@@ -415,38 +526,38 @@ func (options preloginOptions) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aux)
 }
 
-// tdsPacket is a header followed by the body. Length is calculated from the
+// TDSPacket is a header followed by the body. Length is calculated from the
 // start of the packet, NOT the start of the body.
-type tdsPacket struct {
-	tdsHeader
+type TDSPacket struct {
+	TDSHeader
 	Body []byte
 }
 
-// decodeTDSPacket decodes a tdsPacket from the start of buf, returning the
+// decodeTDSPacket decodes a TDSPacket from the start of buf, returning the
 // packet and any remaining bytes following it.
-func decodeTDSPacket(buf []byte) (*tdsPacket, []byte, error) {
+func decodeTDSPacket(buf []byte) (*TDSPacket, []byte, error) {
 	header, err := decodeTDSHeader(buf)
 	if err != nil {
 		return nil, nil, err
 	}
 	if len(buf) < int(header.Length) {
-		return nil, nil, errBufferTooSmall
+		return nil, nil, ErrBufferTooSmall
 	}
 	body := buf[8:header.Length]
-	return &tdsPacket{
-		tdsHeader: *header,
+	return &TDSPacket{
+		TDSHeader: *header,
 		Body:      body,
 	}, buf[header.Length:], nil
 }
 
-// tdsPacket.Encode() returns the encoded packet: header + body. Updates the
-// header's length to match the actual body length.
-func (packet *tdsPacket) Encode() ([]byte, error) {
+// Encode returns the encoded packet: header + body. Updates the header's length
+// to match the actual body length.
+func (packet *TDSPacket) Encode() ([]byte, error) {
 	if len(packet.Body)+8 > 0xffff {
-		return nil, errTooLarge
+		return nil, ErrTooLarge
 	}
-	packet.tdsHeader.Length = uint16(len(packet.Body) + 8)
-	header := packet.tdsHeader.Encode()
+	packet.TDSHeader.Length = uint16(len(packet.Body) + 8)
+	header := packet.TDSHeader.Encode()
 	ret := append(header, packet.Body...)
 	return ret, nil
 }
@@ -455,7 +566,7 @@ func (packet *tdsPacket) Encode() ([]byte, error) {
 func (mode EncryptMode) String() string {
 	ret, ok := encryptModeToString[mode]
 	if !ok {
-		return encryptModeToString[encryptModeUnknown]
+		return encryptModeToString[EncryptModeUnknown]
 	}
 	return ret
 }
@@ -469,7 +580,7 @@ func (mode EncryptMode) MarshalJSON() ([]byte, error) {
 func getEncryptMode(enum string) EncryptMode {
 	ret, ok := stringToEncryptMode[enum]
 	if !ok {
-		return encryptModeUnknown
+		return EncryptModeUnknown
 	}
 	return ret
 }
@@ -494,9 +605,13 @@ type Connection struct {
 	// they are sent to the server mod 256).
 	sequenceNumber int
 
-	// preloginOptions contains the values returned by the server in the
+	// readValidTDSPacket gets set to true once we have read a valid TDS packet
+	// on any TDSConnection.
+	readValidTDSPacket bool
+
+	// PreloginOptions contains the values returned by the server in the
 	// PRELOGIN call, once it has happened.
-	preloginOptions *preloginOptions
+	PreloginOptions *PreloginOptions
 }
 
 // SendTDSPacket sends a TDS packet with the given type and body.
@@ -509,12 +624,12 @@ func (connection *Connection) SendTDSPacket(packetType uint8, body []byte) error
 }
 
 // readPreloginPacket reads and decodes an entire Prelogin packet from tdsConn
-func (connection *Connection) readPreloginPacket() (*tdsPacket, *preloginOptions, error) {
+func (connection *Connection) readPreloginPacket() (*TDSPacket, *PreloginOptions, error) {
 	packet, err := connection.tdsConn.ReadPacket()
 	if err != nil {
 		return nil, nil, err
 	}
-	if packet.Type != tdsPacketTypeTabularResult {
+	if packet.Type != TDSPacketTypeTabularResult {
 		return packet, nil, &zgrab2.ScanError{Status: zgrab2.SCAN_APPLICATION_ERROR, Err: err}
 	}
 	plOptions, rest, err := decodePreloginOptions(packet.Body)
@@ -522,54 +637,54 @@ func (connection *Connection) readPreloginPacket() (*tdsPacket, *preloginOptions
 		return packet, nil, err
 	}
 	if len(rest) > 0 {
-		return packet, nil, errInvalidData
+		return packet, nil, ErrInvalidData
 	}
 	return packet, plOptions, nil
 }
 
 // Prelogin sends the Prelogin packet and reads the response from the server.
-// It populates the connection's preloginOptions field with the response, and
+// It populates the connection's PreloginOptions field with the response, and
 // specifically returns the ENCRYPTION value (which is used to determine whether
 // a TLS handshake needs to be done).
 func (connection *Connection) prelogin(clientEncrypt EncryptMode) (EncryptMode, error) {
 	if clientEncrypt < 0 || clientEncrypt > 0xff {
-		return encryptModeUnknown, errInvalidData
+		return EncryptModeUnknown, ErrInvalidData
 	}
-	preloginOptions := preloginOptions{
-		preloginVersion:    {0, 0, 0, 0, 0, 0},
-		preloginEncryption: {byte(clientEncrypt)},
-		preloginInstance:   {0},
-		preloginThreadID:   {0, 0, 0, 0},
-		preloginMARS:       {0},
+	clientOptions := PreloginOptions{
+		PreloginVersion:    {0, 0, 0, 0, 0, 0},
+		PreloginEncryption: {byte(clientEncrypt)},
+		PreloginInstance:   {0},
+		PreloginThreadID:   {0, 0, 0, 0},
+		PreloginMARS:       {0},
 	}
-	preloginBody, err := preloginOptions.Encode()
+	preloginBody, err := clientOptions.Encode()
 	if err != nil {
-		return encryptModeUnknown, err
+		return EncryptModeUnknown, err
 	}
-	err = connection.SendTDSPacket(tdsPacketTypePrelogin, preloginBody)
+	err = connection.SendTDSPacket(TDSPacketTypePrelogin, preloginBody)
 
 	if err != nil {
-		return encryptModeUnknown, err
+		return EncryptModeUnknown, err
 	}
 	packet, response, err := connection.readPreloginPacket()
 	if response != nil {
-		connection.preloginOptions = response
+		connection.PreloginOptions = response
 	}
 	if err != nil {
 		if packet != nil {
 			// FIXME: debug packet info?
 			logrus.Warnf("Got bad packet? type=0x%02x", packet.Type)
 		}
-		return encryptModeUnknown, err
+		return EncryptModeUnknown, err
 	}
 
 	serverEncrypt := connection.getEncryptMode()
 
-	if clientEncrypt == encryptModeOn && serverEncrypt == encryptModeNotSupported {
-		return serverEncrypt, errNoServerEncryption
+	if clientEncrypt == EncryptModeOn && serverEncrypt == EncryptModeNotSupported {
+		return serverEncrypt, ErrNoServerEncryption
 	}
-	if clientEncrypt == encryptModeNotSupported && serverEncrypt == encryptModeRequired {
-		return serverEncrypt, errServerRequiresEncryption
+	if clientEncrypt == EncryptModeNotSupported && serverEncrypt == EncryptModeRequired {
+		return serverEncrypt, ErrServerRequiresEncryption
 	}
 	return serverEncrypt, nil
 }
@@ -589,8 +704,8 @@ func (connection *Connection) Close() error {
 // from an external library like tls.Handshake()) by adding / removing TDS
 // headers for writes / reads.
 // For example, wrapped.Write("abc") will call
-// wrapped.conn.Write(tdsHeader + "abc"), while wrapped.Read() will read
-// tdsHeader + "def" from net.Conn, then return "def" to the caller.
+// wrapped.conn.Write(TDSHeader + "abc"), while wrapped.Read() will read
+// TDSHeader + "def" from net.Conn, then return "def" to the caller.
 // For reads, this reads entire TDS packets at a time -- blocking until it
 // can -- and returns partial packets (or data from multiple packets) as needed.
 type tdsConnection struct {
@@ -621,11 +736,40 @@ func min(a, b int) int {
 	return b
 }
 
+// Check if the given header is likely to be a valid TDS header (for detection
+// purposes).
+func isValidTDSHeader(header *TDSHeader) bool {
+	if header == nil {
+		logrus.Warn("nil header")
+		return false
+	}
+
+	if header.Status != TDSStatusEOM {
+		// The only valid/recognized values for the server status are 0x00 and
+		// 0x01 -- the rest of the bits are either client-to-server flags or
+		// undefined.
+		// We don't say we've read a packet until we've received the final
+		// packet in a sequence, so 0x00 is also out.
+		return false
+	}
+
+	if header.Window != 0 {
+		// "This 1 byte is currently not used. This byte SHOULD be set to 0x00
+		//  and SHOULD be ignored by the receiver."
+		return false
+	}
+	_, ok := knownTDSPacketTypes[TDSPacketType(header.Type)]
+	if !ok {
+		return false
+	}
+	return true
+}
+
 // Read a single packet from the connection and return the whole packet (this is
 // the only way to see the packet type, sequence number, etc).
-func (connection *tdsConnection) ReadPacket() (*tdsPacket, error) {
+func (connection *tdsConnection) ReadPacket() (*TDSPacket, error) {
 	if !connection.enabled {
-		return nil, errInvalidState
+		return nil, ErrInvalidState
 	}
 	header, err := readTDSHeader(connection.conn)
 	if err != nil {
@@ -636,8 +780,11 @@ func (connection *tdsConnection) ReadPacket() (*tdsPacket, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &tdsPacket{
-		tdsHeader: *header,
+	if isValidTDSHeader(header) {
+		connection.session.readValidTDSPacket = true
+	}
+	return &TDSPacket{
+		TDSHeader: *header,
 		Body:      buf,
 	}, nil
 }
@@ -667,7 +814,7 @@ func (connection *tdsConnection) Read(b []byte) (n int, err error) {
 		}
 		// END FIXME
 		connection.remainder = make([]byte, header.Length-8)
-		n, err = io.ReadFull(connection.conn, connection.remainder)
+		_, err = io.ReadFull(connection.conn, connection.remainder)
 		if err != nil {
 			logrus.Warn("Error reading body", err)
 			return soFar, err
@@ -685,19 +832,19 @@ func (connection *tdsConnection) Read(b []byte) (n int, err error) {
 }
 
 // The wrapped Write method. If not enabled, just pass through to conn.Write.
-// Otherise, wrap b in a tdsHeader with the next sequence number and packet type
+// Otherise, wrap b in a TDSHeader with the next sequence number and packet type
 // given by messageType, and send it in a single conn.Write().
 func (connection *tdsConnection) Write(b []byte) (n int, err error) {
 	if !connection.enabled {
 		return connection.conn.Write(b)
 	}
 	if len(b)+8 > 0xffff {
-		return 0, errTooLarge
+		return 0, ErrTooLarge
 	}
 	connection.session.sequenceNumber++
-	header := tdsHeader{
+	header := TDSHeader{
 		Type:           connection.messageType,
-		Status:         tdsStatusEOM,
+		Status:         TDSStatusEOM,
 		Length:         uint16(len(b) + 8),
 		SPID:           0,
 		SequenceNumber: uint8(connection.session.sequenceNumber % 0x100),
@@ -754,12 +901,12 @@ func NewConnection(conn net.Conn) *Connection {
 }
 
 // Login sends the LOGIN packet. Called after Handshake(). If
-// self.getEncryptMode() == encryptModeOff, disables TLS afterwards.
+// self.getEncryptMode() == EncryptModeOff, disables TLS afterwards.
 // NOTE: Not currently implemented.
 func (connection *Connection) Login() {
 	panic("unimplemented")
 	// TODO: send login
-	if connection.getEncryptMode() != encryptModeOn {
+	if connection.getEncryptMode() != EncryptModeOn {
 		// Client was only using encryption for login, so switch back to rawConn
 		connection.tdsConn = &tdsConnection{conn: connection.rawConn, enabled: true, session: connection}
 		// tdsConnection.Write(rawData) -> net.Conn.Write(header + rawData)
@@ -769,15 +916,15 @@ func (connection *Connection) Login() {
 
 // getEncryptMode returns the EncryptMode enum returned by the server in the
 // PRELOGIN step. If PRELOGIN has not yet been called or if the ENCRYPTION token
-// was not included / was invalid, returns encryptModeUnknown.
+// was not included / was invalid, returns EncryptModeUnknown.
 func (connection *Connection) getEncryptMode() EncryptMode {
-	if connection.preloginOptions == nil {
-		return encryptModeUnknown
+	if connection.PreloginOptions == nil {
+		return EncryptModeUnknown
 	}
 
-	ret, err := connection.preloginOptions.GetByteOption(preloginEncryption)
+	ret, err := connection.PreloginOptions.GetByteOption(PreloginEncryption)
 	if err != nil {
-		return encryptModeUnknown
+		return EncryptModeUnknown
 	}
 	return EncryptMode(ret)
 }
@@ -786,14 +933,14 @@ func (connection *Connection) getEncryptMode() EncryptMode {
 // First sends the PRELOGIN packet to the server and reads the response.
 // Then, if necessary, does a TLS handshake.
 // Returns the ENCRYPTION value from the response to PRELOGIN.
-func (connection *Connection) Handshake(flags *mssqlFlags) (EncryptMode, error) {
+func (connection *Connection) Handshake(flags *Flags) (EncryptMode, error) {
 	encryptMode := getEncryptMode(flags.EncryptMode)
 	mode, err := connection.prelogin(encryptMode)
 	if err != nil {
 		return mode, err
 	}
 	connection.tdsConn.messageType = 0x12
-	if mode == encryptModeNotSupported {
+	if mode == EncryptModeNotSupported {
 		return mode, nil
 	}
 	tlsClient, err := flags.TLSFlags.GetTLSConnection(connection.tdsConn)

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -1,107 +1,147 @@
+// Package mssql provides the zgrab2 scanner module for the MSSQL protocol.
+// Default Port: 1433 (TCP)
+//
+// The --encrypt-mode flag allows setting an explicit client encryption mode
+// (the default is ENCRYPT_ON). Note: only ENCRYPT_NOT_SUP will skip the TLS
+// handshake, since even ENCRYPT_OFF uses TLS for the login step.
+//
+// The scan performs a PRELOGIN and if possible does a TLS handshake.
+//
+// The output is the the server version and instance name, and if applicable the
+// TLS output.
 package mssql
 
 import (
-	"fmt"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 )
 
-// HandshakeLog contains detailed information about each step of the
+// ScanResults contains detailed information about each step of the
 // MySQL handshake, and can be encoded to JSON.
-type mssqlScanResults struct {
-	Version         string           `json:"version,omitempty"`
-	InstanceName    string           `json:"instance_name,omitempty"`
-	TLSLog          *zgrab2.TLSLog   `json:"tls,omitempty"`
-	PreloginOptions *preloginOptions `json:"prelogin_options,omitempty" zgrab:"debug"`
+type ScanResults struct {
+	// Version is the version returned by the server in the PRELOGIN response.
+	// Its format is "MAJOR.MINOR.BUILD_NUMBER".
+	Version string `json:"version,omitempty"`
+
+	// InstanceName is the value of the INSTANCE field returned by the server
+	// in the PRELOGIN response.
+	InstanceName string `json:"instance_name,omitempty"`
+
+	// PreloginOptions are the raw key-value pairs returned by the server in
+	// response to the PRELOGIN call. Debug only.
+	PreloginOptions *PreloginOptions `json:"prelogin_options,omitempty" zgrab:"debug"`
+
+	// TLSLog is the shared TLS handshake/scan log.
+	TLSLog *zgrab2.TLSLog `json:"tls,omitempty"`
 }
 
-type mssqlFlags struct {
+// Flags defines the command-line configuration options for the module.
+type Flags struct {
 	zgrab2.BaseFlags
 	zgrab2.TLSFlags
-	EncryptMode string `long:"encrypt-mode" description:"The type of encryption to request in the pre-login step. One of ENCRYPT_ON, ENCRYPT_OFF, ENCRYPT_NOT_SUP."`
+	EncryptMode string `long:"encrypt-mode" description:"The type of encryption to request in the pre-login step. One of ENCRYPT_ON, ENCRYPT_OFF, ENCRYPT_NOT_SUP." default:"ENCRYPT_ON"`
 	Verbose     bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
-type mssqlModule struct {
+// Module is the implementation of zgrab2.Module for the MSSQL protocol.
+type Module struct {
 }
 
-type mssqlScanner struct {
-	config *mssqlFlags
+// Scanner is the implementation of zgrab2.Scanner for the MSSQL protocol.
+type Scanner struct {
+	config *Flags
 }
 
-func init() {
-	var module mssqlModule
-	_, err := zgrab2.AddCommand("mssql", "MSSQL", "Grab a MSSQL handshake", 1433, &module)
-	if err != nil {
-		log.Fatal(err)
-	}
+// NewFlags returns a default Flags instance to be populated by the command
+// line flags.
+func (module *Module) NewFlags() interface{} {
+	return new(Flags)
 }
 
-func (module *mssqlModule) NewFlags() interface{} {
-	return new(mssqlFlags)
+// NewScanner returns a new Scanner instance.
+func (module *Module) NewScanner() zgrab2.Scanner {
+	return new(Scanner)
 }
 
-func (module *mssqlModule) NewScanner() zgrab2.Scanner {
-	return new(mssqlScanner)
-}
-
-func (flags *mssqlFlags) Validate(args []string) error {
+// Validate does nothing in this module.
+func (flags *Flags) Validate(args []string) error {
 	return nil
 }
 
-func (flags *mssqlFlags) Help() string {
+// Help returns the help string for this module.
+func (flags *Flags) Help() string {
 	return ""
 }
 
-func (scanner *mssqlScanner) Init(flags zgrab2.ScanFlags) error {
-	f, _ := flags.(*mssqlFlags)
+// Init initializes the Scanner instance with the given command-line flags.
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
+	f, _ := flags.(*Flags)
 	scanner.config = f
 	return nil
 }
 
-func (scanner *mssqlScanner) InitPerSender(senderID int) error {
+// InitPerSender does nothing in this module.
+func (scanner *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
-func (scanner *mssqlScanner) GetName() string {
+// GetName returns the configured scanner name.
+func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
-func (scanner *mssqlScanner) GetPort() uint {
+// GetPort returns the configured scanner port.
+func (scanner *Scanner) GetPort() uint {
 	return scanner.config.Port
 }
 
-func (scanner *mssqlScanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+// Scan performs the MSSQL scan.
+// 1. Open a TCP connection to the target port (default 1433).
+// 2. Send a PRELOGIN packet to the server.
+// 3. Read the PRELOGIN response from the server.
+// 4. If the server encrypt mode is EncryptModeNotSupported, break.
+// 5. Perform a TLS handshake, with the packets wrapped in TDS headers.
+// 6. Decode the Version and InstanceName from the PRELOGIN response
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
 	sql := NewConnection(conn)
 	defer sql.Close()
-	result := &mssqlScanResults{}
+	result := &ScanResults{}
 	_, err = sql.Handshake(scanner.config)
 
 	if sql.tlsConn != nil {
 		result.TLSLog = sql.tlsConn.GetLog()
 	}
 
-	if sql.preloginOptions != nil {
-		result.PreloginOptions = sql.preloginOptions
-		version := sql.preloginOptions.GetVersion()
+	if sql.PreloginOptions != nil {
+		result.PreloginOptions = sql.PreloginOptions
+		version := sql.PreloginOptions.GetVersion()
 		if version != nil {
-			result.Version = fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.BuildNumber)
+			result.Version = version.String()
 		}
+		result.InstanceName = string((*sql.PreloginOptions)[PreloginInstance])
 	}
 
 	if err != nil {
+		if sql.PreloginOptions == nil && sql.readValidTDSPacket == false {
+			// If we received no PreloginOptions and none of the packets we've
+			// read appeared to be a valid TDS header, then the inference is
+			// that we found no MSSQL service on the target.
+			// NOTE: In the case where PreloginOptions == nil but
+			// readValidTDSPacket == true, the result will be empty, but not
+			// nil.
+			result = nil
+		}
 		switch err {
-		case errNoServerEncryption:
-			return zgrab2.SCAN_APPLICATION_ERROR, &result, err
-		case errServerRequiresEncryption:
-			return zgrab2.SCAN_APPLICATION_ERROR, &result, err
+		case ErrNoServerEncryption:
+			return zgrab2.SCAN_APPLICATION_ERROR, result, err
+		case ErrServerRequiresEncryption:
+			return zgrab2.SCAN_APPLICATION_ERROR, result, err
 		default:
-			return zgrab2.TryGetScanStatus(err), &result, err
+			return zgrab2.TryGetScanStatus(err), result, err
 		}
 	}
 	return zgrab2.SCAN_SUCCESS, result, nil
@@ -109,7 +149,7 @@ func (scanner *mssqlScanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, 
 
 // RegisterModule is called by modules/mssql.go's init()
 func RegisterModule() {
-	var module mssqlModule
+	var module Module
 	_, err := zgrab2.AddCommand("mssql", "MSSQL", "Grab a mssql handshake", 1433, &module)
 	log.SetLevel(log.DebugLevel)
 	if err != nil {


### PR DESCRIPTION
 * re-export MSSQL primitives, remove stuttering `mssql.mssqlXYZ`  names
 * re-run golint / gofmt
 * add package godocs
 * add detailed scan docs
 * bugfixes:
  * populate InstanceName in result
  * fix return value in case of failed / incomplete detection
  * add default EncryptMode

## How to Test

`TEST_MODULES=mssql make integration-test`

 * Confirm that InstanceName is set
 * Point to a non-mssql service, like HTTP, and confirm that it returns a nil result

