### PR TITLE
MSSQL: include negotiated encrypt_mode

### DIFF
--- a/zgrab2_schemas/zgrab2/mssql.py
+++ b/zgrab2_schemas/zgrab2/mssql.py
@@ -41,6 +41,7 @@ mssql_scan_response = SubRecord({
         "version": String(),
         "instance_name": String(),
         "prelogin_options": prelogin_options,
+        "encrypt_mode": Enum(values=ENCRYPT_MODES, doc="The negotiated ENCRYPT_MODE with the server."),
         "tls": zgrab2.tls_log,
     })
 }, extends=zgrab2.base_scan_response)


### PR DESCRIPTION
MSSQL currently includes the `encrypt_mode` returned by the server during prelogin (though only as a debug field), but not the actually-negotiated value.

This includes that.

** NOTE **: This requires a corresponding ES schema push.

## How to Test

`TEST_MODULES=mssql make integration-test`

## Notes & Caveats

This isn't crucial, but it would be nice to have.
