### PR TITLE
Omit empty build_info elm on mongodb output

### DIFF
--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -181,8 +181,8 @@ type IsMaster_t struct {
 
 // Result holds the data returned by a scan
 type Result struct {
-	IsMaster *IsMaster_t `json:"is_master"`
-	BuildInfo *BuildInfo_t `json:"build_info"`
+	IsMaster *IsMaster_t `json:"is_master,omitempty"`
+	BuildInfo *BuildInfo_t `json:"build_info,omitempty"`
 }
 
 // Init initializes the scanner


### PR DESCRIPTION


Mark build_info as `omitempty` so that zschema does not complain when it's None.

## How to Test

zgrab a mongodb host where isMaster succeeds but buildInfo does not


## Issue Tracking

CEN-817