### PR TITLE
zgrab2: Port modbus from zgrab

### DIFF
--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -96,7 +96,11 @@ func (scanner *Scanner) GetPort() uint {
 }
 
 // Scan TODO: describe what is scanned
-func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result interface{}, thrown error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	conn, err := target.Open(&scanner.config.BaseFlags)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
 	// TODO: implement
 	return zgrab2.SCAN_UNKNOWN_ERROR, nil, nil
 }

--- a/modules/modbus/modbus.go
+++ b/modules/modbus/modbus.go
@@ -1,0 +1,401 @@
+package modbus
+
+/*
+ * ZGrab Copyright 2015 Regents of the University of Michigan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// MEIResponse is the parsed data field from the 0x2B/0x0E response.
+type MEIResponse struct {
+	// ConformityLevel specifies the confirmity level of the device and the type of supported access.
+	// Valid values include 0x01, 0x02, 0x03, for basic, regular, extended stream access, and
+	// 8x81, 0x82, 0x83 for basic, regular, extended stream/individual access.
+	ConformityLevel int `json:"conformity_level"`
+
+	// MoreFollows specifies whether more data follows. Strictly should be 00 or FF, but we take any nonzero number
+	// to mean that more data follows.
+	MoreFollows bool `json:"more_follows"`
+
+	// NextObjectID gives the next object ID if MoreFollows is set, otherwise it should be 0x00.
+	NextObjectID int `json:"next_object_id"`
+
+	// ObjectCount gives the number of items returned.
+	ObjectCount int `json:"object_count"`
+
+	// Objects is a set of object ID/value pairs returned by the server.
+	Objects MEIObjectSet `json:"objects,omitempty"`
+}
+
+// MEIObjectSet wraps the list of object ID/value pairs, encoding them as a dict of ID name -> value
+type MEIObjectSet []MEIObject
+
+// MarshalJSON encodes the object ID list as a map of { "obj.OID.Name()": obj.Value }
+func (ms *MEIObjectSet) MarshalJSON() ([]byte, error) {
+	enc := make(map[string]string, len(*ms))
+	for _, obj := range *ms {
+		enc[obj.OID.Name()] = obj.Value
+	}
+	return json.Marshal(enc)
+}
+
+// MEIObject wraps the ID/value pair in the 0x2B/0x0E response.
+type MEIObject struct {
+	// OID is the object identifier.
+	OID MEIObjectID
+	// Value is the value for that object identifier.
+	Value string
+}
+
+// MEIObjectID is the numeric identifier used by the server to identify different data.
+type MEIObjectID int
+
+const (
+	// OIDVendor identifies the vendor name. Mandatory ASCII String, category = basic.
+	OIDVendor MEIObjectID = 0
+
+	// OIDProductCode identifies the product code. Mandatory ASCII String, category = basic.
+	OIDProductCode MEIObjectID = 1
+
+	// OIDRevision identifies the MajorMinorRevision. Mandatory ASCII String, category = basic.
+	OIDRevision MEIObjectID = 2
+
+	// OIDVendorURL identifies the vendor URL. Optional ASCII String, category = regular.
+	OIDVendorURL MEIObjectID = 3
+
+	// OIDProductName identifies the product name. Optional ASCII String, category = regular.
+	OIDProductName MEIObjectID = 4
+
+	// OIDModelName identifies the model name. Optional ASCII String, category = regular.
+	OIDModelName MEIObjectID = 5
+
+	// OIDUserApplicationName identifies the user application name. Optional ASCII String, category = regular.
+	OIDUserApplicationName MEIObjectID = 6
+)
+
+var meiObjectNames = []string{
+	"vendor",
+	"product_code",
+	"revision",
+	"vendor_url",
+	"product_name",
+	"model_name",
+	"user_application_name",
+}
+
+// Name maps the object ID to its friendly name; if the ID is not on the list, it returns "oid_$(id)".
+func (m *MEIObjectID) Name() string {
+	oid := int(*m)
+	var name string
+	if oid >= len(meiObjectNames) || oid < 0 {
+		name = "oid_" + strconv.Itoa(oid)
+	} else {
+		name = meiObjectNames[oid]
+	}
+	return name
+}
+
+// MarshalJSON encodes the identifier as its friendly name.
+func (m *MEIObject) MarshalJSON() ([]byte, error) {
+	enc := make(map[string]interface{}, 1)
+	name := m.OID.Name()
+	enc[name] = m.Value
+	return json.Marshal(enc)
+}
+
+// ExceptionResponse wraps the exception returned by the server.
+type ExceptionResponse struct {
+	// ExceptionFunction is the function to which the server is responding -- namely, the value of the FunctionCode in
+	// the response with the high bit masked off.
+	ExceptionFunction FunctionCode `json:"exception_function"`
+
+	// ExceptionType is the type code representing the exception.
+	// For details see e.g. section 7 of http://www.modbus.org/docs/Modbus_Application_Protocol_V1_1b.pdf
+	ExceptionType byte `json:"exception_type"`
+}
+
+// ModbusEvent is the response object. Either MEIResponse or ExceptionResponse will be set.
+type ModbusEvent struct {
+	// Length is the data length the server claimed to return in the header. Should be len(Response) + 1 (the function
+	// code is included)
+	Length int `json:"length"`
+
+	// UnitID is the unit ID for which the server is responding. If request unit ID was nonzero, should match that.
+	UnitID int `json:"unit_id"`
+
+	// Function is the response function code. The high bit indicates the presence of an exception (set -> exception).
+	Function FunctionCode `json:"function_code"`
+
+	// Response is the response data (not including the function code).
+	Response []byte `json:"raw_response,omitempty"`
+
+	// MEIResponse is the parsed response; it is present if the response was decoded successfully and there was no
+	// exception.
+	MEIResponse *MEIResponse `json:"mei_response,omitempty"`
+
+	// ExceptionResponse is the parsed exception; it is present if the response was decoded successfully and there was
+	// an exception (i.e. the high bit of Function is set).
+	ExceptionResponse *ExceptionResponse `json:"exception_response,omitempty"`
+
+	// Raw is the full raw response from the server, including the header.
+	Raw []byte `json:"raw,omitempty"`
+}
+
+// IsException returns true if this response indicates an exception has occurred.
+func (m *ModbusResponse) IsException() bool {
+	return (m.Function&0x80 != 0)
+}
+
+// getEvent does basic validation parsing, and on success, returns the event; on failure, it returns nil and the error,
+// which should be interpreted as a protocol error / failed detection.
+func (m *ModbusResponse) getEvent(strict bool) (*ModbusEvent, error) {
+	ret := &ModbusEvent{
+		Length:   m.Length,
+		UnitID:   m.UnitID,
+		Function: m.Function,
+		Response: m.Data,
+		Raw:      m.Raw,
+	}
+	if m.IsException() {
+		ex, err := m.getExceptionResponse(strict)
+		if err != nil {
+			return nil, err
+		}
+		ret.ExceptionResponse = ex
+	} else {
+		// TODO: This is only valid for 0x0E.
+		mei, err := m.getMEIResponse(strict)
+		if err != nil {
+			return nil, err
+		}
+		ret.MEIResponse = mei
+	}
+	return ret, nil
+}
+
+func (m *ModbusResponse) getExceptionResponse(strict bool) (*ExceptionResponse, error) {
+	exceptionFunction := m.Function & 0x7F
+	var exceptionType byte
+	if len(m.Data) > 0 {
+		exceptionType = m.Data[0]
+	} else if strict {
+		return nil, fmt.Errorf("Empty response body on error for function 0x%02x", exceptionFunction)
+	}
+	return &ExceptionResponse{
+		ExceptionFunction: exceptionFunction,
+		ExceptionType:     exceptionType,
+	}, nil
+}
+
+func (m *ModbusResponse) getMEIResponse(strict bool) (*MEIResponse, error) {
+	if m.Function != FunctionCodeMEI {
+		return nil, fmt.Errorf("Invalid function code 0x%02x", m.Function)
+	}
+	if len(m.Data) < 6 {
+		return nil, fmt.Errorf("Response too short (%d bytes)", len(m.Data))
+	}
+	meiType := m.Data[0]
+	if meiType != 0x0E {
+		return nil, fmt.Errorf("Invalid response data (expected 0xee, got 0x%02x)", meiType)
+	}
+	// TODO: Allow different values here
+	readType := m.Data[1]
+	if readType != 1 {
+		return nil, fmt.Errorf("Invalid response data (expected 0x01, got 0x%02x)", readType)
+	}
+	conformityLevel := m.Data[2]
+	moreFollows := (m.Data[3] != 0)
+	if strict && m.Data[3] != 0x00 && m.Data[3] != 0xFF {
+		return nil, fmt.Errorf("Invalid response data (expected 0x00 or 0xff for MoreFollows, got 0x%02x)", m.Data[3])
+	}
+	nextObject := m.Data[4]
+	if strict && (!moreFollows && nextObject != 0) {
+		return nil, fmt.Errorf("For MoreFollows == 0x00, expected NextObjectID == 0x00 (got 0x%02x)", nextObject)
+	}
+	objectCount := m.Data[5]
+	objects := make([]MEIObject, objectCount)
+	it := 6
+	for idx := range objects {
+		n, obj := parseMEIObject(m.Data[it:])
+		it += n
+		if obj == nil {
+			break
+		}
+		objects[idx] = *obj
+	}
+	return &MEIResponse{
+		ConformityLevel: int(conformityLevel),
+		MoreFollows:     moreFollows,
+		NextObjectID:    int(nextObject),
+		ObjectCount:     int(objectCount),
+		Objects:         objects,
+	}, nil
+}
+
+func parseMEIObject(objectBytes []byte) (int, *MEIObject) {
+	length := len(objectBytes)
+	if length < 2 {
+		return length, nil
+	}
+	oid := objectBytes[0]
+	objLen := int(objectBytes[1])
+	if length < 2+objLen {
+		return length, nil
+	}
+	s := string(objectBytes[2 : 2+objLen])
+	obj := MEIObject{
+		OID:   MEIObjectID(oid),
+		Value: s,
+	}
+	return 2 + objLen, &obj
+}
+
+// FunctionCode identifies the Modbus function being queried.
+type FunctionCode byte
+
+// ExceptionFunctionCode represents the function code corresponding to an exception -- that is, with the high bit set.
+type ExceptionFunctionCode byte
+
+// ExceptionCode represents the exception description codes.
+type ExceptionCode byte
+
+// ModbusRequest wraps the Modbus ApplicationDataUnit (ADU).
+type ModbusRequest struct {
+	// UnitID is the target unit ID. 0 can get special treatment (ignored, invalid, or treated as broadcast).
+	UnitID int
+
+	// FunctionCode identifies the function for the server to execute.
+	Function FunctionCode
+
+	//  Deta is the payload for the request, its format depends on the FunctionCode.
+	Data []byte
+}
+
+// MarshalBinary marshals the request for transport to the server.
+func (r *ModbusRequest) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 7+1+len(r.Data))
+	copy(data[0:4], ModbusHeaderBytes)
+	msglen := len(r.Data) + 2 // unit ID and function
+	binary.BigEndian.PutUint16(data[4:6], uint16(msglen))
+	// leaving UnitID == 0 keeps the original zgrab behavior (which hangs on the modbus simulator -- "station #0 so no
+	// response allowed")
+	// similarly, if the identified unit is offline, it hangs with "Station ID <X> off-line, no response sent".
+	data[6] = byte(r.UnitID)
+	data[7] = byte(r.Function)
+	copy(data[8:], r.Data)
+	return
+}
+
+// ModbusResponse wraps the data returned by the server in response to the ModbusRequest.
+type ModbusResponse struct {
+	// Length is the number of bytes the server says it will return.
+	Length int
+
+	// UnitID identifies the unit this response pertains to.
+	UnitID int
+
+	// Function is the function code returned by the server (which may have the high bit set to indicate an exception).
+	Function FunctionCode
+
+	// Data is payload, its format depends on the function code. Should be Length - 1 bytes.
+	Data []byte
+
+	// Raw is the actual data returned by the server, including the header.
+	Raw []byte
+}
+
+// GetModbusResponse reads the response from the server and does some minimal parsing.
+func (c *Conn) GetModbusResponse() (*ModbusResponse, error) {
+	header := make([]byte, 7)
+	_, err := io.ReadFull(c.getUnderlyingConn(), header)
+	if err != nil {
+		return nil, fmt.Errorf("modbus: could not get response: %s", err.Error())
+	}
+
+	// first 4 bytes should be known, verify them
+	if !bytes.Equal(header[0:4], ModbusHeaderBytes) {
+		return nil, fmt.Errorf("modbus: not a modbus response")
+	}
+
+	msglen := int(binary.BigEndian.Uint16(header[4:6]))
+	unitID := int(header[6])
+	body := make([]byte, msglen-1)
+	cnt := 0
+	// One of the bytes in length counts as part of the header
+	var readError error
+	for cnt < len(body) {
+		var n int
+		n, readError = c.getUnderlyingConn().Read(body[cnt:])
+		cnt += n
+
+		if readError != nil {
+			// Some servers return a message length of 09, but stop sending data after the two-byte error
+			body = body[:cnt]
+			break
+		}
+	}
+
+	if readError == io.EOF {
+		readError = nil
+	}
+	raw := make([]byte, len(header)+len(body))
+	copy(raw[0:7], header)
+	copy(raw[7:], body)
+	//TODO this really should be done by a more elegant unmarshaling function
+	return &ModbusResponse{
+		Length:   msglen,
+		UnitID:   unitID,
+		Function: FunctionCode(body[0]),
+		Data:     body[1:],
+		Raw:      raw,
+	}, readError
+}
+
+// FunctionCode strips the high bit off of the exception function code, to get the function for which the server is
+// responding.
+func (e ExceptionFunctionCode) FunctionCode() FunctionCode {
+	code := byte(e) & byte(0x7f)
+	return FunctionCode(code)
+}
+
+// ExceptionFunctionCode gets the code that the server would return in an exception to the given function code.
+func (c FunctionCode) ExceptionFunctionCode() ExceptionFunctionCode {
+	code := byte(c) | byte(0x80)
+	return ExceptionFunctionCode(code)
+}
+
+// IsException checks if the given function code is an exception (i.e. its high bit is set).
+func (c FunctionCode) IsException() bool {
+	return (byte(c) & 0x80) == 0x80
+}
+
+// ModbusHeaderBytes is the header prepended to each packet -- both server and client.
+var ModbusHeaderBytes = []byte{
+	0x13, 0x37, // do not matter, will just be verifying they are the same
+	0x00, 0x00, // must be 0
+}
+
+// ModbusFunctionEncapsulatedInterface identifies the MEI read function.
+var ModbusFunctionEncapsulatedInterface = FunctionCode(0x2B)
+
+const (
+	// FunctionCodeMEI identifies the MEI read function.
+	FunctionCodeMEI = FunctionCode(0x2B)
+)

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -25,8 +25,6 @@ import (
 	"github.com/zmap/zgrab2"
 )
 
-import "github.com/jb/tcpwrap"
-
 // Flags holds the command-line configuration for the modbus scan module.
 // Populated by the framework.
 type Flags struct {
@@ -137,7 +135,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	defer conn.Close()
 
-	c := Conn{Conn: tcpwrap.Wrap(conn)}
+	c := Conn{Conn: conn}
 	req := ModbusRequest{
 		UnitID:   int(scanner.config.UnitID),
 		Function: ModbusFunctionEncapsulatedInterface,

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -1,0 +1,207 @@
+// Package modbus provides a zgrab2 module that scans for modbus.
+// Default Port: 502 (TCP)
+//
+// The --unit-id flag allows overriding the default value of 0 (the simulator
+// for example does not respond at all to UnitID == 0; other servers may
+// interpret it as a broadcast).
+//
+// The --object-id flag allows reading a different object ID's information.
+// The default of 0x00 is the VendorName, which is required.
+//
+// The --strict flag allows turning on new validity checks beyond those
+// done in the original zgrab, to help rule out false matches.
+//
+// The output is the same as the original ZGrab: a "modbus event" object,
+// with either the parsed MEI response or the parsed exception info.
+// The only addition is a "raw" field containing the raw response data.
+package modbus
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zgrab2"
+)
+
+import "github.com/jb/tcpwrap"
+
+// Flags holds the command-line configuration for the modbus scan module.
+// Populated by the framework.
+type Flags struct {
+	zgrab2.BaseFlags
+	// Protocols that support TLS should include zgrab2.TLSFlags
+	UnitID   uint8 `long:"unit-id" description:"The UnitID / Station ID to probe"`
+	ObjectID uint8 `long:"object-id" description:"The ObjectID of the object to be read." default:"0x00"`
+	Strict   bool  `long:"strict" description:"If set, perform stricter checks on the response data to get fewer false positives"`
+	Verbose  bool  `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+}
+
+// Module implements the zgrab2.Module interface.
+type Module struct {
+}
+
+// Scanner implements the zgrab2.Scanner interface.
+type Scanner struct {
+	config *Flags
+}
+
+// RegisterModule registers the zgrab2 module.
+func RegisterModule() {
+	var module Module
+	_, err := zgrab2.AddCommand("modbus", "modbus", "Probe for modbus", 502, &module)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// NewFlags returns a default Flags object.
+func (module *Module) NewFlags() interface{} {
+	return new(Flags)
+}
+
+// NewScanner returns a new Scanner instance.
+func (module *Module) NewScanner() zgrab2.Scanner {
+	return new(Scanner)
+}
+
+// Validate checks that the flags are valid.
+// On success, returns nil.
+// On failure, returns an error instance describing the error.
+func (flags *Flags) Validate(args []string) error {
+	if flags.Verbose {
+		// If --verbose is set, do some extra checking but don't fail.
+		if flags.ObjectID >= 0x07 && flags.ObjectID < 0x80 {
+			log.Warnf("ObjectIDs 0x07...0x7F are reserved (requested 0x%02x)", flags.ObjectID)
+		}
+	}
+	return nil
+}
+
+// Help returns the module's help string.
+func (flags *Flags) Help() string {
+	return ""
+}
+
+// Init initializes the Scanner.
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
+	f, _ := flags.(*Flags)
+	scanner.config = f
+	return nil
+}
+
+// InitPerSender initializes the scanner for a given sender.
+func (scanner *Scanner) InitPerSender(senderID int) error {
+	return nil
+}
+
+// GetName returns the Scanner name defined in the Flags.
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
+}
+
+// Protocol returns the protocol identifier of the scan.
+func (scanner *Scanner) Protocol() string {
+	return "modbus"
+}
+
+// GetPort returns the port being scanned.
+func (scanner *Scanner) GetPort() uint {
+	return scanner.config.Port
+}
+
+// Conn wraps the connection state (more importantly, it provides the interface used by the old zgrab code, so that it
+// could be taken over as-is).
+type Conn struct {
+	Conn net.Conn
+}
+
+func (c *Conn) getUnderlyingConn() net.Conn {
+	return c.Conn
+}
+
+// Scan probes for a modbus service.
+// It connects to the configured TCP port (default 502) and sends a packet with:
+//	 UnitID = <flags.UnitID, default 0>
+//   FunctionCode = 0x2B: Encapsulated Interface Transport)
+//   MEI Type = 0x0E: Read Device Info
+//   Category = 0x01: Basic
+//	 ObjectID = <flags.ObjectID, default 0: VendorName>
+// If the response is not a valid modbus response to this packet, then fail with a SCAN_PROTOCOL_ERROR.
+// Otherwise, return the parsed response and status (SCAN_SUCCESS or SCAN_APPLICATION_ERROR)
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	conn, err := target.Open(&scanner.config.BaseFlags)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	defer conn.Close()
+
+	c := Conn{Conn: tcpwrap.Wrap(conn)}
+	req := ModbusRequest{
+		UnitID:   int(scanner.config.UnitID),
+		Function: ModbusFunctionEncapsulatedInterface,
+		Data: []byte{
+			0x0E, // 0x0E = MEI Read Device Identification
+			0x01, // 0x01 = "Category" = basic (02 = regular, 03 = extended, 04 = specific)
+			scanner.config.ObjectID,
+		},
+	}
+
+	data, err := req.MarshalBinary()
+	if err != nil {
+		log.Fatalf("Unexpected error marshaling modbus packet: %v", err)
+	}
+	w := 0
+	for w < len(data) {
+		written, err := c.getUnderlyingConn().Write(data[w:])
+		w += written
+		if err != nil {
+			return zgrab2.TryGetScanStatus(err), nil, err
+		}
+	}
+
+	res, err := c.GetModbusResponse()
+	if res == nil {
+		if err == nil {
+			// unreachable
+			log.Fatalf("Unreachable: no result, no error from modbus.GetModbusResponse()")
+		}
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+
+	// if there was an error but we still got a response, try to continue
+	if scanner.config.Verbose {
+		log.Debugf("Got non-fatal error while reading modbus response: %v", err)
+	}
+
+	if res.Function&0x7F != ModbusFunctionEncapsulatedInterface {
+		// The server should always return a response for the same function
+		return zgrab2.SCAN_PROTOCOL_ERROR, nil, fmt.Errorf("Invalid response function code 0x%02x (raw = %s)", res.Function, hex.Dump(res.Raw))
+	}
+	if scanner.config.Strict && (scanner.config.UnitID != 0 && res.UnitID != int(scanner.config.UnitID)) {
+		// response for different unitID.
+		// If request unit ID was 0, don't enforce matching since that may be interpreted as a broadcast.
+		return zgrab2.SCAN_PROTOCOL_ERROR, nil, fmt.Errorf("Invalid response unit ID 0x%02x (raw = %s)", res.UnitID, hex.Dump(res.Raw))
+	}
+
+	if res.Length != len(res.Data)+2 {
+		// data not expected size
+		// Let this one slide with a debug-only warning, since some actual servers seem to behave this way
+		log.Debugf("Server advertised %d bytes of data, received %d", res.Length, len(res.Data)+2)
+	}
+
+	ret, err := res.getEvent(scanner.config.Strict)
+	if err != nil {
+		// Unable to parse the response as a valid event
+		log.Debugf("Unable to process response as modbus: %v. Raw response data=[\n%s\n]", err, hex.Dump(res.Raw))
+		return zgrab2.SCAN_PROTOCOL_ERROR, nil, err
+	}
+
+	status := zgrab2.SCAN_SUCCESS
+	if res.IsException() {
+		// Note the exception, but note that the modbus protocol was detected
+		status = zgrab2.SCAN_APPLICATION_ERROR
+	}
+	return status, ret, nil
+}

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -8,6 +8,9 @@
 // The --object-id flag allows reading a different object ID's information.
 // The default of 0x00 is the VendorName, which is required.
 //
+// The --request-id flag allows setting a custom request identifier (which
+// the server will use in its response).
+//
 // The --strict flag allows turning on new validity checks beyond those
 // done in the original zgrab, to help rule out false matches.
 //
@@ -30,10 +33,11 @@ import (
 type Flags struct {
 	zgrab2.BaseFlags
 	// Protocols that support TLS should include zgrab2.TLSFlags
-	UnitID   uint8 `long:"unit-id" description:"The UnitID / Station ID to probe"`
-	ObjectID uint8 `long:"object-id" description:"The ObjectID of the object to be read." default:"0x00"`
-	Strict   bool  `long:"strict" description:"If set, perform stricter checks on the response data to get fewer false positives"`
-	Verbose  bool  `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	UnitID    uint8  `long:"unit-id" description:"The UnitID / Station ID to probe"`
+	ObjectID  uint8  `long:"object-id" description:"The ObjectID of the object to be read." default:"0x00"`
+	Strict    bool   `long:"strict" description:"If set, perform stricter checks on the response data to get fewer false positives"`
+	RequestID uint16 `long:"request-id" description:"Override the default request ID." default:"0x5A47"`
+	Verbose   bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module implements the zgrab2.Module interface.
@@ -112,7 +116,8 @@ func (scanner *Scanner) GetPort() uint {
 // Conn wraps the connection state (more importantly, it provides the interface used by the old zgrab code, so that it
 // could be taken over as-is).
 type Conn struct {
-	Conn net.Conn
+	Conn    net.Conn
+	scanner *Scanner
 }
 
 func (c *Conn) getUnderlyingConn() net.Conn {
@@ -135,7 +140,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	defer conn.Close()
 
-	c := Conn{Conn: conn}
+	c := Conn{Conn: conn, scanner: scanner}
 	req := ModbusRequest{
 		UnitID:   int(scanner.config.UnitID),
 		Function: ModbusFunctionEncapsulatedInterface,
@@ -146,7 +151,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		},
 	}
 
-	data, err := req.MarshalBinary()
+	data, err := c.MarshalRequest(&req)
 	if err != nil {
 		log.Fatalf("Unexpected error marshaling modbus packet: %v", err)
 	}

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -11,3 +11,4 @@ import schemas.smtp
 import schemas.telnet
 import schemas.pop3
 import schemas.smb
+import schemas.modbus

--- a/schemas/modbus.py
+++ b/schemas/modbus.py
@@ -19,7 +19,9 @@ mei_object_names = [
 
 # IDs without an explicit name are encoded as oid_(decimal id).
 mei_object_set = SubRecord({
-    i < len(mei_object_names) and mei_object_names[i] or 'oid_' + str(i): String() for i in range(0, 256)
+    i < len(mei_object_names) and mei_object_names[i]
+    or 'oid_' + str(i): String()
+    for i in range(0, 256)
 })
 
 mei_response = SubRecord({
@@ -28,6 +30,11 @@ mei_response = SubRecord({
     'next_object_id': Unsigned8BitInteger(),
     'object_count': Unsigned8BitInteger(),
     'objects': mei_object_set,
+})
+
+exception_response = SubRecord({
+    'exception_function': Unsigned8BitInteger(),
+    'exception_type': Unsigned8BitInteger(),
 })
 
 modbus_scan_response = SubRecord({

--- a/schemas/modbus.py
+++ b/schemas/modbus.py
@@ -1,0 +1,47 @@
+# zschema sub-schema for zgrab2's modbus module
+# Registers zgrab2-modbus globally, and modbus with the main zgrab2 schema.
+from zschema.leaves import *
+from zschema.compounds import *
+import zschema.registry
+
+import schemas.zcrypto as zcrypto
+import schemas.zgrab2 as zgrab2
+
+mei_object_names = [
+    'vendor',
+    'product_code',
+    'revision',
+    'vendor_url',
+    'product_name',
+    'model_name',
+    'user_application_name',
+]
+
+# IDs without an explicit name are encoded as oid_(decimal id).
+mei_object_set = SubRecord({
+    i < len(mei_object_names) and mei_object_names[i] or 'oid_' + str(i): String() for i in range(0, 256)
+})
+
+mei_response = SubRecord({
+    'conformity_level': Unsigned8BitInteger(),
+    'more_follows': Boolean(),
+    'next_object_id': Unsigned8BitInteger(),
+    'object_count': Unsigned8BitInteger(),
+    'objects': mei_object_set,
+})
+
+modbus_scan_response = SubRecord({
+    'result': SubRecord({
+        'length': Unsigned16BitInteger(),
+        'unit_id': Unsigned8BitInteger(),
+        'function_code': Unsigned8BitInteger(),
+        'raw_response': Binary(),
+        'mei_response': mei_response,
+        'exception_response': exception_response,
+        'raw': Binary(),
+    })
+}, extends=zgrab2.base_scan_response)
+
+zschema.registry.register_schema('zgrab2-modbus', modbus_scan_response)
+
+zgrab2.register_scan_response_type('modbus', modbus_scan_response)

--- a/status.go
+++ b/status.go
@@ -13,18 +13,17 @@ type ScanStatus string
 
 // TODO: Conform to standard string const format (names, capitalization, hyphens/underscores, etc)
 // TODO: Enumerate further status types
+// TODO: lump connection closed / io timeout?
+// TODO: Add SCAN_TLS_PROTOCOL_ERROR? For purely TLS-wrapped protocols, SCAN_PROTOCOL_ERROR is fine -- but for protocols that have a non-TLS bootstrap (e.g. a STARTTLS procedure), SCAN_PROTOCOL_ERROR is misleading, since it did get far-enough into the application protocol to start TLS handshaking -- but a garbled TLS handshake is certainly not a SCAN_APPLICATION_ERROR
 const (
-	SCAN_SUCCESS            = "success"            // The protocol in question was positively identified and the scan encountered no errors
-	SCAN_CONNECTION_REFUSED = "connection-refused" // TCP connection was actively rejected
-	SCAN_CONNECTION_TIMEOUT = "connection-timeout" // No response to TCP connection request
-
-	// TODO: lump connection closed / io timeout?
-	SCAN_CONNECTION_CLOSED = "connection-closed" // The TCP connection was unexpectedly closed
-	SCAN_IO_TIMEOUT        = "io-timeout"        // Timed out waiting on data
-	SCAN_PROTOCOL_ERROR    = "protocol-error"    // Received data incompatible with the target protocol
-	// TODO: Add SCAN_TLS_PROTOCOL_ERROR? For purely TLS-wrapped protocols, SCAN_PROTOCOL_ERROR is fine -- but for protocols that have a non-TLS bootstrap (e.g. a STARTTLS procedure), SCAN_PROTOCOL_ERROR is misleading, since it did get far-enough into the application protocol to start TLS handshaking -- but a garbled TLS handshake is certainly not a SCAN_APPLICATION_ERROR
-	SCAN_APPLICATION_ERROR = "application-error" // The application reported an error
-	SCAN_UNKNOWN_ERROR     = "unknown-error"     // Catch-all for unrecognized errors
+	SCAN_SUCCESS            ScanStatus = "success"            // The protocol in question was positively identified and the scan encountered no errors
+	SCAN_CONNECTION_REFUSED            = "connection-refused" // TCP connection was actively rejected
+	SCAN_CONNECTION_TIMEOUT            = "connection-timeout" // No response to TCP connection request
+	SCAN_CONNECTION_CLOSED             = "connection-closed"  // The TCP connection was unexpectedly closed
+	SCAN_IO_TIMEOUT                    = "io-timeout"         // Timed out waiting on data
+	SCAN_PROTOCOL_ERROR                = "protocol-error"     // Received data incompatible with the target protocol
+	SCAN_APPLICATION_ERROR             = "application-error"  // The application reported an error
+	SCAN_UNKNOWN_ERROR                 = "unknown-error"      // Catch-all for unrecognized errors
 )
 
 // ScanError an error that also includes a ScanStatus.


### PR DESCRIPTION
Port the modbus scanner from zgrab.

Started by copying over the code as-is, but had to make some changes (beyond those needed to pass `golint`).

If run with the default flags, the behavior is should be unchanged (except with a different request ID) --  but some fields are now configurable, and there is an optional `strict` flag to be more selective.

## How to Test

No unit tests / integration tests (none in the original).

There are modbus simulators available; if using the "official" Windows one, you will need to set `--unit-id` to something other than the default of 0, otherwise it will not respond.

## Issue Tracking

Jira issue CEN-72.

