### PR TITLE
add missing _unknown_error_tag to postgres error schema

### DIFF
--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
+	"encoding/json"
 )
 
 const (
@@ -86,6 +87,18 @@ type PostgresError map[string]string
 // authentication. These are 'S'-type packets.
 // We keep track of them all -- but the golang postgres library only stores the server_version and TimeZone.
 type ServerParameters map[string]string
+
+// MarshalJSON returns the ServerParameters as a list of name/value pairs (work
+// around schema issue)
+func (s *ServerParameters) MarshalJSON() ([]byte, error) {
+	ret := make([]string, len(*s))
+	i := 0
+	for k, v := range *s {
+		ret[i] = k + "=" + v
+		i++
+	}
+	return json.Marshal(strings.Join(ret, ","))
+}
 
 // BackendKeyData is the data returned by the 'K'-type packet.
 type BackendKeyData struct {

--- a/zgrab2_schemas/zgrab2/postgres.py
+++ b/zgrab2_schemas/zgrab2/postgres.py
@@ -30,6 +30,7 @@ postgres_error = SubRecord({
     "file": String(),
     "line": String(),
     "routine": String(),
+    "_unknown_error_tag": String(),
 })
 
 # modules/postgres/scanner.go - decodeAuthMode()


### PR DESCRIPTION
`_unknown_error_tag` was missing previously, and `server_parameters` is schema'd as a string.

## How to Test

`TEST_MODULES=postgres make integration-test`
