### PR TITLE
zgrab2: port BACNet from zgrab

### DIFF
--- a/modules/bacnet/common.go
+++ b/modules/bacnet/common.go
@@ -1,0 +1,74 @@
+package bacnet
+
+import (
+	"errors"
+	"net"
+)
+
+const (
+	MAX_BACNET_FRAME_LEN = 1476
+)
+
+// VLC Header constants
+const (
+	VLC_TYPE_IP               byte = 0x81
+	VLC_FUNCTION_UNICAST_NPDU byte = 0x0a
+)
+
+// NPDU header constant
+const (
+	NPDU_VERSION_ASHRAE_135_1995 byte = 0x01
+	NPDU_FLAG_EXPECTING_RESPONSE byte = 0x04
+)
+
+// APDU Server Choice constants
+const (
+	SERVER_CHOICE_READ_PROPERTY byte = 0x0c
+)
+
+var (
+	errBACNetPacketTooShort error = errors.New("BACNet packet too short")
+	errInvalidPacket        error = errors.New("Invalid BACNet packet")
+	errNotBACNet            error = errors.New("Not a BACNet packet")
+)
+
+func SendVLC(c net.Conn, payload []byte) error {
+	if len(payload) > 1472 {
+		return errors.New("payload too long")
+	}
+	vlc := VLC{
+		Type:     VLC_TYPE_IP,
+		Function: VLC_FUNCTION_UNICAST_NPDU,
+		Length:   4 + uint16(len(payload)),
+	}
+	b, _ := vlc.Marshal()
+	b = append(b, payload...)
+	if _, err := c.Write(b); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ReadVLC(c net.Conn) (vlc *VLC, npdu *NPDU, apdu *APDU, leftovers []byte, err error, isBACNet bool) {
+	b := make([]byte, MAX_BACNET_FRAME_LEN)
+	n, err := c.Read(b)
+	if err != nil {
+		return
+	}
+	b = b[0:n]
+	leftovers = b
+	vlc = new(VLC)
+	if leftovers, err = vlc.Unmarshal(leftovers); err != nil {
+		return
+	}
+	isBACNet = true
+	npdu = new(NPDU)
+	if leftovers, err = npdu.Unmarshal(leftovers); err != nil {
+		return
+	}
+	apdu = new(APDU)
+	if leftovers, err = apdu.Unmarshal(leftovers); err != nil {
+		return
+	}
+	return
+}

--- a/modules/bacnet/log.go
+++ b/modules/bacnet/log.go
@@ -1,0 +1,119 @@
+package bacnet
+
+import "net"
+
+type Log struct {
+	IsBACNet                    bool   `json:"is_bacnet"`
+	InstanceNumber              uint32 `json:"instance_number"`
+	VendorID                    uint16 `json:"vendor_id"`
+	VendorName                  string `json:"vendor_name,omitempty"`
+	FirmwareRevision            string `json:"firmware_revision,omitempty"`
+	ApplicationSoftwareRevision string `json:"application_software_revision,omitempty"`
+	ObjectName                  string `json:"object_name,omitempty"`
+	ModelName                   string `json:"model_name,omitempty"`
+	Description                 string `json:"description,omitempty"`
+	Location                    string `json:"location,omitempty"`
+}
+
+func (log *Log) sendReadProperty(c net.Conn, oid ObjectID, pid PropertyID) ([]byte, error, bool) {
+	rp := NewReadPropertyRequest(oid, pid)
+	b, err := rp.Marshal()
+	if err != nil {
+		return nil, err, false
+	}
+	if err := SendVLC(c, b); err != nil {
+		return nil, err, false
+	}
+	var body []byte
+	var isBACNet bool
+	_, _, _, body, err, isBACNet = ReadVLC(c)
+	if err != nil {
+		return nil, err, isBACNet
+	}
+	r := new(ReadProperty)
+	if body, err = r.Unmarshal(body); err != nil {
+		return nil, err, isBACNet
+	}
+	return body, nil, true
+}
+
+func (log *Log) queryStringProperty(c net.Conn, oid ObjectID, pid PropertyID) (value string, err error) {
+	var body []byte
+	if body, err, _ = log.sendReadProperty(c, oid, pid); err != nil {
+		return
+	}
+	_, value, err = readStringProperty(body)
+	return
+}
+
+func (log *Log) QueryDeviceID(c net.Conn) (err error) {
+	var body []byte
+	if body, err, log.IsBACNet = log.sendReadProperty(c, OID_ANY, PID_OID); err != nil {
+		return
+	}
+	if !log.IsBACNet {
+		return errNotBACNet
+	}
+	var instanceNumber uint32
+	_, instanceNumber, err = readInstanceNumber(body)
+	if err != nil {
+		return err
+	}
+	log.InstanceNumber = instanceNumber
+	return nil
+}
+
+func (log *Log) QueryVendorNumber(c net.Conn) (err error) {
+	var body []byte
+	if body, err, _ = log.sendReadProperty(c, OID_ANY, PID_VENDOR_NUMBER); err != nil {
+		return
+	}
+	var vendorID uint16
+	_, vendorID, err = readVendorID(body)
+	if err != nil {
+		return err
+	}
+	log.VendorID = vendorID
+	return nil
+}
+
+func (log *Log) QueryVendorName(c net.Conn) (err error) {
+	log.VendorName, err = log.queryStringProperty(c, OID_ANY, PID_VENDOR_NAME)
+	return
+}
+
+func (log *Log) QueryFirmwareRevision(c net.Conn) (err error) {
+	log.FirmwareRevision, err = log.queryStringProperty(c, OID_ANY, PID_FIRMWARE_REVISION)
+	if err == nil && len(log.FirmwareRevision) == 0 {
+		log.FirmwareRevision = "0.0"
+	}
+	return
+}
+
+func (log *Log) QueryApplicationSoftwareRevision(c net.Conn) (err error) {
+	log.ApplicationSoftwareRevision, err = log.queryStringProperty(c, OID_ANY, PID_APPLICATION_SOFTWARE_REVISION)
+	if err == nil && len(log.ApplicationSoftwareRevision) == 0 {
+		log.ApplicationSoftwareRevision = "0.0"
+	}
+	return
+}
+
+func (log *Log) QueryObjectName(c net.Conn) (err error) {
+	log.ObjectName, err = log.queryStringProperty(c, OID_ANY, PID_OBJECT_NAME)
+	return
+}
+
+func (log *Log) QueryModelName(c net.Conn) (err error) {
+	log.ModelName, err = log.queryStringProperty(c, OID_ANY, PID_MODEL_NAME)
+	return
+}
+
+func (log *Log) QueryDescription(c net.Conn) (err error) {
+	log.Description, err = log.queryStringProperty(c, OID_ANY, PID_DESCRIPTION)
+	return
+}
+
+func (log *Log) QueryLocation(c net.Conn) (err error) {
+	log.Location, err = log.queryStringProperty(c, OID_ANY, PID_LOCATION)
+	return
+}

--- a/modules/bacnet/messages.go
+++ b/modules/bacnet/messages.go
@@ -1,0 +1,113 @@
+package bacnet
+
+import "bytes"
+
+type VLC struct {
+	Type     byte
+	Function byte
+	Length   uint16
+}
+
+type NPDU struct {
+	Version byte
+	Control byte
+}
+
+type SegmentParameters struct {
+	raw byte
+	set bool
+}
+
+type APDU struct {
+	TypeAndFlags byte              `json:"type_and_flags"`
+	SegmentSizes SegmentParameters `json:"segment_sizes"`
+	InvokeID     byte              `json:"invoke_id"`
+	ServerChoice byte              `json:"server_choice"`
+}
+
+type Frame struct {
+	VLC     *VLC        `json:"vlc,omitempty"`
+	NPDU    *NPDU       `json:"npdu,omitempty"`
+	APDU    *APDU       `json:"apdu,omitempty"`
+	Payload interface{} `json:"payload,omitempty"`
+}
+
+const vlcLength = 4
+
+// Marshal encodes a VLC header to binary
+func (vlc *VLC) Marshal() ([]byte, error) {
+	out := make([]byte, vlcLength)
+	out[0] = vlc.Type
+	out[1] = vlc.Function
+	out[2] = byte(vlc.Length >> 8)
+	out[3] = byte(vlc.Length)
+	return out, nil
+}
+
+// Unmarshal decodes a VLC header from binary
+func (vlc *VLC) Unmarshal(b []byte) ([]byte, error) {
+	if len(b) < vlcLength {
+		return b, errBACNetPacketTooShort
+	}
+	if b[0] != 0x81 {
+		return b, errNotBACNet
+	}
+	vlc.Type = b[0]
+	vlc.Function = b[1]
+	vlc.Length = (uint16(b[2]) << 8) + uint16(b[3])
+	rb := b[vlcLength:]
+	return rb, nil
+}
+
+const npduLength = 2
+
+// Marshal encodes an NPDU header to binary
+func (npdu *NPDU) Marshal() ([]byte, error) {
+	b := make([]byte, npduLength)
+	b[0] = npdu.Version
+	b[1] = npdu.Control
+	return b, nil
+}
+
+// Unmarshal decodes an NPDU header from binary
+func (npdu *NPDU) Unmarshal(b []byte) ([]byte, error) {
+	if len(b) < 2 {
+		return b, errBACNetPacketTooShort
+	}
+	npdu.Version = b[0]
+	npdu.Control = b[1]
+	return b[2:], nil
+}
+
+// Marshal encodes a full APDU to binary
+func (apdu *APDU) Marshal() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	buf.WriteByte(apdu.TypeAndFlags)
+	if apdu.SegmentSizes.set {
+		buf.WriteByte(apdu.SegmentSizes.raw)
+	}
+	buf.WriteByte(apdu.InvokeID)
+	buf.WriteByte(apdu.ServerChoice)
+	return buf.Bytes(), nil
+}
+
+// Unmarshal decodes a full APDU from binary
+func (apdu *APDU) Unmarshal(b []byte) (out []byte, err error) {
+	buf := bytes.NewBuffer(b)
+	if apdu.TypeAndFlags, err = buf.ReadByte(); err != nil {
+		return b, errBACNetPacketTooShort
+	}
+	if apdu.SegmentSizes.set {
+		if apdu.SegmentSizes.raw, err = buf.ReadByte(); err != nil {
+			return b, errBACNetPacketTooShort
+		}
+	}
+	if apdu.InvokeID, err = buf.ReadByte(); err != nil {
+		return b, errBACNetPacketTooShort
+	}
+	if apdu.ServerChoice, err = buf.ReadByte(); err != nil {
+		return b, errBACNetPacketTooShort
+	}
+	bytesRead := len(b) - buf.Len()
+	return b[bytesRead:], nil
+}

