### PR TITLE
Try TLS before plaintext when using ipps-retry

### DIFF
--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -620,7 +620,7 @@ func (scan *scan) getCheckRedirect(scanner *Scanner) func(*http.Request, *http.R
 // Taken from zgrab2 http library, slightly modified to use slightly leaner scan object
 func (scan *scan) getTLSDialer(scanner *Scanner) func(net, addr string) (net.Conn, error) {
 	return func(net, addr string) (net.Conn, error) {
-		outer, err := zgrab2.DialTimeoutConnection(net, addr, time.Second*time.Duration(scanner.config.BaseFlags.Timeout))
+		outer, err := zgrab2.DialTimeoutConnection(net, addr, scanner.config.BaseFlags.Timeout)
 		if err != nil {
 			return nil, err
 		}
@@ -661,7 +661,7 @@ func (scanner *Scanner) newIPPScan(target *zgrab2.ScanTarget, tls bool) *scan {
 		MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 	}
 	transport.DialTLS = newScan.getTLSDialer(scanner)
-	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(time.Duration(scanner.config.Timeout) * time.Second).DialContext
+	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.BaseFlags.Timeout).DialContext
 	newScan.client.CheckRedirect = newScan.getCheckRedirect(scanner)
 	newScan.client.UserAgent = scanner.config.UserAgent
 	newScan.client.Transport = transport

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -69,7 +69,7 @@ type ScanResults struct {
 	VersionString string `json:"version_string,omitempty"`
 	CUPSVersion   string `json:"cups_version,omitempty"`
 
-	Attributes           []*Attribute `json:"attributes,omitempty" zgrab:"debug"`
+	Attributes           []*Attribute `json:"attributes,omitempty"`
 	AttributeCUPSVersion string   `json:"attr_cups_version,omitempty"`
 	AttributeIPPVersions []string `json:"attr_ipp_versions,omitempty"`
 	AttributePrinterURIs []string `json:"attr_printer_uris,omitempty"`

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -88,7 +88,7 @@ type Flags struct {
 	MaxSize      int    `long:"max-size" default:"256" description:"Max kilobytes to read in response to an IPP request"`
 	MaxRedirects int    `long:"max-redirects" default:"0" description:"Max number of redirects to follow"`
 	UserAgent    string `long:"user-agent" default:"Mozilla/5.0 zgrab/0.x" description:"Set a custom user agent"`
-	TLSRetry     bool   `long:"tls-retry" description:"If the initial request using TLS fails, reconnect and try using plaintext IPP."`
+	TLSRetry     bool   `long:"ipps-retry" description:"If the initial request using TLS fails, reconnect and try using plaintext IPP."`
 
 	// FollowLocalhostRedirects overrides the default behavior to return
 	// ErrRedirLocalhost whenever a redirect points to localhost.

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -286,10 +286,14 @@ func readAllAttributes(body []byte, scanner *Scanner) ([]*Attribute, error) {
 		// If tag is a delimiter-tag ([0x00, 0x05]), read the next tag, which corresponds to the first
 		// attribute's value-tag
 		if tag <= 0x05 {
+			lastTag = tag
 			if err := binary.Read(buf, binary.BigEndian, &tag); err != nil {
 				return attrs, detectReadBodyError(err)
 			}
 			bytesRead++
+			// Start a new iteration after reading this tag, since the next tag could be another
+			// delimiter to be caught by this same if block
+			continue
 		}
 		// TODO: Implement parsing attribute collections, since they're special
 		// Read in length of attribute's name, which will be used to determine whether this attribute stands alone
@@ -660,11 +664,7 @@ func (scanner *Scanner) newIPPScan(target *zgrab2.ScanTarget, tls bool) *scan {
 		MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 	}
 	transport.DialTLS = newScan.getTLSDialer(scanner)
-<<<<<<< HEAD
-	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.BaseFlags.Timeout).DialContext
-=======
 	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.Timeout).DialContext
->>>>>>> master
 	newScan.client.CheckRedirect = newScan.getCheckRedirect(scanner)
 	newScan.client.UserAgent = scanner.config.UserAgent
 	newScan.client.Transport = transport


### PR DESCRIPTION
Attempts to connect with TLS first, then falls back to plaintext if that fails. Renames option to ipps-retry rather than retry-tls

## How to Test

`make integration-test`

## Notes & Caveats

Future work:
Add an integration test based on a CUPS container that only accepts plaintext traffic, like many of the hosts encountered in the wild. This will verify that ipps-retry falls back successfully.
