### PR TITLE
Make travis run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 - pip install --user zschema
 - docker ps -a
 install:
-- make clean zgrab2
+- make clean zgrab2 test
 script:
 - make integration-test
 after_script:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ TEST_MODULES ?=
 
 all: zgrab2
 
-.PHONY: all clean integration-test integration-test-clean docker-runner container-clean gofmt
+.PHONY: all clean integration-test integration-test-clean docker-runner container-clean gofmt test
+
+# Test currently only runs on the modules folder because some of the 
+# third-party libraries in lib (e.g. http) are failing.
+test:
+	cd modules && go test -v ./...
 
 gofmt:
 	goimports -w -l $(GO_FILES)


### PR DESCRIPTION
 * Added phony `test` Makefile target
 * Make travis run the `test` target before getting into the much longer integration tests

## How to Test

Run `make test`, or kick off a travisci build.
