### PR TITLE
To ensure that the HTTP connection is not blocked!

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -279,6 +279,7 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
 	ret.client.CheckRedirect = ret.getCheckRedirect()
 	ret.client.Transport = ret.transport
 	ret.client.Jar = nil // Don't send or receive cookies (otherwise use CookieJar)
+	ret.client.Timeout=time.Now().Add(scanner.config.Timeout)
 	host := t.Domain
 	if host == "" {
 		host = t.IP.String()


### PR DESCRIPTION
https://github.com/zmap/zgrab2/blob/15127f1b89dd780c7873760d00ecff18e05c51b3/modules/http/scanner.go#L281
shoud add  a line code 
ret.client.Timeout=time.Now().Add(scanner.config.Timeout)

please see the code in
https://github.com/zmap/zgrab2/blob/15127f1b89dd780c7873760d00ecff18e05c51b3/lib/http/client.go#L609