### PR TITLE
Set default timeout to 10s

### DIFF
--- a/module.go
+++ b/module.go
@@ -60,7 +60,7 @@ type ScanFlags interface {
 type BaseFlags struct {
 	Port    uint   `short:"p" long:"port" description:"Specify port to grab on"`
 	Name    string `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
-	Timeout uint   `short:"t" long:"timeout" description:"Set connection timeout in seconds"`
+	Timeout uint   `short:"t" long:"timeout" description:"Set connection timeout in seconds (0 = no timeout)" default:"10"`
 }
 
 // UDPFlags contains the common options used for all UDP scans


### PR DESCRIPTION
Per conversation with Zakir (and issue #94), make default timeout 10s to match zgrab behavior.
Indefinite timeout is still possible by setting an explicit timeout of 0.

## How to Test

```bash
nc -l -p 12345 &
echo "127.0.0.1" | cmd/zgrab2/zgrab2 telnet --port 12345
```
Before this PR, it will sit indefinitely (or until you kill the nc process); afterwards, it times out after 10s.

## Issue Tracking

Brought up in discussion for #94.
