### PR TITLE
TLS SNI fixes / API cleanup

### DIFF
--- a/modules/tls.go
+++ b/modules/tls.go
@@ -62,20 +62,29 @@ func (s *TLSScanner) InitPerSender(senderID int) error {
 	return nil
 }
 
+// Scan opens a TCP connection to the target (default port 443), then performs
+// a TLS handshake. If the handshake gets past the ServerHello stage, the
+// handshake log is returned (along with any other TLS-related logs, such as
+// heartbleed, if enabled).
 func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
-	tcpConn, err := t.Open(&s.config.BaseFlags)
+	conn, err := t.OpenTLS(&s.config.BaseFlags, &s.config.TLSFlags)
+	if conn != nil {
+		defer conn.Close()
+	}
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), &zgrab2.TLSLog{}, err
+		if conn != nil {
+			if log := conn.GetLog(); log != nil {
+				if log.HandshakeLog.ServerHello != nil {
+					// If we got far enough to get a valid ServerHello, then
+					// consider it to be a positive TLS detection.
+					return zgrab2.TryGetScanStatus(err), log, err
+				}
+				// Otherwise, detection failed.
+			}
+		}
+		return zgrab2.TryGetScanStatus(err), nil, err
 	}
-	var conn *zgrab2.TLSConnection
-	if conn, err = s.config.TLSFlags.GetTLSConnection(tcpConn); err != nil {
-		return zgrab2.TryGetScanStatus(err), &zgrab2.TLSLog{}, err
-	}
-	result := conn.GetLog()
-	if err = conn.Handshake(); err != nil {
-		return zgrab2.TryGetScanStatus(err), result, err
-	}
-	return zgrab2.SCAN_SUCCESS, result, nil
+	return zgrab2.SCAN_SUCCESS, conn.GetLog(), nil
 }
 
 // Protocol returns the protocol identifer for the scanner.

--- a/processing.go
+++ b/processing.go
@@ -60,6 +60,18 @@ func (target *ScanTarget) Open(flags *BaseFlags) (net.Conn, error) {
 	return DialTimeoutConnection("tcp", address, flags.Timeout)
 }
 
+// OpenTLS connects to the ScanTarget using the configured flags, then performs
+// the TLS handshake. On success error is nil, but the connection can be non-nil
+// even if there is an error (this allows fetching the handshake log).
+func (target *ScanTarget) OpenTLS(baseFlags *BaseFlags, tlsFlags *TLSFlags) (*TLSConnection, error) {
+	conn, err := tlsFlags.Connect(target, baseFlags)
+	if err != nil {
+		return conn, err
+	}
+	err = conn.Handshake()
+	return conn, err
+}
+
 // OpenUDP connects to the ScanTarget using the configured flags, and returns a net.Conn that uses the configured timeouts for Read/Write operations.
 // Note that the UDP "connection" does not have an associated timeout.
 func (target *ScanTarget) OpenUDP(flags *BaseFlags, udp *UDPFlags) (net.Conn, error) {


### PR DESCRIPTION
Previously, SNI was only supported with an explicit `--server-name`, which is obviously not helpful for realistic scans (see e.g. #145).

This adds new API calls that allow the `ScanTarget` (where the domain name is, when it's present) to be included when setting up the TLS connection, and updates the TLS scan module to use these them.

## How to Test

`echo "$(dig +short www.google.com),www.google.com" | cmd/zgrab2/zgrab2 --debug tls | jp data.tls.result.handshake_log.client_hello.server_name` -- should be "www.google.com"

`echo "$(dig +short www.google.com),www.google.com" | cmd/zgrab2/zgrab2 --debug tls --server-name www.fake-google.com | jp data.tls.result.handshake_log.client_hello.server_name` -- should be "www.fake-google.com"

`echo "$(dig +short www.google.com),www.google.com" | cmd/zgrab2/zgrab2 --debug tls --no-sni | jp data.tls.result.handshake_log.client_hello.server_name` -- should be null.

## Notes & Caveats

We'll still need to update all of the other scanners currently using TLS to either `target.OpenTLS()` or `tlsFlags.GetTLSConnectionForTarget()`.

## Issue Tracking

#145, #147
