### PR TITLE
Add a dialer for the non-TLS case in HTTP

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -241,6 +241,7 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
 		client: http.MakeNewClient(),
 	}
 	ret.transport.DialTLS = ret.getTLSDialer()
+	ret.transport.DialContext = zgrab2.GetTimeoutConnectionDialer(time.Duration(scanner.config.Timeout) * time.Second).DialContext
 	ret.client.UserAgent = scanner.config.UserAgent
 	ret.client.CheckRedirect = ret.getCheckRedirect()
 	ret.client.Transport = ret.transport


### PR DESCRIPTION
So that `--timeout` is honored even if `--use-https` is not set (issue #109).

## How to Test

`echo google.com | ./zgrab2 http --port 8080 --timeout 3`

Before the test, this hangs for much longer than 3s. Afterwards, it doesn't.

## Issue Tracking

#109 
