### PR TITLE
Feature/IPP: Fix Retry-TLS and Collect All IPP Attributes

### DIFF
--- a/integration_tests/ipp/test.sh
+++ b/integration_tests/ipp/test.sh
@@ -36,7 +36,7 @@ function test_cups() {
 }
 
 function test_cups_tls() {
-    echo "ipp/test: Tests runner for ipp_cups"
+    echo "ipp/test: Tests runner for ipp_cups-tls"
 
     CONTAINER_NAME="zgrab_ipp_cups-tls" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --timeout 3 --ipps --verbose > "$OUTPUT_ROOT/cups-tls.json"
     # FIXME: No good reason to use a tmp file & saved file, b/c I'm not testing any failure states yet
@@ -60,7 +60,7 @@ function test_cups_tls() {
         echo "ipp/test: Incorrect CUPS version. Expected CUPS/2.1, got $cups"
         exit 1
     fi
-    if [ $tls = "null" ]; then
+    if [ "$tls" = "null" ]; then
         echo "ipp/test: No TLS handshake logged"
         exit 1
     fi

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -694,7 +694,7 @@ func (scanner *Scanner) tryGrabForVersions(target *zgrab2.ScanTarget, versions [
 	defer scan.Cleanup()
 	var err *zgrab2.ScanError
 	for i := 0; i < len(versions); i++ {
-		err = scanner.Grab(scan, target, &(versions)[i])
+		err = scanner.Grab(scan, target, &versions[i])
 		if err != nil && err.Err == ErrVersionNotSupported && i < len(versions)-1 {
 			continue
 		}

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -79,8 +79,6 @@ type ScanResults struct {
 	TLSLog *zgrab2.TLSLog `json:"tls,omitempty"`
 }
 
-// TODO: Annotate every flag thoroughly
-// TODO: Add more protocol-specific flags as needed
 // Flags holds the command-line configuration for the ipp scan module.
 // Populated by the framework.
 type Flags struct {
@@ -88,7 +86,7 @@ type Flags struct {
 	zgrab2.TLSFlags
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 
-	//FIXME: Borrowed from http module
+	//FIXME: Borrowed from http module, determine whether this is all needed
 	MaxSize      int    `long:"max-size" default:"256" description:"Max kilobytes to read in response to an IPP request"`
 	MaxRedirects int    `long:"max-redirects" default:"0" description:"Max number of redirects to follow"`
 	UserAgent    string `long:"user-agent" default:"Mozilla/5.0 zgrab/0.x" description:"Set a custom user agent"`

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -285,7 +285,7 @@ func (scan *scan) tryReadAttributes(resp *http.Response) *zgrab2.ScanError {
 	body := []byte(resp.BodyText)
 	// TODO: Cite RFC justification for this
 	// Reject successful responses which specify non-IPP MIME mediatype (ie: text/html)
-	if ipp, _ := isIPP(resp); !ipp {
+	if ipp := isIPP(resp); !ipp {
 		// TODO: Log error if any
 		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("IPP Content-Type not detected."))
 	}

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -70,7 +70,8 @@ type ScanResults struct {
 	MinorVersion  *int8  `json:"version_minor,omitempty"`
 	VersionString string `json:"version_string,omitempty"`
 	CUPSVersion   string `json:"cups_version,omitempty"`
-	
+
+	Attributes           []*Attribute `json:"attributes,omitempty" zgrab:"debug"`
 	AttributeCUPSVersion string   `json:"attr_cups_version,omitempty"`
 	AttributeIPPVersions []string `json:"attr_ipp_versions,omitempty"`
 	AttributePrinterURIs []string `json:"attr_printer_uris,omitempty"`

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -384,18 +384,15 @@ func (scanner *Scanner) tryReadAttributes(resp *http.Response, scan *scan) *zgra
 	scan.results.Attributes = append(scan.results.Attributes, attrs...)
 
 	for _, attr := range scan.results.Attributes {
-		// TODO: Make this record all CUPS versions given. Currently records first version from first attribute.
 		if attr.Name == CupsVersion && scan.results.AttributeCUPSVersion == "" {
 			scan.results.AttributeCUPSVersion = string(attr.Values[0].Bytes)
 		}
-		// TODO: Make this report all IPP versions given. Currently records all versions from first attribute.
 		if attr.Name == VersionsSupported && len(scan.results.AttributeIPPVersions) == 0 {
 			for _, v := range attr.Values {
 				scan.results.AttributeIPPVersions = append(scan.results.AttributeIPPVersions, string(v.Bytes))
 			}
 		}
-		// TODO: Make this record all printer URI's given. Currently records the first uri for each attribute.
-		if attr.Name == PrinterURISupported && len(scan.results.AttributePrinterURIs) == 0 {
+		if attr.Name == PrinterURISupported {
 			scan.results.AttributePrinterURIs = append(scan.results.AttributePrinterURIs, string(attr.Values[0].Bytes))
 		}
 	}

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -63,7 +63,7 @@ type ScanResults struct {
 
 	// RedirectResponseChain is non-empty if the scanner follows a redirect.
 	// It contains all redirect responses prior to the final response.
-	RedirectResponseChain []*http.Response `json:"redirect_response_chain,omitempty" zgrab:"debug"`
+	RedirectResponseChain []*http.Response `json:"redirect_response_chain,omitempty"`
 
 	MajorVersion  *int8  `json:"version_major,omitempty"`
 	MinorVersion  *int8  `json:"version_minor,omitempty"`

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -230,7 +230,7 @@ func shouldReturnAttrs(length, soFar, size, upperBound int) (bool, error) {
 
 func detectReadBodyError(err error) error {
 	if err == io.EOF || err == io.ErrUnexpectedEOF {
-		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Couldn't read enough body bytes."))
+		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Fewer body bytes read than expected."))
 	}
 	return zgrab2.NewScanError(zgrab2.TryGetScanStatus(err), err)
 }

--- a/zgrab2_schemas/zgrab2/ipp.py
+++ b/zgrab2_schemas/zgrab2/ipp.py
@@ -148,12 +148,16 @@ http_response_full = SubRecord({
 })
 
 # TODO: Determine whether value-tag types with same underlying form should have a different name in this mapping
+# TODO: Add method to decode these values appropriately. Encoding of different tag's attribute values specified
+# in Table 7 of RFC 8010 Section 3.9 (https://tools.ietf.org/html/rfc8010#section-3.9)
+# "value-tag" values which specify the interpretation of an attribute's value:
+# From RFC 8010 Section 3.5.2 (https://tools.ietf.org/html/rfc8010#section-3.5.2)
+# Note: value-tag values are camelCase because the names are specified that way in RFC
 ipp_attribute_value = SubRecord({
     "raw": Binary(),
     "integer": Signed32BitInteger(),
     "boolean": Boolean(),
     "enum": String(),
-    # TODO: Determine appropriate type for octetString w/o specified format
     "octetString": Binary(),
     "dateTime": DateTime(),
     # TODO: Determine appropriate type for resolution
@@ -180,7 +184,7 @@ ipp_attribute_value = SubRecord({
 ipp_attribute = SubRecord({
     "name": String(),
     "values": ListOf(ipp_attribute_value),
-    "tag": Binary(),
+    "tag": Unsigned8BitInteger(),
 })
 
 ipp_scan_response = SubRecord({

--- a/zgrab2_schemas/zgrab2/ipp.py
+++ b/zgrab2_schemas/zgrab2/ipp.py
@@ -147,15 +147,52 @@ http_response_full = SubRecord({
     "request": http_request_full
 })
 
+# TODO: Determine whether value-tag types with same underlying form should have a different name in this mapping
+ipp_attribute_value = SubRecord({
+    "raw": Binary(),
+    "integer": Signed32BitInteger(),
+    "boolean": Boolean(),
+    "enum": String(),
+    # TODO: Determine appropriate type for octetString w/o specified format
+    "octetString": Binary(),
+    "dateTime": DateTime(),
+    # TODO: Determine appropriate type for resolution
+    "resolution": Binary(),
+    # TODO: Determine appropriate type for range of Integers (probably {min, max} pair)
+    "rangeOfInteger": Binary(),
+    # TODO: Determine appropriate type for beginning of attribute collection
+    "begCollection": Binary(),
+    "textWithLanguage": String(),
+    "nameWithLanguage": String(),
+    # TODO: Determine appropriate type for end of attribute collection
+    "endCollection": Binary(),
+    "textWithoutLanguage": String(),
+    "nameWithoutLanguage": String(),
+    "keyword": String(),
+    "uri": String(),
+    "uriScheme": String(),
+    "charset": String(),
+    "naturalLanguage": String(),
+    "mimeMediaType": String(),
+    "memberAttrName": String(),
+})
+
+ipp_attribute = SubRecord({
+    "name": String(),
+    "values": ListOf(ipp_attribute_value),
+    "tag": Binary(),
+})
+
 ipp_scan_response = SubRecord({
     "result": SubRecord({
         "version_major": Signed8BitInteger(),
         "version_minor": Signed8BitInteger(),
         "version_string": String(),
         "cups_version": String(),
+        "attributes": ListOf(ipp_attribute),
         "attr_cups_version": String(),
         "attr_ipp_versions": ListOf(String()),
-        "attr_printer_uri": String(),
+        "attr_printer_uris": ListOf(String()),
         "response": http_response_full,
         "cups_response": http_response_full,
         "tls": zgrab2.tls_log,


### PR DESCRIPTION
Fixes retry-TLS. The retry occurs if and only if the plaintext connection fails.

Collects all attributes returned in any IPP responses received.

## How to Test

`make integration-test`

## Notes & Caveats

Future Work:
Could use further refactoring.
Add support for Upgrade to HTTPS.
Add support for proper redirect handling. (Currently reporting application error for non-200 status code.)

## Issue Tracking

N/A
