### PR TITLE
zgrab2: Port IMAP scanner from zgrab

### DIFF
--- a/modules/imap.go
+++ b/modules/imap.go
@@ -1,0 +1,7 @@
+package modules
+
+import "github.com/zmap/zgrab2/modules/imap"
+
+func init() {
+	imap.RegisterModule()
+}

--- a/modules/imap/imap.go
+++ b/modules/imap/imap.go
@@ -1,0 +1,37 @@
+package imap
+
+import (
+	"net"
+	"regexp"
+
+	"github.com/zmap/zgrab2"
+)
+
+// This is the regex used in zgrab.
+var imapStatusEndRegex = regexp.MustCompile(`\r\n$`)
+
+const readBufferSize int = 0x10000
+
+// Connection wraps the state and access to the SMTP connection.
+type Connection struct {
+	Conn net.Conn
+}
+
+// ReadResponse reads from the connection until it matches the imapEndRegex. Copied from the original zgrab.
+// TODO: Catch corner cases, parse out success/error character.
+func (conn *Connection) ReadResponse() (string, error) {
+	ret := make([]byte, readBufferSize)
+	n, err := zgrab2.ReadUntilRegex(conn.Conn, ret, imapStatusEndRegex)
+	if err != nil {
+		return "", nil
+	}
+	return string(ret[0:n]), nil
+}
+
+// SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.
+func (conn *Connection) SendCommand(cmd string) (string, error) {
+	if _, err := conn.Conn.Write([]byte(cmd + "\r\n")); err != nil {
+		return "", err
+	}
+	return conn.ReadResponse()
+}

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -1,0 +1,208 @@
+// Package imap provides a zgrab2 module that scans for IMAP mail
+// servers.
+// Default Port: 143 (TCP)
+//
+// The --imaps flag tells the scanner to perform a TLS handshake
+// immediately after connecting, before even attempting to read
+// the banner.
+// The --starttls flag tells the scanner to send the STARTTLS
+// command and then negotiate a TLS connection.
+// The scanner uses the standard TLS flags for the handshake.
+// --imaps and --starttls are mutually exclusive.
+// --imaps does not change the default port number from 143, so
+// it should usually be coupled with e.g. --port 993.
+//
+// The --send-close flag tells the scanner to send a CLOSE command
+// before disconnecting.
+//
+// So, if no flags are specified, the scanner simply reads the banner
+// returned by the server and disconnects.
+//
+// The output contains the banner and the responses to any commands that
+// were sent, and if or --imaps --starttls were set, the standard TLS logs.
+package imap
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zgrab2"
+	"strings"
+)
+
+
+// ScanResults instances are returned by the module's Scan function.
+type ScanResults struct {
+	// Banner is the string sent by the server immediately after connecting.
+	Banner string `json:"banner,omitempty"`
+
+	// StartTLS is the server's response to the STARTTLS command, if it is sent.
+	StartTLS string `json:"starttls,omitempty"`
+
+	// CLOSE is the server's response to the CLOSE command, if it is sent.
+	CLOSE string `json:"close,omitempty"`
+
+	// TLSLog is the standard TLS log, if --starttls or --imaps is enabled.
+	TLSLog *zgrab2.TLSLog `json:"tls,omitempty"`
+}
+
+// Flags holds the command-line configuration for the IMAP scan module.
+// Populated by the framework.
+type Flags struct {
+	zgrab2.BaseFlags
+	zgrab2.TLSFlags
+
+	// SendCLOSE indicates that the CLOSE command should be sent.
+	SendCLOSE bool `long:"send-close" description:"Send the CLOSE command before closing."`
+
+	// IMAPSecure indicates that the client should do a TLS handshake immediately after connecting.
+	IMAPSecure bool `long:"imaps" description:"Immediately negotiate a TLS connection"`
+
+	// StartTLS indicates that the client should attempt to update the connection to TLS.
+	StartTLS bool `long:"starttls" description:"Send STLS before negotiating"`
+
+	// Verbose indicates that there should be more verbose logging.
+	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+}
+
+// Module implements the zgrab2.Module interface.
+type Module struct {
+}
+
+// Scanner implements the zgrab2.Scanner interface.
+type Scanner struct {
+	config *Flags
+}
+
+// RegisterModule registers the zgrab2 module.
+func RegisterModule() {
+	var module Module
+	_, err := zgrab2.AddCommand("imap", "imap", "Probe for IMAP", 143, &module)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// NewFlags returns a default Flags object.
+func (module *Module) NewFlags() interface{} {
+	return new(Flags)
+}
+
+// NewScanner returns a new Scanner instance.
+func (module *Module) NewScanner() zgrab2.Scanner {
+	return new(Scanner)
+}
+
+// Validate checks that the flags are valid.
+// On success, returns nil.
+// On failure, returns an error instance describing the error.
+func (flags *Flags) Validate(args []string) error {
+	if flags.StartTLS && flags.IMAPSecure {
+		log.Error("Cannot send both --starttls and --imaps")
+		return zgrab2.ErrInvalidArguments
+	}
+	return nil
+}
+
+// Help returns the module's help string.
+func (flags *Flags) Help() string {
+	return ""
+}
+
+// Init initializes the Scanner.
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
+	f, _ := flags.(*Flags)
+	scanner.config = f
+	return nil
+}
+
+// InitPerSender initializes the scanner for a given sender.
+func (scanner *Scanner) InitPerSender(senderID int) error {
+	return nil
+}
+
+// GetName returns the Scanner name defined in the Flags.
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
+}
+
+// Protocol returns the protocol identifier of the scan.
+func (scanner *Scanner) Protocol() string {
+	return "imap"
+}
+
+// GetPort returns the port being scanned.
+func (scanner *Scanner) GetPort() uint {
+	return scanner.config.Port
+}
+
+func getIMAPError(response string) error {
+	if strings.HasPrefix(response, "a001 OK") {
+		return nil
+	}
+	return fmt.Errorf("error: %s", response)
+}
+
+// Scan performs the IMAP scan.
+// 1. Open a TCP connection to the target port (default 143).
+// 2. If --imaps is set, perform a TLS handshake using the command-line
+//    flags.
+// 3. Read the banner.
+// 6. If --starttls is sent, send a001 STARTTLS, read the result, negotiate a
+//    TLS connection using the command-line flags.
+// 7. If --send-close is sent, send a001 CLOSE and read the result.
+// 8. Close the connection.
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	c, err := target.Open(&scanner.config.BaseFlags)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	defer c.Close()
+	result := &ScanResults{}
+	if scanner.config.IMAPSecure {
+		tlsConn, err := scanner.config.TLSFlags.GetTLSConnection(c)
+		if err != nil {
+			return zgrab2.TryGetScanStatus(err), nil, err
+		}
+		result.TLSLog = tlsConn.GetLog()
+		if err := tlsConn.Handshake(); err != nil {
+			return zgrab2.TryGetScanStatus(err), result, err
+		}
+		c = tlsConn
+	}
+	conn := Connection{Conn: c}
+	banner, err := conn.ReadResponse()
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	result.Banner = banner
+	if scanner.config.StartTLS {
+		ret, err := conn.SendCommand("a001 STARTTLS")
+		if err != nil {
+			return zgrab2.TryGetScanStatus(err), result, err
+		}
+		result.StartTLS = ret
+		if err := getIMAPError(ret); err != nil {
+			return zgrab2.TryGetScanStatus(err), result, err
+		}
+		tlsConn, err := scanner.config.TLSFlags.GetTLSConnection(conn.Conn)
+		if err != nil {
+			return zgrab2.TryGetScanStatus(err), result, err
+		}
+		result.TLSLog = tlsConn.GetLog()
+		if err := tlsConn.Handshake(); err != nil {
+			return zgrab2.TryGetScanStatus(err), result, err
+		}
+		conn.Conn = tlsConn
+	}
+	if scanner.config.SendCLOSE {
+		ret, err := conn.SendCommand("a001 CLOSE")
+		if err != nil {
+			if err != nil {
+				return zgrab2.TryGetScanStatus(err), nil, err
+			}
+		}
+		result.CLOSE = ret
+	}
+	return zgrab2.SCAN_SUCCESS, result, nil
+}

--- a/schemas/imap.py
+++ b/schemas/imap.py
@@ -1,0 +1,23 @@
+# zschema sub-schema for zgrab2's pop3 module
+# Registers zgrab2-pop3 globally, and pop3 with the main zgrab2 schema.
+from zschema.leaves import *
+from zschema.compounds import *
+import zschema.registry
+
+import schemas.zcrypto as zcrypto
+import schemas.zgrab2 as zgrab2
+
+pop3_scan_response = SubRecord({
+    "result": SubRecord({
+        "banner": String(),
+        "noop": String(),
+        "help": String(),
+        "starttls": String(),
+        "quit": String(),
+        "tls": zgrab2.tls_log,
+    })
+}, extends=zgrab2.base_scan_response)
+
+zschema.registry.register_schema("zgrab2-pop3", pop3_scan_response)
+
+zgrab2.register_scan_response_type("pop3", pop3_scan_response)


### PR DESCRIPTION
Copy existing IMAP scanning behavior from ZGrab.

## How to Test

No unit tests in the original, so none here.

No container here...you should be able to find an IMAP server, though:

`echo "imap.gmail.com" | cmd/zgrab2/zgrab2 imap --port 995 --imaps --send-quit`

## Issue Tracking

Jira issue CEN-74
