### PR TITLE
Postgres: Output format tweaks

### DIFF
--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -200,7 +200,7 @@ func appendStringList(dest string, val string) string {
 
 // ServerParameters.appendBadParam() adds a packet to the list of bad/unexpected parameters
 func (p *ServerParameters) appendBadParam(packet *ServerPacket) {
-	(*p)[KeyBadParameters] = appendStringList((*p)[KeyBadParameters], packet.ToString())
+	(*p)[KeyBadParameters] = appendStringList((*p)[KeyBadParameters], packet.OutputValue())
 }
 
 // Results.decodeServerResponse() fills out the results object with packets returned by the server.
@@ -409,7 +409,7 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 		if response.Type != 'E' {
 			// No server should be allowing a 0.0 client...but if it does allow it, don't bail out
 			log.Debugf("Unexpected response from server: %s", response.ToString())
-			results.SupportedVersions = response.ToString()
+			results.SupportedVersions = response.OutputValue()
 		} else {
 			results.SupportedVersions = strings.Trim(string(response.Body), "\x00\r\n ")
 		}
@@ -440,7 +440,7 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 		if response.Type != 'E' {
 			// No server should be allowing a 255.255 client...but if it does allow it, don't bail out
 			log.Debugf("Unexpected response from server: %s", response.ToString())
-			results.ProtocolError = nil
+			results.ProtocolError = response.ToError()
 		} else {
 			results.ProtocolError = decodeError(response.Body)
 		}
@@ -474,6 +474,7 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 		} else {
 			// No server should allow a missing User field -- but if it does, log and continue
 			log.Debugf("Unexpected response from server: %s", response.ToString())
+			results.StartupError = response.ToError()
 		}
 		// TODO: use any packets returned to fill out results? There probably won't be any, and they will probably be overwritten if Config.User etc is set...
 		if _, readErr = sql.ReadAll(); readErr != nil {


### PR DESCRIPTION
Somewhat addresses #125 -- when a server returns syntactically-valid but unexpected postgres results, include those in the output (and stop including the debug string as was happening for ProtocolVersions).

## How to Test

Find some error-producing servers:
```python
results = api.search('tags.raw:"postgres" AND ServerPacket', fields=["ip", "5432.postgres.banner"])
for i in range(0, 100):
  result = next(results)
  if random.random() < 0.1: print result["ip"]
```

Then run the new code against them.

## Issue Tracking

#125 -- this doesn't tighten the detection threshold for tagging purposes, but it does make distinguishing false positives (and perhaps different configurations) easier.