--- a/modules/bacnet/messages_test.go
+++ b/modules/bacnet/messages_test.go
@@ -1,0 +1,88 @@
+package bacnet
+
+import (
+	"encoding/binary"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestMessages(t *testing.T) { TestingT(t) }
+
+type VLCSuite struct {
+}
+
+type NPDUSuite struct {
+}
+
+type APDUSuite struct {
+}
+
+var _ = Suite(&VLCSuite{})
+var _ = Suite(&NPDUSuite{})
+var _ = Suite(&APDUSuite{})
+
+func (s *VLCSuite) TestMarshalUnmarshalVLC(c *C) {
+	vlc := VLC{
+		Type:     VLC_TYPE_IP,
+		Function: VLC_FUNCTION_UNICAST_NPDU,
+		Length:   300,
+	}
+	b, e := vlc.Marshal()
+	c.Assert(e, IsNil)
+	c.Assert(b, NotNil)
+	encodedLength := binary.BigEndian.Uint16(b[2:])
+	c.Check(encodedLength, Equals, vlc.Length)
+	dec := VLC{}
+	b, err := dec.Unmarshal(b)
+	c.Assert(err, IsNil)
+	c.Check(len(b), Equals, 0)
+}
+
+func (s *VLCSuite) TestUnmarshalShortVLC(c *C) {
+	b := make([]byte, vlcLength-1)
+	v := VLC{}
+	leftovers, err := v.Unmarshal(b)
+	c.Check(leftovers, DeepEquals, b)
+	c.Check(err, NotNil)
+	c.Check(err, Equals, errBACNetPacketTooShort)
+}
+
+func (s *NPDUSuite) TestMarshalUnmarshalNPDU(c *C) {
+	npdu := NPDU{
+		Version: NPDU_VERSION_ASHRAE_135_1995,
+		Control: 0x4,
+	}
+	b, e := npdu.Marshal()
+	c.Assert(e, IsNil)
+	c.Assert(b, NotNil)
+	c.Check(len(b), Equals, 2)
+	dec := NPDU{}
+	leftovers, err := dec.Unmarshal(b)
+	c.Check(len(leftovers), Equals, 0)
+	c.Assert(err, IsNil)
+	c.Check(dec, Equals, npdu)
+}
+
+func (s *NPDUSuite) TestMarshalUnmarshalShortNPDU(c *C) {
+	b := make([]byte, npduLength-1)
+	v := VLC{}
+	leftovers, err := v.Unmarshal(b)
+	c.Check(leftovers, DeepEquals, b)
+	c.Check(err, Equals, errBACNetPacketTooShort)
+}
+
+func (s *APDUSuite) TestMarshalUnmarshalAPDU(c *C) {
+	apdu := APDU{
+		TypeAndFlags: 0x30,
+		InvokeID:     1,
+		ServerChoice: SERVER_CHOICE_READ_PROPERTY,
+	}
+	b, err := apdu.Marshal()
+	c.Assert(err, IsNil)
+	dec := new(APDU)
+	b, err = dec.Unmarshal(b)
+	c.Assert(err, IsNil)
+	c.Check(dec, DeepEquals, &apdu)
+	c.Check(len(b), Equals, 0)
+}

--- a/modules/bacnet/objects.go
+++ b/modules/bacnet/objects.go
@@ -1,0 +1,152 @@
+package bacnet
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+type ObjectID uint32
+
+const (
+	OID_ANY ObjectID = 0x023fffff
+)
+
+type PropertyID byte
+
+const (
+	PID_OID                           PropertyID = 75
+	PID_VENDOR_NUMBER                 PropertyID = 0x78
+	PID_VENDOR_NAME                   PropertyID = 0x79
+	PID_FIRMWARE_REVISION             PropertyID = 0x2c
+	PID_APPLICATION_SOFTWARE_REVISION PropertyID = 0x0c
+	PID_OBJECT_NAME                   PropertyID = 0x4d
+	PID_MODEL_NAME                    PropertyID = 0x46
+	PID_DESCRIPTION                   PropertyID = 0x1c
+	PID_LOCATION                      PropertyID = 0x3a
+)
+
+type ReadProperty struct {
+	Object   ObjectID   `json:"object"`
+	Property PropertyID `json:"property"`
+}
+
+func (rp *ReadProperty) Marshal() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	buf.WriteByte(0x0c)
+	if err := binary.Write(buf, binary.BigEndian, uint32(rp.Object)); err != nil {
+		return nil, err
+	}
+	buf.WriteByte(0x19)
+	buf.WriteByte(byte(rp.Property))
+	return buf.Bytes(), nil
+}
+
+func (rp *ReadProperty) Unmarshal(b []byte) (leftovers []byte, err error) {
+	buf := bytes.NewBuffer(b)
+	leftovers = b
+	if oidContextTag, _ := buf.ReadByte(); oidContextTag != 0x0c {
+		return b, errInvalidPacket
+	}
+	var oid uint32
+	if err = binary.Read(buf, binary.BigEndian, &oid); err != nil {
+		return
+	}
+	rp.Object = ObjectID(oid)
+	if pidContextTag, _ := buf.ReadByte(); pidContextTag != 0x19 {
+		return b, errInvalidPacket
+	}
+	var pid byte
+	if pid, err = buf.ReadByte(); err != nil {
+		return
+	}
+	rp.Property = PropertyID(pid)
+	bytesRead := len(b) - buf.Len()
+	return b[bytesRead:], nil
+}
+
+func readInstanceNumber(b []byte) (leftovers []byte, instanceNumber uint32, err error) {
+	buf := bytes.NewBuffer(b)
+	leftovers = b
+	var openByte, appByte, closeByte byte
+	if openByte, err = buf.ReadByte(); openByte != 0x3e {
+		return
+	}
+	if appByte, err = buf.ReadByte(); appByte != 0xc4 {
+		return
+	}
+	if err = binary.Read(buf, binary.BigEndian, &instanceNumber); err != nil {
+		return
+	}
+	if closeByte, err = buf.ReadByte(); closeByte != 0x3f {
+		return
+	}
+	bytesRead := len(b) - buf.Len()
+	leftovers = b[bytesRead:]
+	instanceNumber &= 0x0003ffff
+	return
+}
+
+func readVendorID(b []byte) (leftovers []byte, vendorID uint16, err error) {
+	buf := bytes.NewBuffer(b)
+	leftovers = b
+	var openByte, appByte, closeByte byte
+	if openByte, err = buf.ReadByte(); openByte != 0x3e {
+		return
+	}
+	if appByte, err = buf.ReadByte(); appByte != 0x22 && appByte != 0x21 {
+		return
+	}
+	if appByte == 0x22 {
+		if err = binary.Read(buf, binary.BigEndian, &vendorID); err != nil {
+			return
+		}
+	} else {
+		var vendorIDByte byte
+		if err = binary.Read(buf, binary.BigEndian, &vendorIDByte); err != nil {
+			return
+		}
+		vendorID = uint16(vendorIDByte)
+	}
+	if closeByte, err = buf.ReadByte(); closeByte != 0x3f {
+		return
+	}
+	bytesRead := len(b) - buf.Len()
+	leftovers = b[bytesRead:]
+	return
+}
+
+func readStringProperty(b []byte) (leftovers []byte, value string, err error) {
+	buf := bytes.NewBuffer(b)
+	leftovers = b
+	var openByte, appByte, closeByte, lengthByte byte
+	if openByte, err = buf.ReadByte(); openByte != 0x3e {
+		return
+	}
+	if appByte, err = buf.ReadByte(); appByte&0xF8 != 0x70 {
+		return
+	}
+	lengthBits := appByte & 0x07
+	if lengthBits == 5 {
+		if lengthByte, err = buf.ReadByte(); err != nil {
+			return
+		}
+	} else {
+		lengthByte = lengthBits
+	}
+	propertyBytes := make([]byte, lengthByte)
+	var n int
+	if n, err = buf.Read(propertyBytes); err != nil {
+		return
+	}
+	if n != int(lengthByte) || lengthByte < 1 {
+		err = errBACNetPacketTooShort
+		return
+	}
+	value = string(propertyBytes[1:])
+	if closeByte, err = buf.ReadByte(); closeByte != 0x3f {
+		return
+	}
+	bytesRead := len(b) - buf.Len()
+	leftovers = b[bytesRead:]
+	return
+}

