### PR TITLE
(IPP) improve scan output

### DIFF
--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -439,7 +439,7 @@ func (scanner *Scanner) Grab(scan *scan, target *zgrab2.ScanTarget, version *ver
 	// TODO: Cite RFC justification for this
 	// Reject successful responses which specify non-IPP MIME mediatype (ie: text/html)
 	if isIPP, _ := hasContentType(resp, ContentType);
-		resp.StatusCode == 200 && resp.Header.Get("Content-Type") != "" && !isIPP {
+	   resp.StatusCode == 200 && resp.Header.Get("Content-Type") != "" && !isIPP {
 		// TODO: Log error if any
 		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("application/ipp not present in Content-Type header."))
 	}

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -183,7 +183,7 @@ func hasContentType(resp *http.Response, contentType string) (bool, error) {
 	// Parameters can be ignored, since there are no required or optional parameters
 	// IPP parameters specified at https://www.iana.org/assignments/media-types/application/ipp
 	mediatype, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-	// FIXME: See if empty media type is sufficient as failure indicator,
+	// TODO: See if empty media type is sufficient as failure indicator,
 	// there could be other states where reading mediatype screwed up, but isn't empty (ie: corrupted/malformed)
 	if mediatype == "" && err != nil {
 		//TODO: Handle errors in a weird way, since media type is still returned

--- a/modules/ipp/scanner_test.go
+++ b/modules/ipp/scanner_test.go
@@ -1,0 +1,2 @@
+package ipp
+

--- a/zgrab2_schemas/zgrab2/ipp.py
+++ b/zgrab2_schemas/zgrab2/ipp.py
@@ -7,147 +7,8 @@ import zschema.registry
 import zcrypto_schemas.zcrypto as zcrypto
 import zgrab2
 
-# FIXME: Copy-pasted from http schema except for ipp_scan_response
-# lib/http/header.go: knownHeaders
-http_known_headers = [
-    "access_control_allow_origin",
-    "accept_patch",
-    "accept_ranges",
-    "age",
-    "allow",
-    "alt_svc",
-    "alternate_protocol",
-    "cache_control",
-    "connection",
-    "content_disposition",
-    "content_encoding",
-    "content_language",
-    "content_length",
-    "content_location",
-    "content_md5",
-    "content_range",
-    "content_type",
-    "expires",
-    "last_modified",
-    "link",
-    "location",
-    "p3p",
-    "pragma",
-    "proxy_agent",
-    "proxy_authenticate",
-    "public_key_pins",
-    "referer",
-    "refresh",
-    "retry_after",
-    "server",
-    "set_cookie",
-    "status",
-    "strict_transport_security",
-    "trailer",
-    "transfer_encoding",
-    "upgrade",
-    "vary",
-    "via",
-    "warning",
-    "www_authenticate",
-    "x_frame_options",
-    "x_xss_protection",
-    "content_security_policy",
-    "x_content_security_policy",
-    "x_webkit_csp",
-    "x_content_type_options",
-    "x_powered_by",
-    "x_ua_compatible",
-    "x_content_duration",
-    "x_real_ip",
-    "x_forwarded_for",
-]
+import zgrab2_schemas.zgrab2.http as http
 
-http_unknown_headers = ListOf(SubRecord({
-    "key": String(),
-    "value": ListOf(String())
-}))
-
-_http_headers = dict(
-    (header_name, ListOf(String()))
-    for header_name in http_known_headers
-)
-_http_headers["unknown"] = http_unknown_headers
-
-# Format from the custom JSON Marshaller in lib/http/header.go
-http_headers = SubRecord(_http_headers)
-
-# net.url: type Values map[string][]string
-http_form_values = SubRecord({})  # TODO FIXME: unconstrained dict
-
-# lib/http/request.go: URLWrapper
-http_url_wrapper = SubRecord({
-    "scheme": String(),
-    "opaque": String(),
-    "host": String(),
-    "path": String(),
-    "raw_path": String(),
-    "raw_query": String(),
-    "fragment": String()
-})
-
-# modules/http.go: HTTPRequest
-http_request = SubRecord({
-    "method": String(),
-    "endpoint": String(),
-    "user_agent": String(),
-    "body": String()
-})
-
-# modules/http.go: HTTPResponse
-http_response = SubRecord({
-    "version_major": Signed32BitInteger(),
-    "version_minor": Signed32BitInteger(),
-    "status_code": Signed32BitInteger(),
-    "status_line": String(),
-    "headers": http_headers,
-    "body": String(),
-    "body_sha256": String()
-})
-
-# lib/http/request.go: http.Request
-http_request_full = SubRecord({
-    "url": http_url_wrapper,
-    "method": String(),
-    "headers":  http_headers,
-    "body": String(),
-    "content_length": Signed64BitInteger(),
-    "transfer_encoding": ListOf(String()),
-    "close": Boolean(),
-    "host": String(),
-    "form": http_form_values,
-    "post_form": http_form_values,
-    "multipart_form": http_form_values,
-    "trailers": http_headers,
-    # The new field tls_log contains the zgrab2 TLS logs.
-    "tls_log": zgrab2.tls_log
-})
-
-# lib/http/response.go: http.Response
-http_response_full = SubRecord({
-    "status_line": String(),
-    "status_code": Unsigned32BitInteger(),
-    # lib/http/protocol.go: http.Protocol
-    "protocol": SubRecord({
-        "name": String(),
-        "major": Unsigned32BitInteger(),
-        "minor": Unsigned32BitInteger(),
-    }),
-    "headers": http_headers,
-    "body": String(),
-    "body_sha256": Binary(),
-    "content_length": Signed64BitInteger(),
-    "transfer_encoding": ListOf(String()),
-    "trailers": http_headers,
-    "request": http_request_full
-})
-
-# TODO: Re-work to use most of schema from http module, rather than copy-pasting
 ipp_scan_response = SubRecord({
     "result": SubRecord({
         "version_major": Signed8BitInteger(),
@@ -157,10 +18,10 @@ ipp_scan_response = SubRecord({
         "attr_cups_version": String(),
         "attr_ipp_versions": ListOf(String()),
         "attr_printer_uri": String(),
-        "response": http_response_full,
-        "cups_response": http_response_full,
+        "response": http.http_response_full,
+        "cups_response": http.http_response_full,
         "tls": zgrab2.tls_log,
-        "redirect_response_chain": ListOf(http_response_full),
+        "redirect_response_chain": ListOf(http.http_response_full),
     })
 }, extends=zgrab2.base_scan_response)
 

--- a/zgrab2_schemas/zgrab2/ipp.py
+++ b/zgrab2_schemas/zgrab2/ipp.py
@@ -156,10 +156,10 @@ ipp_scan_response = SubRecord({
         "attr_cups_version": String(),
         "attr_ipp_versions": ListOf(String()),
         "attr_printer_uri": String(),
-        "response": http_schema.http_response_full,
-        "cups_response": http_schema.http_response_full,
+        "response": http_response_full,
+        "cups_response": http_response_full,
         "tls": zgrab2.tls_log,
-        "redirect_response_chain": ListOf(http_schema.http_response_full),
+        "redirect_response_chain": ListOf(http_response_full),
     })
 }, extends=zgrab2.base_scan_response)
 

--- a/zgrab2_schemas/zgrab2/ipp.py
+++ b/zgrab2_schemas/zgrab2/ipp.py
@@ -7,7 +7,145 @@ import zschema.registry
 import zcrypto_schemas.zcrypto as zcrypto
 import zgrab2
 
-import zgrab2_schemas.zgrab2.http as http
+# TODO: Eventually re-introduce (non-cicular) dependency on HTTP zgrab2 schema
+# lib/http/header.go: knownHeaders
+http_known_headers = [
+    "access_control_allow_origin",
+    "accept_patch",
+    "accept_ranges",
+    "age",
+    "allow",
+    "alt_svc",
+    "alternate_protocol",
+    "cache_control",
+    "connection",
+    "content_disposition",
+    "content_encoding",
+    "content_language",
+    "content_length",
+    "content_location",
+    "content_md5",
+    "content_range",
+    "content_type",
+    "expires",
+    "last_modified",
+    "link",
+    "location",
+    "p3p",
+    "pragma",
+    "proxy_agent",
+    "proxy_authenticate",
+    "public_key_pins",
+    "referer",
+    "refresh",
+    "retry_after",
+    "server",
+    "set_cookie",
+    "status",
+    "strict_transport_security",
+    "trailer",
+    "transfer_encoding",
+    "upgrade",
+    "vary",
+    "via",
+    "warning",
+    "www_authenticate",
+    "x_frame_options",
+    "x_xss_protection",
+    "content_security_policy",
+    "x_content_security_policy",
+    "x_webkit_csp",
+    "x_content_type_options",
+    "x_powered_by",
+    "x_ua_compatible",
+    "x_content_duration",
+    "x_real_ip",
+    "x_forwarded_for",
+]
+
+http_unknown_headers = ListOf(SubRecord({
+    "key": String(),
+    "value": ListOf(String())
+}))
+
+_http_headers = dict(
+    (header_name, ListOf(String()))
+    for header_name in http_known_headers
+)
+_http_headers["unknown"] = http_unknown_headers
+
+# Format from the custom JSON Marshaller in lib/http/header.go
+http_headers = SubRecord(_http_headers)
+
+# net.url: type Values map[string][]string
+http_form_values = SubRecord({})  # TODO FIXME: unconstrained dict
+
+# lib/http/request.go: URLWrapper
+http_url_wrapper = SubRecord({
+    "scheme": String(),
+    "opaque": String(),
+    "host": String(),
+    "path": String(),
+    "raw_path": String(),
+    "raw_query": String(),
+    "fragment": String()
+})
+
+# modules/http.go: HTTPRequest
+http_request = SubRecord({
+    "method": String(),
+    "endpoint": String(),
+    "user_agent": String(),
+    "body": String()
+})
+
+# modules/http.go: HTTPResponse
+http_response = SubRecord({
+    "version_major": Signed32BitInteger(),
+    "version_minor": Signed32BitInteger(),
+    "status_code": Signed32BitInteger(),
+    "status_line": String(),
+    "headers": http_headers,
+    "body": String(),
+    "body_sha256": String()
+})
+
+# lib/http/request.go: http.Request
+http_request_full = SubRecord({
+    "url": http_url_wrapper,
+    "method": String(),
+    "headers":  http_headers,
+    "body": String(),
+    "content_length": Signed64BitInteger(),
+    "transfer_encoding": ListOf(String()),
+    "close": Boolean(),
+    "host": String(),
+    "form": http_form_values,
+    "post_form": http_form_values,
+    "multipart_form": http_form_values,
+    "trailers": http_headers,
+    # The new field tls_log contains the zgrab2 TLS logs.
+    "tls_log": zgrab2.tls_log
+})
+
+# lib/http/response.go: http.Response
+http_response_full = SubRecord({
+    "status_line": String(),
+    "status_code": Unsigned32BitInteger(),
+    # lib/http/protocol.go: http.Protocol
+    "protocol": SubRecord({
+        "name": String(),
+        "major": Unsigned32BitInteger(),
+        "minor": Unsigned32BitInteger(),
+    }),
+    "headers": http_headers,
+    "body": String(),
+    "body_sha256": Binary(),
+    "content_length": Signed64BitInteger(),
+    "transfer_encoding": ListOf(String()),
+    "trailers": http_headers,
+    "request": http_request_full
+})
 
 ipp_scan_response = SubRecord({
     "result": SubRecord({
@@ -18,10 +156,10 @@ ipp_scan_response = SubRecord({
         "attr_cups_version": String(),
         "attr_ipp_versions": ListOf(String()),
         "attr_printer_uri": String(),
-        "response": http.http_response_full,
-        "cups_response": http.http_response_full,
+        "response": http_schema.http_response_full,
+        "cups_response": http_schema.http_response_full,
         "tls": zgrab2.tls_log,
-        "redirect_response_chain": ListOf(http.http_response_full),
+        "redirect_response_chain": ListOf(http_schema.http_response_full),
     })
 }, extends=zgrab2.base_scan_response)
 


### PR DESCRIPTION
Correctly determines whether to include ScanResults object in output json.
Rejects successful responses which are identifiable as non-IPP.
Reduces code duplication by refactoring several re-usable segments into independent functions.
Greatly simplifies IPP zgrab2 schema by depending upon HTTP zgrab2 schema.

## How to Test

`make integration-test`

## Notes & Caveats

Future Work:
Could use further refactoring.
Add support for Upgrade to HTTPS.

## Issue Tracking

N/A
