### PR TITLE
add missing 'constraint' field for postgres_error

### DIFF
--- a/zgrab2_schemas/zgrab2/postgres.py
+++ b/zgrab2_schemas/zgrab2/postgres.py
@@ -27,6 +27,7 @@ postgres_error = SubRecord({
     "schema": WhitespaceAnalyzedString(),
     "table": WhitespaceAnalyzedString(),
     "data": WhitespaceAnalyzedString(),
+    "constraint": WhitespaceAnalyzedString(),
     "file": WhitespaceAnalyzedString(),
     "line": WhitespaceAnalyzedString(),
     "routine": WhitespaceAnalyzedString(),


### PR DESCRIPTION
@cdzombak noted that this was missing. Comparing this to https://github.com/zmap/zgrab2/blob/jb/addMissingPostgresErrorType/modules/postgres/scanner.go#L184, `constraint` seems to be the only field that was not present.
