### PR TITLE
Fix typo in scanner template

### DIFF
--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -1,4 +1,4 @@
-// Package #{MODULE_NAME} provides a zgrab2 module that proves for #{MODULE_NAME}.
+// Package #{MODULE_NAME} provides a zgrab2 module that scans for #{MODULE_NAME}.
 // TODO: Describe module, the flags, the probe, the output, etc.
 package #{MODULE_NAME}
 


### PR DESCRIPTION
Change 

> _"Package #{MODULE_NAME} provides a zgrab2 module that **proves** for #{MODULE_NAME}"_

to

> _"Package #{MODULE_NAME} provides a zgrab2 module that **scans** for #{MODULE_NAME}"_		

