### PR TITLE
Corrects CertType's id's type

### DIFF
--- a/zgrab2_schemas/zgrab2/ssh.py
+++ b/zgrab2_schemas/zgrab2/ssh.py
@@ -158,7 +158,7 @@ SSHPublicKey = SubRecordType({
 })
 
 CertType = SubRecordType({
-    "id": Enum(values=[1, 2], doc="The numerical certificate type value. 1 identifies user certificates, 2 identifies host certificates."),
+    "id": Enum(values=["1", "2"], doc="The numerical certificate type value. 1 identifies user certificates, 2 identifies host certificates."),
     "name": Enum(values=["USER", "HOST", "unknown"], doc="The human-readable name for the certificate type."),
 })
 


### PR DESCRIPTION
Changes CertType's id field to Enum of strings, since an Enum of ints is not valid.

## Notes & Caveats

CertType SubRecords being created according to this definition were invalid, since their contained id Enum was invalid.