### PR TITLE
Add support for Tags and Triggers

### DIFF
--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -85,6 +85,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "#{MODULE_NAME}"

--- a/module.go
+++ b/module.go
@@ -12,6 +12,9 @@ type Scanner interface {
 	// Returns the name passed at init
 	GetName() string
 
+	// Returns the trigger passed at init
+	GetTrigger() string
+
 	// Protocol returns the protocol identifier for the scan.
 	Protocol() string
 
@@ -61,6 +64,7 @@ type BaseFlags struct {
 	Port    uint   `short:"p" long:"port" description:"Specify port to grab on"`
 	Name    string `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
 	Timeout uint   `short:"t" long:"timeout" description:"Set connection timeout in seconds (0 = no timeout)" default:"10"`
+	Trigger string `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
 }
 
 // UDPFlags contains the common options used for all UDP scans

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -77,6 +77,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "bacnet"

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -75,6 +75,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "dnp3"

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -75,6 +75,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "fox"

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -121,6 +121,11 @@ func (s *Scanner) GetName() string {
 	return s.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // GetPort returns the configured port for the Scanner.
 func (s *Scanner) GetPort() uint {
 	return s.config.Port

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -78,12 +79,12 @@ type Scanner struct {
 // It is used to implement the zgrab2.Scanner interface.
 type scan struct {
 	connections []net.Conn
-	scanner   *Scanner
-	target    *zgrab2.ScanTarget
-	transport *http.Transport
-	client    *http.Client
-	results   Results
-	url       string
+	scanner     *Scanner
+	target      *zgrab2.ScanTarget
+	transport   *http.Transport
+	client      *http.Client
+	results     Results
+	url         string
 }
 
 // NewFlags returns an empty Flags object.
@@ -126,6 +127,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 // GetName returns the name defined in the Flags.
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
 }
 
 // Cleanup closes any connections that have been opened during the scan
@@ -306,6 +312,7 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 // the target. If the scanner is configured to follow redirects, this may entail
 // multiple TCP connections to hosts other than target.
 func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	fmt.Printf("%v %v %v %v %v\n", t, scanner.config.Name, scanner.config.Port, scanner.config.Trigger, scanner.config.UserAgent)
 	scan := scanner.newHTTPScan(&t)
 	defer scan.Cleanup()
 	err := scan.Grab()

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -312,7 +311,6 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 // the target. If the scanner is configured to follow redirects, this may entail
 // multiple TCP connections to hosts other than target.
 func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
-	fmt.Printf("%v %v %v %v %v\n", t, scanner.config.Name, scanner.config.Port, scanner.config.Trigger, scanner.config.UserAgent)
 	scan := scanner.newHTTPScan(&t)
 	defer scan.Cleanup()
 	err := scan.Grab()

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 )
 
-
 // ScanResults instances are returned by the module's Scan function.
 type ScanResults struct {
 	// Banner is the string sent by the server immediately after connecting.
@@ -124,6 +123,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 // GetName returns the Scanner name defined in the Flags.
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
 }
 
 // Protocol returns the protocol identifier of the scan.

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -35,9 +35,9 @@ type ScanResults struct {
 	MinorVersion int8 `json:"version_minor"`
 
 	VersionString string `json:"version_string,omitempty"`
-	CUPSVersion string `json:"cups_version,omitempty"`
+	CUPSVersion   string `json:"cups_version,omitempty"`
 
-	TLSLog      *zgrab2.TLSLog `json:"tls,omitempty"`
+	TLSLog *zgrab2.TLSLog `json:"tls,omitempty"`
 }
 
 // TODO: Annotate every flag thoroughly
@@ -114,6 +114,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 // GetName returns the Scanner name defined in the Flags.
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
 }
 
 // Protocol returns the protocol identifier of the scan.

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -103,6 +103,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "modbus"

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -103,6 +103,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // GetPort returns the configured scanner port.
 func (scanner *Scanner) GetPort() uint {
 	return scanner.config.Port

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -200,6 +200,11 @@ func (s *Scanner) GetName() string {
 	return s.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // GetPort returns the port that is being scanned.
 func (s *Scanner) GetPort() uint {
 	return s.config.Port

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -863,7 +863,12 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
-// GetPort returns the port that is being scanned
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
+// scanner returns the port that is being scanned
 func (scanner *Scanner) GetPort() uint {
 	return scanner.config.Port
 }

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -868,7 +868,7 @@ func (scanner *Scanner) GetTrigger() string {
 	return scanner.config.Trigger
 }
 
-// scanner returns the port that is being scanned
+// GetPort returns the port that is being scanned
 func (scanner *Scanner) GetPort() uint {
 	return scanner.config.Port
 }

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -173,6 +173,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "oracle"

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -33,7 +33,6 @@ import (
 	"strings"
 )
 
-
 // ScanResults instances are returned by the module's Scan function.
 type ScanResults struct {
 	// Banner is the string sent by the server immediately after connecting.
@@ -139,6 +138,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 // GetName returns the Scanner name defined in the Flags.
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
 }
 
 // Protocol returns the protocol identifier of the scan.

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -15,9 +15,9 @@ import (
 	"net"
 	"strings"
 
+	"encoding/json"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"encoding/json"
 )
 
 const (
@@ -312,6 +312,11 @@ func (s *Scanner) Protocol() string {
 // GetName returns the name from the parameters.
 func (s *Scanner) GetName() string {
 	return s.Config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (s *Scanner) GetTrigger() string {
+	return s.Config.Trigger
 }
 
 // GetPort returns the port being scanned.

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -48,7 +48,7 @@ type scan struct {
 	result  *Result
 	target  *zgrab2.ScanTarget
 	conn    *Connection
-	close  func()
+	close   func()
 }
 
 // Result is the struct that is returned by the scan.
@@ -135,6 +135,11 @@ func (scanner *Scanner) InitPerSender(senderID int) error {
 // GetName returns the name of the scanner
 func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
 }
 
 // GetPort returns the port being scanned

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -74,6 +74,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "siemens"
@@ -100,7 +105,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	defer conn.Close()
 	result := new(S7Log)
 
-	err = GetS7Banner(result, conn, func() (net.Conn, error){ return target.Open(&scanner.config.BaseFlags)})
+	err = GetS7Banner(result, conn, func() (net.Conn, error) { return target.Open(&scanner.config.BaseFlags) })
 	if !result.IsS7 {
 		result = nil
 	}

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -77,6 +77,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "smb"

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -17,7 +17,7 @@
 // The scanner uses the standard TLS flags for the handshake.
 //
 // The --send-quit flag tells the scanner to send a QUIT command.
-// 
+//
 // So, if no flags are specified, the scanner simply reads the banner
 // returned by the server and disconnects.
 //
@@ -166,6 +166,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "smtp"
@@ -227,7 +232,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	conn := Connection{Conn: c}
 	banner, err := conn.ReadResponse()
 	if err != nil {
-		if ! scanner.config.SMTPSecure {
+		if !scanner.config.SMTPSecure {
 			result = nil
 		}
 		return zgrab2.TryGetScanStatus(err), result, err

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -73,6 +73,10 @@ func (s *SSHScanner) GetName() string {
 	return s.config.Name
 }
 
+func (s *SSHScanner) GetTrigger() string {
+	return s.config.Trigger
+}
+
 func (s *SSHScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
 	data := new(ssh.HandshakeLog)
 

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -81,6 +81,11 @@ func (scanner *Scanner) GetName() string {
 	return scanner.config.Name
 }
 
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
 // Protocol returns the protocol identifier of the scan.
 func (scanner *Scanner) Protocol() string {
 	return "telnet"

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -54,6 +54,10 @@ func (s *TLSScanner) GetName() string {
 	return s.config.Name
 }
 
+func (s *TLSScanner) GetTrigger() string {
+	return s.config.Trigger
+}
+
 func (s *TLSScanner) InitPerSender(senderID int) error {
 	return nil
 }


### PR DESCRIPTION
This PR adds support for a new pair of concepts, tags and triggers, that allow a ZGrab instance to more flexibly scan multiple protocols.

A tag is a string associated with a grab target.  Any input line can end in a tag, which is written preceded by an equals sign, as follows:

```
141.212.113.199 =tagA
216.239.38.21, censys.io =tagB
```

A trigger is a new parameter associated with each scan module.  When `--trigger=X` is specified, the scan module will only be invoked on targets with tag `X`.  Likewise, inputs containing a tag will not be processed by scan modules that do not include a corresponding trigger.

Tags and triggers are particularly powerful when combined with ZGrab's multiple command feature.  For instance, invoking `zgrab2 multiple` with the following configuration will perform an SSH grab on the first target above and an HTTP grab on the second target:

```
[ssh]
trigger="tagA"
name="ssh21"
port=22

[http]
trigger="tagB"
name="http80"
port=80
```

## Notes & Caveats

ZGrab2's multiple command support is currently hobbled by https://github.com/zmap/zflags/issues/3.  This may cause problems during testing.
