### PR TITLE
Fix read all attributes

### DIFF
--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -620,7 +620,7 @@ func (scan *scan) getCheckRedirect(scanner *Scanner) func(*http.Request, *http.R
 // Taken from zgrab2 http library, slightly modified to use slightly leaner scan object
 func (scan *scan) getTLSDialer(scanner *Scanner) func(net, addr string) (net.Conn, error) {
 	return func(net, addr string) (net.Conn, error) {
-		outer, err := zgrab2.DialTimeoutConnection(net, addr, time.Second*time.Duration(scanner.config.BaseFlags.Timeout))
+		outer, err := zgrab2.DialTimeoutConnection(net, addr, scanner.config.BaseFlags.Timeout)
 		if err != nil {
 			return nil, err
 		}
@@ -661,7 +661,7 @@ func (scanner *Scanner) newIPPScan(target *zgrab2.ScanTarget, tls bool) *scan {
 		MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 	}
 	transport.DialTLS = newScan.getTLSDialer(scanner)
-	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(time.Duration(scanner.config.Timeout) * time.Second).DialContext
+	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.BaseFlags.Timeout).DialContext
 	newScan.client.CheckRedirect = newScan.getCheckRedirect(scanner)
 	newScan.client.UserAgent = scanner.config.UserAgent
 	newScan.client.Transport = transport

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -286,10 +286,14 @@ func readAllAttributes(body []byte, scanner *Scanner) ([]*Attribute, error) {
 		// If tag is a delimiter-tag ([0x00, 0x05]), read the next tag, which corresponds to the first
 		// attribute's value-tag
 		if tag <= 0x05 {
+			lastTag = tag
 			if err := binary.Read(buf, binary.BigEndian, &tag); err != nil {
 				return attrs, detectReadBodyError(err)
 			}
 			bytesRead++
+			// Start a new iteration after reading this tag, since the next tag could be another
+			// delimiter to be caught by this same if block
+			continue
 		}
 		// TODO: Implement parsing attribute collections, since they're special
 		// Read in length of attribute's name, which will be used to determine whether this attribute stands alone
@@ -660,11 +664,7 @@ func (scanner *Scanner) newIPPScan(target *zgrab2.ScanTarget, tls bool) *scan {
 		MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 	}
 	transport.DialTLS = newScan.getTLSDialer(scanner)
-<<<<<<< HEAD
-	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.BaseFlags.Timeout).DialContext
-=======
 	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.Timeout).DialContext
->>>>>>> master
 	newScan.client.CheckRedirect = newScan.getCheckRedirect(scanner)
 	newScan.client.UserAgent = scanner.config.UserAgent
 	newScan.client.Transport = transport


### PR DESCRIPTION
Ensures that delimiter tags are handled correctly, allowing all attributes to be read.

## How to Test
`make integration-test`
