### PR TITLE
BSON tag is case sensitive - s/isMaster/ismaster

### DIFF
--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -169,7 +169,7 @@ type BuildInfo_t struct {
 
 // IsMaster_t holds the data returned by an isMaster query
 type IsMaster_t struct {
-	IsMaster bool `bson:"isMaster" json:"is_master"`
+	IsMaster bool `bson:"ismaster" json:"is_master"`
 	MaxWireVersion int32 `bson:"maxWireVersion,omitempty" json:"max_wire_version,omitempty"`
 	MinWireVersion int32 `bson:"minWireVersion,omitempty" json:"min_wire_version,omitempty"`
 	MaxBsonObjectSize int32 `bson:"maxBsonObjectSize,omitempty" json:"max_bson_object_size,omitempty"`


### PR DESCRIPTION
BSON tag is case sensitive. Mongodb isMaster command responds with bool "ismaster", which we were tagging for BSON with "isMaster", causing it to be missed / always false. 

## How to Test

Pass IPs to zgrab of mongodb hosts which are master and not. Confirm that `is_master` is `true` when master and `false` when not.

Master:

```
"result":{"is_master":{"is_master":true,"max_wire_version":4,"max_bson_object_size":16777216,"max_write_batch_size":1000,"max_message_size_bytes":48000000,"read_only":false}}
```

Not Master:

```
"result":{"is_master":{"is_master":false,"max_wire_version":5,"max_bson_object_size":16777216,"max_write_batch_size":1000,"max_message_size_bytes":48000000,"read_only":false}}
```
