### PR TITLE
Add --retry-https flag

### DIFF
--- a/schemas/http.py
+++ b/schemas/http.py
@@ -123,8 +123,6 @@ http_request_full = SubRecord({
     "post_form": http_form_values,
     "multipart_form": http_form_values,
     "trailers": http_headers,
-    # For compatibility, left tls -> tls.ConnectionState
-    "tls": zcrypto.tls_connection_state,
     # The new field tls_log contains the zgrab2 TLS logs.
     "tls_log": zgrab2.tls_log
 })

--- a/schemas/zcrypto.py
+++ b/schemas/zcrypto.py
@@ -558,16 +558,3 @@ heartbleed_log = SubRecord({
 
 # zcrypto/x509/chain.go: type CertificateChain []*Certificate
 certificate_chain = ListOf(parsed_certificate)
-
-# zcrypto/tls/common.go: ConnectionState (note: no `json` tags)
-tls_connection_state = SubRecord({
-    "Version": Unsigned16BitInteger(),
-    "HandshakeComplete": Boolean(),
-    "DidResume": Boolean(),
-    "CipherSuite": Unsigned16BitInteger(),
-    "NegotiatedProtocol": String(),
-    "NegotiatedProtocolIsMutual": Boolean(),
-    "ServerName": String(),
-    "PeerCertificate": parsed_certificate,
-    "VerifiedChains": ListOf(certificate_chain),
-})


### PR DESCRIPTION
Add `--retry-https` flag to work with unknown HTTP/HTTPS servers (attempt HTTP, on failure, retry with HTTPS).

Also, removed unused `request.tls` field from schema (only used for HTTP servers, caused zschema errors because of `ListOf(ListOf())`)

## How to Test

`echo "google.com" | cmd/zgrab2/zgrab2 http --retry-https --port 443`

