### PR TITLE
Fix possible index error on malformed msg

### DIFF
--- a/modules/mongodb/types.go
+++ b/modules/mongodb/types.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"io"
 	"encoding/binary"
+	"fmt"
 	"github.com/zmap/zgrab2"
 )
 
@@ -53,6 +54,11 @@ func (conn *Connection) ReadMsg() ([]byte, error) {
 		return nil, err
 	}
 	msglen := binary.LittleEndian.Uint32(msglen_buf[:])
+	if msglen < 4 {
+		// msglen is length of message which includes msglen itself; Less than
+		// four is invalid.
+		return nil, fmt.Errorf("Server sent invalid message: msglen = %d", msglen)
+	}
 	msg_buf := make([]byte, msglen)
 	// Extra copy to make result look like spec (only four bytes)
 	binary.LittleEndian.PutUint32(msg_buf[0:], msglen)

--- a/modules/mongodb/types.go
+++ b/modules/mongodb/types.go
@@ -54,9 +54,10 @@ func (conn *Connection) ReadMsg() ([]byte, error) {
 		return nil, err
 	}
 	msglen := binary.LittleEndian.Uint32(msglen_buf[:])
-	if msglen < 4 {
-		// msglen is length of message which includes msglen itself; Less than
-		// four is invalid.
+	if msglen < 4 || msglen > 5125 {
+	        // msglen is length of message which includes msglen itself; Less than
+		// four is invalid. More than a few K probably mean this isn't actually
+		// a mongodb server.
 		return nil, fmt.Errorf("Server sent invalid message: msglen = %d", msglen)
 	}
 	msg_buf := make([]byte, msglen)


### PR DESCRIPTION
## Description

First four bytes of mongodb message header are length of message, which includes the four byte length itself. A message of simply "\x00\x00\x00\x00" caused a zero-length buffer to be allocated and 0x00000000 attempted to be written into it. Fixed by returning an error if message length < 4, because it must at least include itself.

## How to Test

Run ./zgrab mongodb against server which responds to query with 4-byte 0x00000000.

### Before
```
ERRO[0000] Panic on scanner mongodb when scanning target XXX.XXX.XXX.XXX: "index out of range"
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range

goroutine 45 [running]:
github.com/zmap/zgrab2.grabTarget.func1(0xc42016e060, 0xc420352030, 0x10, 0x10, 0x0, 0x0, 0x0, 0x0, 0x16ccc6f, 0x7)
	/Users/paul/go/src/github.com/zmap/zgrab2/processing.go:105 +0x1ab
panic(0x15fe040, 0x1aef6f0)
	/usr/local/go/src/runtime/panic.go:502 +0x229
encoding/binary.binary.littleEndian.PutUint32(...)
	/usr/local/go/src/encoding/binary/binary.go:68
github.com/zmap/zgrab2/modules/mongodb.(*Connection).ReadMsg(0xc42015c020, 0xc4201b6cc0, 0x3a, 0x3a, 0x0, 0x0)
	/Users/paul/go/src/github.com/zmap/zgrab2/modules/mongodb/types.go:61 +0x396
github.com/zmap/zgrab2/modules/mongodb.getIsMaster(0xc42015c020, 0xc420142010, 0xc4204320f0, 0x0)
	/Users/paul/go/src/github.com/zmap/zgrab2/modules/mongodb/scanner.go:268 +0xb7
github.com/zmap/zgrab2/modules/mongodb.(*Scanner).Scan(0xc4201bb180, 0xc420352030, 0x10, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/paul/go/src/github.com/zmap/zgrab2/modules/mongodb/scanner.go:306 +0x12b
github.com/zmap/zgrab2.RunScanner(0x1785140, 0xc4201bb180, 0xc420395120, 0xc420352030, 0x10, 0x10, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/paul/go/src/github.com/zmap/zgrab2/scanner.go:32 +0xd7
github.com/zmap/zgrab2.grabTarget(0xc420352030, 0x10, 0x10, 0x0, 0x0, 0x0, 0x0, 0xc420395120, 0x0, 0x0, ...)
	/Users/paul/go/src/github.com/zmap/zgrab2/processing.go:108 +0x26e
github.com/zmap/zgrab2.Process.func2(0xc4201b18c0, 0xc420395120, 0xc4201b1920, 0xc420353a30, 0x2)
	/Users/paul/go/src/github.com/zmap/zgrab2/processing.go:176 +0x131
created by github.com/zmap/zgrab2.Process
	/Users/paul/go/src/github.com/zmap/zgrab2/processing.go:169 +0x167
```

### After

```
{"ip":"XXX.XXX.XXX.XXX","data":{"mongodb":{"status":"protocol-error","protocol":"mongodb","timestamp":"2018-08-28T14:30:24-04:00","error":"Server sent invalid message: msglen = 0"}}}
```
