### PR TITLE
Fix heartbleed check

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -250,6 +250,9 @@ func (z *TLSConnection) Handshake() error {
 		}()
 		// TODO - CheckHeartbleed does not bubble errors from Handshake
 		_, err := z.CheckHeartbleed(buf)
+		if err == tls.HeartbleedError {
+			err = nil
+		}
 		return err
 	} else {
 		defer func() {


### PR DESCRIPTION
This was originally copied from https://github.com/zmap/zgrab/blob/master/zlib/grabber.go#L595, but that actually references zgrab's own `CheckHeartbleed` wrapper: https://github.com/zmap/zgrab/blob/master/zlib/conn.go#L508.

Updated behavior matches zgrab classic.

## How to Test

`cmd\zgrab2\zgrab2.exe http --use-https --max-redirects 2 --heartbleed --heartbeat-enabled --timeout 3 --port 443 < alexa100.csv > alexa100.02.json`

Before, a whole mess of HeartbleedErrors got dumped. Now, they don't.
