### PR TITLE
MongoDB - fix isMaster message length check.

### DIFF
--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -270,11 +270,11 @@ func getIsMaster(conn *Connection) (*IsMaster_t, error) {
 		return nil, err
 	}
 
-	if len(msg) < MSGHEADER_LEN + 4 {
+	if len(msg) < doc_offset + 4 {
 		err = fmt.Errorf("Server truncated message - no query reply (%d bytes: %s)", len(msg), hex.EncodeToString(msg))
 		return nil, err
 	}
-	respFlags := binary.LittleEndian.Uint32(msg[MSGHEADER_LEN:MSGHEADER_LEN + 5])
+	respFlags := binary.LittleEndian.Uint32(msg[MSGHEADER_LEN:MSGHEADER_LEN + 4])
 	if respFlags & QUERY_RESP_FAILED != 0 {
 		err = fmt.Errorf("isMaster query failed")
 		return nil, err


### PR DESCRIPTION
Updated message length to account for OP_REPLY header.

Also fixed off-by-one uint32 read buffer size, but I don't think that would have broken anything.

## How to Test

Connect to host which responds to isMaster OP_QUERY with a reply which is longer than mongodb message header + 4 but less than that + OP_REPLY header.
