### PR TITLE
issue #91 -- heartbleed flag implies heartbeat enabled

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -179,7 +179,7 @@ func (t *TLSFlags) GetTLSConfig() (*tls.Config, error) {
 		log.Fatalf("--signature-algorithms not implemented")
 	}
 
-	if t.HeartbeatEnabled {
+	if t.HeartbeatEnabled || t.Heartbleed {
 		ret.HeartbeatEnabled = true
 	} else {
 		ret.HeartbeatEnabled = false


### PR DESCRIPTION
Previously, you had to explicitly set `--heartbeat-enabled` in addition to `--heartbleed` for your heartbleed check to work.

This addresses that by making `--heartbleed` imply `--heartbeat-enabled`.

## How to Test

1. Find a heartbleed-vulnerable machine (e.g. https://censys.io/ipv4?q=443.https.heartbleed.heartbleed_vulnerable%3Atrue)
2. Run `echo "target-machine" | cmd/zgrab2/zgrab2 tls --heartbleed --port 443`
  - Try before and after the fix, confirm that afterwards it comes out `"heartbleed_vulnerable":true`

## Issue Tracking

Issue #91 