### PR TITLE
Stop marking fields as “required”

### DIFF
--- a/zgrab2_schemas/zgrab2/mysql.py
+++ b/zgrab2_schemas/zgrab2/mysql.py
@@ -59,7 +59,7 @@ mysql_capability_flags = zgrab2.FlagsSet([
 # zgrab2/modules/mysql.go: MySQLScanResults
 mysql_scan_response = SubRecord({
     "result": SubRecord({
-        "protocol_version": Unsigned8BitInteger(required=True, doc="8-bit unsigned integer representing the server's protocol version sent in the initial HandshakePacket from the server.", examples=["10"]),
+        "protocol_version": Unsigned8BitInteger(doc="8-bit unsigned integer representing the server's protocol version sent in the initial HandshakePacket from the server.", examples=["10"]),
         "server_version": WhitespaceAnalyzedString(doc="The specific server version returned in the initial HandshakePacket. Often in the form x.y.z, but not always.", examples=["5.5.58", "5.6.38", "5.7.20", "8.0.3-rc-log"]),
         "connection_id": DebugOnly(Unsigned32BitInteger(doc="The server's internal identifier for this client's connection, sent in the initial HandshakePacket.")),
         "auth_plugin_data": DebugOnly(Binary(doc="Optional plugin-specific data, whose meaning depends on the value of auth_plugin_name. Returned in the initial HandshakePacket.")),

--- a/zgrab2_schemas/zgrab2/postgres.py
+++ b/zgrab2_schemas/zgrab2/postgres.py
@@ -14,9 +14,9 @@ import zgrab2
 # These are defined in detail at
 #   https://www.postgresql.org/docs/10/static/protocol-error-fields.html
 postgres_error = SubRecord({
-    "severity": WhitespaceAnalyzedString(required=True),
+    "severity": WhitespaceAnalyzedString(),
     "severity_v": WhitespaceAnalyzedString(),
-    "code": WhitespaceAnalyzedString(required=True),
+    "code": WhitespaceAnalyzedString(),
     "message": WhitespaceAnalyzedString(),
     "detail": WhitespaceAnalyzedString(),
     "hint": WhitespaceAnalyzedString(),
@@ -58,7 +58,7 @@ postgres_scan_response = SubRecord({
         "supported_versions": WhitespaceAnalyzedString(),
         "protocol_error": postgres_error,
         "startup_error": postgres_error,
-        "is_ssl": Boolean(required=True),
+        "is_ssl": Boolean(),
         "authentication_mode": postgres_auth_mode,
         # TODO FIXME: This is currendly an unconstrained map[string]string
         "server_parameters": WhitespaceAnalyzedString(),

--- a/zgrab2_schemas/zgrab2/zgrab2.py
+++ b/zgrab2_schemas/zgrab2/zgrab2.py
@@ -32,7 +32,7 @@ grab_result = Record({
     # TODO: ip may be required; see https://github.com/zmap/zgrab2/issues/104
     "ip": IPv4Address(required=False, doc="The IP address of the target."),
     "domain": String(required=False, doc="The domain name of the target, if available."),
-    "data": SubRecord(scan_response_types, required=True, doc="The scan data for this host."),
+    "data": SubRecord(scan_response_types, doc="The scan data for this host."),
 })
 
 # zgrab2/module.go: const SCAN_*
@@ -49,9 +49,9 @@ STATUS_VALUES = [
 
 # zgrab2/module.go: ScanResponse
 base_scan_response = SubRecord({
-    "status": Enum(values=STATUS_VALUES, required=True, doc="The status of the request."),
-    "protocol": String(required=True, doc="The identifier of the protocol being scanned."),
-    "timestamp": DateTime(required=True, doc="The time the scan was started."),
+    "status": Enum(values=STATUS_VALUES, doc="The status of the request."),
+    "protocol": String(doc="The identifier of the protocol being scanned."),
+    "timestamp": DateTime(doc="The time the scan was started."),
     "result": SubRecord({}, required=False),  # This is overridden by the protocols' implementations
     "error": String(required=False, doc="If the status was not success, error may contain information about the failure.")
     # TODO: error_component? domain?


### PR DESCRIPTION
This causes problems when trying to load data into BigQuery if, for example, an entire protocol or subrecord is unpopulated.