### PR TITLE
Include scanner protocol in response

### DIFF
--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -85,6 +85,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// Protocol returns the protocol identifier of the scan.
+func (scanner *Scanner) Protocol() string {
+	return "#{MODULE_NAME}"
+}
+
 // GetPort returns the port being scanned.
 func (scanner *Scanner) GetPort() uint {
 	return scanner.config.Port

--- a/module.go
+++ b/module.go
@@ -12,14 +12,22 @@ type Scanner interface {
 	// Returns the name passed at init
 	GetName() string
 
+	// Protocol returns the protocol identifier for the scan.
+	Protocol() string
+
 	// Scan connects to a host. The result should be JSON-serializable
 	Scan(t ScanTarget) (ScanStatus, interface{}, error)
 }
 
 // ScanResponse is the result of a scan on a single host
 type ScanResponse struct {
-	// Status is required for all responses. Other fields are optional.
-	Status    ScanStatus  `json:"status"`
+	// Status is required for all responses.
+	Status ScanStatus `json:"status"`
+
+	// Protocol is the identifier if the protocol that did the scan. In the case of a complex scan, this may differ from
+	// the scan name.
+	Protocol string `json:"protocol"`
+
 	Result    interface{} `json:"result,omitempty"`
 	Timestamp string      `json:"timestamp,omitempty"`
 	Error     *string     `json:"error,omitempty"`

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -98,6 +98,11 @@ func (f *Flags) Help() string {
 	return ""
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "ftp"
+}
+
 // Init initializes the Scanner instance with the flags from the command
 // line.
 func (s *Scanner) Init(flags zgrab2.ScanFlags) error {

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -104,6 +104,11 @@ func (flags *Flags) Help() string {
 	return ""
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "http"
+}
+
 // Init initializes the scanner with the given flags
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	fl, _ := flags.(*Flags)

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -85,6 +85,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "mssql"
+}
+
 // GetName returns the configured scanner name.
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -176,6 +176,11 @@ func (s *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "mysql"
+}
+
 // GetName returns the name from the command line flags.
 func (s *Scanner) GetName() string {
 	return s.config.Name

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -853,6 +853,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "ntp"
+}
+
 // GetName returns the module's name
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -288,6 +288,11 @@ func (s *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "postgres"
+}
+
 // GetName returns the name from the parameters.
 func (s *Scanner) GetName() string {
 	return s.Config.Name

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -195,6 +195,11 @@ func forceToString(val RedisValue) string {
 	}
 }
 
+// Protocol returns the protocol identifer for the scanner.
+func (s *Scanner) Protocol() string {
+	return "redis"
+}
+
 // Scan executes the following commands:
 // 1. PING
 // 2. (only if --password is provided) AUTH <password>

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -102,3 +102,8 @@ func (s *SSHScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 	status := zgrab2.TryGetScanStatus(err)
 	return status, data, err
 }
+
+// Protocol returns the protocol identifer for the scanner.
+func (s *SSHScanner) Protocol() string {
+	return "ssh"
+}

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -73,3 +73,8 @@ func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 	}
 	return zgrab2.SCAN_SUCCESS, result, nil
 }
+
+// Protocol returns the protocol identifer for the scanner.
+func (s *TLSScanner) Protocol() string {
+	return "tls"
+}

--- a/scanner.go
+++ b/scanner.go
@@ -39,7 +39,7 @@ func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanRespons
 		errString := e.Error()
 		err = &errString
 	}
-	resp := ScanResponse{Result: res, Error: err, Timestamp: t.Format(time.RFC3339), Status: status}
+	resp := ScanResponse{Result: res, Protocol: s.Protocol(), Error: err, Timestamp: t.Format(time.RFC3339), Status: status}
 	return s.GetName(), resp
 }
 

--- a/schemas/zgrab2.py
+++ b/schemas/zgrab2.py
@@ -40,6 +40,7 @@ STATUS_VALUES = [
 # zgrab2/module.go: ScanResponse
 base_scan_response = SubRecord({
     "status": Enum(values = STATUS_VALUES, required = True),
+    "protocol": String(required = True),
     "timestamp": DateTime(required = True),
     "result": SubRecord({}, required = False), # This is overridden by the protocols' implementations
     "error": String(required = False)


### PR DESCRIPTION
Scanners now implement a `Protocol()` method, which returns a string identifying the protocol (and more to the point, the schema for its output).

Prior to this, there is no safe way to determine the protocol that generated a piece of zgrab2 output; for simple cases the scan name is identical with the protocol, but that will not hold for scans where the default name is not used.

## How to Test

`make integration-test` should still work; you can confirm that in `./zgrab-output/**/*.json` the `[*].data.*.protocol` is set.

## Notes & Caveats

Scans with custom names will still have trouble validating, since the schema validation looks for a field named e.g. `mysql`, rather than `customName.protocol == "mysql"`.

But, since we don't allow unknown key names (even `allow_unknown` has a bug), any solution would probably require a change to zschema.


## Issue Tracking

We could ignore this when the schema was used only for validating the integration test output, since we could guarantee the correct name -- but for integration with the pipeline, we cannot make such demands.
