### PR TITLE
Make auth mode enum optional

### DIFF
--- a/zgrab2_schemas/zgrab2/postgres.py
+++ b/zgrab2_schemas/zgrab2/postgres.py
@@ -41,7 +41,7 @@ AUTH_MODES = [
 
 # modules/postgres/scanner.go: AuthenticationMode
 postgres_auth_mode = SubRecord({
-    "mode": Enum(values=AUTH_MODES, required=True),
+    "mode": Enum(values=AUTH_MODES, required=False),  # this gets lifted
     "Payload": Binary(),
 })
 


### PR DESCRIPTION
This gets lifted out of the subrecord in other schemas, which makes it
optional in them. This is the easiest way to fix that, although it is
indicative or an underlying problem.