### PR TITLE
Fix for zcrypto updates

### DIFF
--- a/lib/ssh/keys.go
+++ b/lib/ssh/keys.go
@@ -381,8 +381,7 @@ func (r *dsaPublicKey) Type() string {
 }
 
 func (r *dsaPublicKey) MarshalJSON() ([]byte, error) {
-	temp := make(map[string]interface{})
-	ztoolsX509.AddDSAPublicKeyToKeyMap(temp, (*dsa.PublicKey)(r))
+	temp := ztoolsX509.GetDSAPublicKeyJSON((*dsa.PublicKey)(r))
 	return json.Marshal(temp)
 }
 
@@ -489,8 +488,7 @@ func (key *ecdsaPublicKey) Type() string {
 }
 
 func (key *ecdsaPublicKey) MarshalJSON() ([]byte, error) {
-	temp := make(map[string]interface{})
-	ztoolsX509.AddECDSAPublicKeyToKeyMap(temp, (*ecdsa.PublicKey)(key))
+	temp := ztoolsX509.GetECDSAPublicKeyJSON((*ecdsa.PublicKey)(key))
 	return json.Marshal(temp)
 }
 


### PR DESCRIPTION
In https://github.com/zmap/zcrypto/pull/173, the utility functions for putting the key components into a dict were removed.

This update uses functions added in https://github.com/zmap/zcrypto/pull/178 that replace this functionality.

## How to Test

The integration tests should pass again. (`make integration-test`)

