### PR TITLE
ZGrab2 pre-release bugfixes

### DIFF
--- a/cmd/zgrab2/main.go
+++ b/cmd/zgrab2/main.go
@@ -4,15 +4,89 @@ import (
 	"encoding/json"
 	"os"
 	"time"
+	"runtime/pprof"
 
 	flags "github.com/zmap/zflags"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 	_ "github.com/zmap/zgrab2/modules"
+	"fmt"
+	"runtime"
+	"strings"
 )
 
+// Get the value of the ZGRAB2_MEMPROFILE variable (or the empty string).
+// This may include {TIMESTAMP} or {NANOS}, which should be replaced using
+// getFormattedFile().
+func getMemProfileFile() string {
+	return os.Getenv("ZGRAB2_MEMPROFILE")
+}
+
+// Get the value of the ZGRAB2_CPUPROFILE variable (or the empty string).
+// This may include {TIMESTAMP} or {NANOS}, which should be replaced using
+// getFormattedFile().
+func getCPUProfileFile() string {
+	return os.Getenv("ZGRAB2_CPUPROFILE")
+}
+
+// Replace instances in formatString of {TIMESTAMP} with when formatted as
+// YYYYMMDDhhmmss, and {NANOS} as the decimal nanosecond offset.
+func getFormattedFile(formatString string, when time.Time) string {
+	timestamp := when.Format("20060102150405")
+	nanos := fmt.Sprintf("%d", when.Nanosecond())
+	ret := strings.Replace(formatString, "{TIMESTAMP}", timestamp, -1)
+	ret = strings.Replace(ret, "{NANOS}", nanos, -1)
+	return ret
+}
+
+// If memory profiling is enabled (ZGRAB2_MEMPROFILE is not empty), perform a GC
+// then write the heap profile to the profile file.
+func dumpHeapProfile() {
+	if file := getMemProfileFile(); file != "" {
+		now := time.Now()
+		fullFile := getFormattedFile(file, now)
+		f, err := os.Create(fullFile)
+		if err != nil {
+			log.Fatal("could not create heap profile: ", err)
+		}
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			log.Fatal("could not write heap profile: ", err)
+		}
+		f.Close()
+	}
+}
+
+// If CPU profiling is enabled (ZGRAB2_CPUPROFILE is not empty), start tracking
+// CPU profiling in the configured file. Caller is responsible for invoking
+// stopCPUProfile() when finished.
+func startCPUProfile() {
+	if file := getCPUProfileFile(); file != "" {
+		now := time.Now()
+		fullFile := getFormattedFile(file, now)
+		f, err := os.Create(fullFile)
+		if err != nil {
+			log.Fatal("could not create CPU profile: ", err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal("could not start CPU profile: ", err)
+		}
+	}
+}
+
+// If CPU profiling is enabled (ZGRAB2_CPUPROFILE is not empty), stop profiling
+// CPU usage.
+func stopCPUProfile() {
+	if getCPUProfileFile() != "" {
+		pprof.StopCPUProfile()
+	}
+}
 func main() {
+	startCPUProfile()
+	defer stopCPUProfile()
+	defer dumpHeapProfile()
 	_, moduleType, flag, err := zgrab2.ParseCommandLine(os.Args[1:])
+
 	// Blanked arg is positional arguments
 	if err != nil {
 		// Outputting help is returned as an error. Exit successfuly on help output.
@@ -54,6 +128,9 @@ func main() {
 		zgrab2.RegisterScan(moduleType, s)
 	}
 	monitor := zgrab2.MakeMonitor()
+	monitor.Callback = func(_ string) {
+		dumpHeapProfile()
+	}
 	start := time.Now()
 	log.Infof("started grab at %s", start.Format(time.RFC3339))
 	zgrab2.Process(monitor)

--- a/conn.go
+++ b/conn.go
@@ -32,6 +32,11 @@ func (c *TimeoutConnection) Write(b []byte) (n int, err error) {
 	return c.Conn.Write(b)
 }
 
+// Close the underlying connection.
+func (c *TimeoutConnection) Close() error {
+	return c.Conn.Close()
+}
+
 // DialTimeoutConnection dials the target and returns a net.Conn that uses the configured timeouts for Read/Write operations.
 func DialTimeoutConnection(proto string, target string, timeout time.Duration) (net.Conn, error) {
 	var conn net.Conn

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/zmap/zcrypto/tls"
-	"golang.org/x/net/lex/httplex"
+	"golang.org/x/net/http/httpguts"
 )
 
 // Errors used by the HTTP server.
@@ -954,15 +954,15 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
 	if len(hosts) > 1 {
 		return nil, badRequestError("too many Host headers")
 	}
-	if len(hosts) == 1 && !httplex.ValidHostHeader(hosts[0]) {
+	if len(hosts) == 1 && !httpguts.ValidHostHeader(hosts[0]) {
 		return nil, badRequestError("malformed Host header")
 	}
 	for k, vv := range req.Header {
-		if !httplex.ValidHeaderFieldName(k) {
+		if !httpguts.ValidHeaderFieldName(k) {
 			return nil, badRequestError("invalid header name")
 		}
 		for _, v := range vv {
-			if !httplex.ValidHeaderFieldValue(v) {
+			if !httpguts.ValidHeaderFieldValue(v) {
 				return nil, badRequestError("invalid header value")
 			}
 		}

--- a/lib/http/transfer.go
+++ b/lib/http/transfer.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/lex/httplex"
+	"golang.org/x/net/http/httpguts"
 )
 
 // ErrLineTooLong is returned when reading request or response bodies
@@ -672,9 +672,9 @@ func shouldClose(major, minor int, header Header, removeCloseHeader bool) bool {
 	}
 
 	conv := header["Connection"]
-	hasClose := httplex.HeaderValuesContainsToken(conv, "close")
+	hasClose := httpguts.HeaderValuesContainsToken(conv, "close")
 	if major == 1 && minor == 0 {
-		return hasClose || !httplex.HeaderValuesContainsToken(conv, "keep-alive")
+		return hasClose || !httpguts.HeaderValuesContainsToken(conv, "keep-alive")
 	}
 
 	if hasClose && removeCloseHeader {

--- a/lib/http/transport.go
+++ b/lib/http/transport.go
@@ -29,7 +29,7 @@ import (
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/http/httptrace"
-	"golang.org/x/net/lex/httplex"
+	"golang.org/x/net/http/httpguts"
 )
 
 // DefaultTransport is the default implementation of Transport and is
@@ -334,11 +334,11 @@ func (t *Transport) RoundTrip(req *Request) (*Response, error) {
 	isHTTP := scheme == "http" || scheme == "https"
 	if isHTTP {
 		for k, vv := range req.Header {
-			if !httplex.ValidHeaderFieldName(k) {
+			if !httpguts.ValidHeaderFieldName(k) {
 				return nil, fmt.Errorf("net/http: invalid header field name %q", k)
 			}
 			for _, v := range vv {
-				if !httplex.ValidHeaderFieldValue(v) {
+				if !httpguts.ValidHeaderFieldValue(v) {
 					return nil, fmt.Errorf("net/http: invalid header field value %q for key %v", v, k)
 				}
 			}

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -331,7 +331,6 @@ func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{
 func RegisterModule() {
 	var module Module
 	_, err := zgrab2.AddCommand("http", "HTTP Banner Grab", "Grab a banner over HTTP", 80, &module)
-	log.SetLevel(log.DebugLevel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/mssql/connection.go
+++ b/modules/mssql/connection.go
@@ -673,7 +673,7 @@ func (connection *Connection) prelogin(clientEncrypt EncryptMode) (EncryptMode, 
 	if err != nil {
 		if packet != nil {
 			// FIXME: debug packet info?
-			logrus.Warnf("Got bad packet? type=0x%02x", packet.Type)
+			logrus.Debugf("Got bad packet? type=0x%02x", packet.Type)
 		}
 		return EncryptModeUnknown, err
 	}
@@ -740,7 +740,7 @@ func min(a, b int) int {
 // purposes).
 func isValidTDSHeader(header *TDSHeader) bool {
 	if header == nil {
-		logrus.Warn("nil header")
+		logrus.Debug("nil header")
 		return false
 	}
 
@@ -816,7 +816,7 @@ func (connection *tdsConnection) Read(b []byte) (n int, err error) {
 		connection.remainder = make([]byte, header.Length-8)
 		_, err = io.ReadFull(connection.conn, connection.remainder)
 		if err != nil {
-			logrus.Warn("Error reading body", err)
+			logrus.Debugf("Error reading body", err)
 			return soFar, err
 		}
 		toCopy := min(len(output), len(connection.remainder))

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -14,6 +14,7 @@ package mssql
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
+	"github.com/Sirupsen/logrus"
 )
 
 // ScanResults contains detailed information about each step of the
@@ -77,6 +78,9 @@ func (flags *Flags) Help() string {
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
+	if f.Verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 	return nil
 }
 
@@ -156,7 +160,6 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 func RegisterModule() {
 	var module Module
 	_, err := zgrab2.AddCommand("mssql", "MSSQL", "Grab a mssql handshake", 1433, &module)
-	log.SetLevel(log.DebugLevel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -14,7 +14,6 @@ package mssql
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"github.com/Sirupsen/logrus"
 )
 
 // ScanResults contains detailed information about each step of the
@@ -79,7 +78,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
 	if f.Verbose {
-		logrus.SetLevel(logrus.DebugLevel)
+		log.SetLevel(log.DebugLevel)
 	}
 	return nil
 }

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/mysql"
+	"github.com/Sirupsen/logrus"
 )
 
 // ScanResults contains detailed information about the scan.
@@ -168,6 +169,9 @@ func (f *Flags) Help() string {
 func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	s.config = f
+	if f.Verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 	return nil
 }
 

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -10,7 +10,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/mysql"
-	"github.com/Sirupsen/logrus"
 )
 
 // ScanResults contains detailed information about the scan.
@@ -170,7 +169,7 @@ func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	s.config = f
 	if f.Verbose {
-		logrus.SetLevel(logrus.DebugLevel)
+		log.SetLevel(log.DebugLevel)
 	}
 	return nil
 }

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -26,7 +26,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"github.com/Sirupsen/logrus"
 )
 
 // ScanResults instances are returned by the module's Scan function.
@@ -159,7 +158,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
 	if f.Verbose {
-		logrus.SetLevel(logrus.DebugLevel)
+		log.SetLevel(log.DebugLevel)
 	}
 	return nil
 }

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
+	"github.com/Sirupsen/logrus"
 )
 
 // ScanResults instances are returned by the module's Scan function.
@@ -157,6 +158,9 @@ func (flags *Flags) Help() string {
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
+	if f.Verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 	return nil
 }
 

--- a/modules/postgres/connection.go
+++ b/modules/postgres/connection.go
@@ -93,6 +93,9 @@ func (c *Connection) tryReadPacket(header byte) (*ServerPacket, *zgrab2.ScanErro
 		if err != nil && err != io.EOF {
 			return nil, zgrab2.DetectScanError(err)
 		}
+		if n < 2 {
+			return nil, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, fmt.Errorf("Server returned too little data (%d bytes: %s)", n, hex.EncodeToString(buf[:n])))
+		}
 		ret.Body = buf[:n]
 		if string(buf[n-2:n]) == "\x0a\x00" {
 			ret.Length = 0

--- a/modules/postgres/connection.go
+++ b/modules/postgres/connection.go
@@ -268,7 +268,7 @@ func (m *connectionManager) closeConnection(c io.Closer) {
 
 // cleanUp closes all managed connections.
 func (m *connectionManager) cleanUp() {
-	// first in, last out: emptry out the map
+	// first in, last out: empty out the map
 	defer func() {
 		for conn, _ := range m.connections {
 			delete(m.connections, conn)

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -470,7 +470,7 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 			log.Debugf("Unexpected response from server: %s", response.ToString())
 		}
 		// TODO: use any packets returned to fill out results? There probably won't be any, and they will probably be overwritten if Config.User etc is set...
-		if _, readErr = sql.ReadAll(); err != nil {
+		if _, readErr = sql.ReadAll(); readErr != nil {
 			return readErr.Unpack(&results)
 		}
 		sql.Close()

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -330,7 +330,7 @@ func (s *Scanner) newConnection(t *zgrab2.ScanTarget, mgr *connectionManager, no
 		return nil, zgrab2.DetectScanError(err)
 	}
 	mgr.addConnection(conn)
-	sql := Connection{Connection: conn, Config: s.Config}
+	sql := Connection{Target: t, Connection: conn, Config: s.Config}
 	sql.IsSSL = false
 	if !nossl && !s.Config.SkipSSL {
 		hasSSL, sslError := sql.RequestSSL()

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -17,7 +17,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"github.com/Sirupsen/logrus"
 )
 
 const (
@@ -282,7 +281,7 @@ func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	s.Config = f
 	if f.Verbose {
-		logrus.SetLevel(logrus.DebugLevel)
+		log.SetLevel(log.DebugLevel)
 	}
 	return nil
 }

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
+	"github.com/Sirupsen/logrus"
 )
 
 const (
@@ -280,6 +281,9 @@ func (f *Flags) Help() string {
 func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	s.Config = f
+	if f.Verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
 	return nil
 }
 
@@ -512,7 +516,6 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 func RegisterModule() {
 	var module Module
 	_, err := zgrab2.AddCommand("postgres", "Postgres", "Grab a Postgres handshake", 5432, &module)
-	log.SetLevel(log.DebugLevel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -459,8 +459,8 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 		if err = sql.SendStartupMessage(s.Config.ProtocolVersion, s.getDefaultKVPs()); err != nil {
 			return zgrab2.SCAN_PROTOCOL_ERROR, &results, err
 		}
-		if response, readErr = sql.ReadPacket(); err != nil {
-			log.Debugf("Error reading response after StartupMessage: %v", err)
+		if response, readErr = sql.ReadPacket(); readErr != nil {
+			log.Debugf("Error reading response after StartupMessage: %v", readErr)
 			return readErr.Unpack(&results)
 		}
 		if response.Type == 'E' {

--- a/monitor.go
+++ b/monitor.go
@@ -5,6 +5,8 @@ package zgrab2
 type Monitor struct {
 	states       map[string]*State
 	statusesChan chan moduleStatus
+	// Callback is invoked after each scan.
+	Callback     func(string)
 }
 
 // State contains the respective number of successes and failures
@@ -42,6 +44,9 @@ func MakeMonitor() *Monitor {
 		for s := range m.statusesChan {
 			if m.states[s.name] == nil {
 				m.states[s.name] = new(State)
+			}
+			if m.Callback != nil {
+				m.Callback(s.name)
 			}
 			switch s.st {
 			case statusSuccess:

--- a/processing.go
+++ b/processing.go
@@ -109,7 +109,7 @@ func grabTarget(input ScanTarget, m *Monitor) []byte {
 	// TODO FIXME: Move verbosity to global level, or add a Verbosity() method to the Module interface.
 	stripped, err := output.Process(raw)
 	if err != nil {
-		log.Warnf("Error processing results: %v", err)
+		log.Debugf("Error processing results: %v", err)
 		stripped = raw
 	}
 

--- a/processing.go
+++ b/processing.go
@@ -83,7 +83,7 @@ func grabTarget(input ScanTarget, m *Monitor) []byte {
 	for _, scannerName := range orderedScanners {
 		defer func(name string) {
 			if e := recover(); e != nil {
-				log.Errorf("Panic on scanner %s when scanning target %s", scannerName, input.String())
+				log.Errorf("Panic on scanner %s when scanning target %s: %#v", scannerName, input.String(), e)
 				// Bubble out original error (with original stack) in lieu of explicitly logging the stack / error
 				panic(e)
 			}

--- a/tls.go
+++ b/tls.go
@@ -276,6 +276,11 @@ func (z *TLSConnection) Handshake() error {
 	}
 }
 
+// Close the underlying connection.
+func (conn *TLSConnection) Close() error {
+	return conn.Conn.Close()
+}
+
 func (t *TLSFlags) GetTLSConnection(conn net.Conn) (*TLSConnection, error) {
 	cfg, err := t.GetTLSConfig()
 	if err != nil {


### PR DESCRIPTION
Includes #113 (rename httplex to match upstream changes)

 * Cap maximum data read for postgres
 * Clean up connections
 * Add flags for profiling
 * Fix some error handling in postgres
 * log level fixes

## How to Test

`make integration-test`

## Notes & Caveats

Except for the postgres max size fix, this is what was run over the weekend for mysql/mssql/oracle (and postgres, but it failed).

With the max size commit (so, everything), this is what is currently being run.