--- a/modules/bacnet/objects_test.go
+++ b/modules/bacnet/objects_test.go
@@ -1,0 +1,24 @@
+package bacnet
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type ObjectsSuite struct {
+}
+
+var _ = Suite(&ObjectsSuite{})
+
+func (s *ObjectsSuite) TestMarshalUnmarshalReadProperty(c *C) {
+	rp := ReadProperty{
+		Object:   OID_ANY,
+		Property: PID_OID,
+	}
+	b, err := rp.Marshal()
+	c.Assert(err, IsNil)
+	dec := new(ReadProperty)
+	b, err = dec.Unmarshal(b)
+	c.Assert(err, IsNil)
+	c.Check(len(b), Equals, 0)
+	c.Check(dec, DeepEquals, &rp)
+}

--- a/modules/bacnet/query.go
+++ b/modules/bacnet/query.go
@@ -1,0 +1,41 @@
+package bacnet
+
+import "bytes"
+
+type ReadPropertyRequest struct {
+	NPDU      NPDU         `json:"npdu"`
+	APDU      APDU         `json:"apdu"`
+	Selection ReadProperty `json:"read_property"`
+}
+
+func (rp *ReadPropertyRequest) Marshal() (out []byte, err error) {
+	buf := new(bytes.Buffer)
+	var b []byte
+	if b, err = rp.NPDU.Marshal(); err != nil {
+		return
+	}
+	buf.Write(b)
+	if b, err = rp.APDU.Marshal(); err != nil {
+		return
+	}
+	buf.Write(b)
+	if b, err = rp.Selection.Marshal(); err != nil {
+		return
+	}
+	buf.Write(b)
+	return buf.Bytes(), nil
+}
+
+func NewReadPropertyRequest(oid ObjectID, pid PropertyID) *ReadPropertyRequest {
+	req := new(ReadPropertyRequest)
+	req.NPDU.Version = NPDU_VERSION_ASHRAE_135_1995
+	req.NPDU.Control |= NPDU_FLAG_EXPECTING_RESPONSE
+	req.APDU.TypeAndFlags = 0
+	req.APDU.SegmentSizes.set = true
+	req.APDU.SegmentSizes.raw = 0x05
+	req.APDU.InvokeID = 1
+	req.APDU.ServerChoice = SERVER_CHOICE_READ_PROPERTY
+	req.Selection.Object = oid
+	req.Selection.Property = pid
+	return req
+}

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -1,0 +1,142 @@
+// Package bacnet provides a zgrab2 module that scans for bacnet.
+// Default Port: 47808 / 0xBAC0 (UDP)
+//
+// Behavior and output copied identically from original zgrab.
+package bacnet
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zgrab2"
+)
+
+// Scan results are in log.go
+
+// Flags holds the command-line configuration for the bacnet scan module.
+// Populated by the framework.
+type Flags struct {
+	zgrab2.BaseFlags
+	zgrab2.UDPFlags
+
+	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+}
+
+// Module implements the zgrab2.Module interface.
+type Module struct {
+}
+
+// Scanner implements the zgrab2.Scanner interface.
+type Scanner struct {
+	config *Flags
+}
+
+// RegisterModule registers the zgrab2 module.
+func RegisterModule() {
+	var module Module
+	_, err := zgrab2.AddCommand("bacnet", "bacnet", "Probe for bacnet", 0xBAC0, &module)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// NewFlags returns a default Flags object.
+func (module *Module) NewFlags() interface{} {
+	return new(Flags)
+}
+
+// NewScanner returns a new Scanner instance.
+func (module *Module) NewScanner() zgrab2.Scanner {
+	return new(Scanner)
+}
+
+// Validate checks that the flags are valid.
+// On success, returns nil.
+// On failure, returns an error instance describing the error.
+func (flags *Flags) Validate(args []string) error {
+	return nil
+}
+
+// Help returns the module's help string.
+func (flags *Flags) Help() string {
+	return ""
+}
+
+// Init initializes the Scanner.
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
+	f, _ := flags.(*Flags)
+	scanner.config = f
+	return nil
+}
+
+// InitPerSender initializes the scanner for a given sender.
+func (scanner *Scanner) InitPerSender(senderID int) error {
+	return nil
+}
+
+// GetName returns the Scanner name defined in the Flags.
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
+}
+
+// Protocol returns the protocol identifier of the scan.
+func (scanner *Scanner) Protocol() string {
+	return "bacnet"
+}
+
+// GetPort returns the port being scanned.
+func (scanner *Scanner) GetPort() uint {
+	return scanner.config.Port
+}
+
+// Scan probes for a BACNet service.
+// Behavior taken from original zgrab.
+// Connects to the configured port over UDP (default 47808/0xBAC0).
+// Attempts to query the following in sequence; if any fails, returning anything that has been detected so far.
+// (Unless QueryDeviceID fails, the service is considered to be detected)
+// 1. Device ID
+// 2. Vendor Number
+// 3. Vendor Name
+// 4. Firmware Revision
+// 5. App software revision
+// 6. Object name
+// 7. Model  name
+// 8. Description
+// 9. Location
+// The result is a bacnet.Log, and contains any of the above.
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	conn, err := target.OpenUDP(&scanner.config.BaseFlags, &scanner.config.UDPFlags)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	ret := new(Log)
+	// TODO: if one fails, try others?
+	// TODO: distinguish protocol vs app errors
+	if err := ret.QueryDeviceID(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	if err := ret.QueryVendorNumber(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryVendorName(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryFirmwareRevision(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryApplicationSoftwareRevision(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryObjectName(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryModelName(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryDescription(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+	if err := ret.QueryLocation(conn); err != nil {
+		return zgrab2.TryGetScanStatus(err), ret, nil
+	}
+
+	return zgrab2.SCAN_SUCCESS, ret, nil
+}

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -12,3 +12,4 @@ import schemas.telnet
 import schemas.pop3
 import schemas.smb
 import schemas.modbus
+import schemas.bacnet

--- a/schemas/bacnet.py
+++ b/schemas/bacnet.py
@@ -1,0 +1,27 @@
+# zschema sub-schema for zgrab2's bacnet module
+# Registers zgrab2-bacnet globally, and bacnet with the main zgrab2 schema.
+from zschema.leaves import *
+from zschema.compounds import *
+import zschema.registry
+
+import schemas.zcrypto as zcrypto
+import schemas.zgrab2 as zgrab2
+
+bacnet_scan_response = SubRecord({
+    "result": SubRecord({
+        "is_bacnet": Boolean(),
+        "instance_number": Unsigned32BitInteger(),
+        "vendor_id": Unsigned16BitInteger(),
+        "vendor_name": String(),
+        "firmware_revision": String(),
+        "application_software_revision": String(),
+        "object_name": String(),
+        "model_name": String(),
+        "description": String(),
+        "location": String(),
+    })
+}, extends=zgrab2.base_scan_response)
+
+zschema.registry.register_schema("zgrab2-bacnet", bacnet_scan_response)
+
+zgrab2.register_scan_response_type("bacnet", bacnet_scan_response)


### PR DESCRIPTION
BACNet taken over directly from zgrab.

## How to Test

No unit tests / integration tests (none in original). Using a BACNet simulator (e.g. http://www.cbmsstudio.com/store/p11/BACnet_Simulator.html, which does not listen on the loopback interface) you can do `echo "my-address" | cmd/zgrab2/zgrab2 bacnet > out.json && python -m zschema validate schemas/__init__.py:zgrab2 out.json`.

## Notes & Caveats

This was written in such a way that it could be taken over from zgrab with no changes.

## Issue Tracking

This represents part of Jira issue CEN-70.
