### PR TITLE
pull zflags from the zmap project

### DIFF
--- a/cmd/zgrab2/main.go
+++ b/cmd/zgrab2/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	flags "github.com/ajholland/zflags"
+	flags "github.com/zmap/zflags"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 	_ "github.com/zmap/zgrab2/modules"

--- a/utility.go
+++ b/utility.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ajholland/zflags"
+	"github.com/zmap/zflags"
 )
 
 var parser *flags.Parser


### PR DESCRIPTION
Imported https://github.com/ajholland/zflags into https://github.com/zmap/zflags; this PR updates references from the former to the latter.

## How to Test

`make test`, or `make && cmd/zgrab2/zgrab2 --help`.
