### PR TITLE
Add a global --debug flag to include zgrab:debug output

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,15 +18,15 @@ type Config struct {
 	LogFileName        string          `short:"l" long:"log-file" default:"-" description:"Log filename, use - for stderr"`
 	Interface          string          `short:"i" long:"interface" description:"Network interface to send on"`
 	Senders            int             `short:"s" long:"senders" default:"1000" description:"Number of send goroutines to use"`
-	Debug			   bool            `long:"debug" description:"Include debug fields in the output."`
+	Debug              bool            `long:"debug" description:"Include debug fields in the output."`
 	GOMAXPROCS         int             `long:"gomaxprocs" default:"0" description:"Set GOMAXPROCS"`
 	ConnectionsPerHost int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	Prometheus         string          `long:"prometheus" description:"Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled."`
 	Multiple           MultipleCommand `command:"multiple" description:"Multiple module actions"`
-	inputFile  *os.File
-	outputFile *os.File
-	metaFile   *os.File
-	logFile    *os.File
+	inputFile          *os.File
+	outputFile         *os.File
+	metaFile           *os.File
+	logFile            *os.File
 }
 
 func init() {

--- a/config.go
+++ b/config.go
@@ -18,11 +18,11 @@ type Config struct {
 	LogFileName        string          `short:"l" long:"log-file" default:"-" description:"Log filename, use - for stderr"`
 	Interface          string          `short:"i" long:"interface" description:"Network interface to send on"`
 	Senders            int             `short:"s" long:"senders" default:"1000" description:"Number of send goroutines to use"`
+	Debug			   bool            `long:"debug" description:"Include debug fields in the output."`
 	GOMAXPROCS         int             `long:"gomaxprocs" default:"0" description:"Set GOMAXPROCS"`
 	ConnectionsPerHost int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	Prometheus         string          `long:"prometheus" description:"Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled."`
 	Multiple           MultipleCommand `command:"multiple" description:"Multiple module actions"`
-
 	inputFile  *os.File
 	outputFile *os.File
 	metaFile   *os.File
@@ -109,4 +109,8 @@ func validateFrameworkConfiguration() {
 // GetMetaFile returns the file to which metadata should be output
 func GetMetaFile() *os.File {
 	return config.metaFile
+}
+
+func includeDebugOutput() bool {
+	return config.Debug
 }


### PR DESCRIPTION
Rather than overloading the meaning of `--verbose` (previously defined, for better or worse, to be per-module), added a global `--debug` flag that skips stripping out the `zgrab:"debug"` output fields.

## How to Test

`docker run -p 33306:3306 -td --rm --name mysqltest -e MYSQL_ALLOW_EMPTY_PASSWORD=true -e MYSQL_LOG_CONSOLE=true mysql:8.0`
`make && echo "localhost" | ./cmd/zgrab2/zgrab2 mysql --port 33306 | jp data.mysql.result.auth_plugin_name`
(should be `null`: `auth_plugin_name` is debug-only)
`echo "localhost" | ./cmd/zgrab2/zgrab2 --debug mysql --port 33306 | jp data.mysql.result.auth_plugin_name`
(should be `"mysql_native_password"`, because `--debug` is enabled).

## Notes & Caveats

As noted in the comments, this takes advantage of the fact that `output.Process()` currently only strips the debug fields, which is a rather expensive procedure.

If more were to be added to `output.Process()`, this would need to be refactored.

