### PR TITLE
Fix CertType

### DIFF
--- a/zgrab2_schemas/zgrab2/ssh.py
+++ b/zgrab2_schemas/zgrab2/ssh.py
@@ -158,7 +158,7 @@ SSHPublicKey = SubRecordType({
 })
 
 CertType = SubRecordType({
-    "id": Enum(values=["1", "2"], doc="The numerical certificate type value. 1 identifies user certificates, 2 identifies host certificates."),
+    "id": Unsigned32BitInteger(doc="The numerical certificate type value. 1 identifies user certificates, 2 identifies host certificates."),
     "name": Enum(values=["USER", "HOST", "unknown"], doc="The human-readable name for the certificate type."),
 })
 

--- a/zgrab2_schemas/zgrab2/ssh.py
+++ b/zgrab2_schemas/zgrab2/ssh.py
@@ -157,6 +157,7 @@ SSHPublicKey = SubRecordType({
     "ed25519_public_key": ED25519PublicKey(),
 })
 
+# lib/ssh/certs.go: JsonCertType
 CertType = SubRecordType({
     "id": Unsigned32BitInteger(doc="The numerical certificate type value. 1 identifies user certificates, 2 identifies host certificates."),
     "name": Enum(values=["USER", "HOST", "unknown"], doc="The human-readable name for the certificate type."),


### PR DESCRIPTION
Originally this was an Enum with numeric values, which was an error, because Enums had to be strings.

That was fixed in #154, but CertType's values are actually uint32s, so the error just got shifted.
