### PR TITLE
SSH: Add banner grabbing

### DIFF
--- a/lib/ssh/client.go
+++ b/lib/ssh/client.go
@@ -230,6 +230,10 @@ func Dial(network, addr string, config *ClientConfig) (*Client, error) {
 	return NewClient(c, chans, reqs), nil
 }
 
+// BannerCallback is the function type used for treat the banner sent by
+// the server. A BannerCallback receives the message sent by the remote server.
+type BannerCallback func(message string) error
+
 // A ClientConfig structure is used to configure a Client. It must not be
 // modified after having been passed to an SSH function.
 type ClientConfig struct {
@@ -249,6 +253,12 @@ type ClientConfig struct {
 	// handshake to validate the server's host key. A nil HostKeyCallback
 	// implies that all host keys are accepted.
 	HostKeyCallback func(hostname string, remote net.Addr, key PublicKey) error
+
+	// BannerCallback is called during the SSH dance to display a custom
+	// server's message. The client configuration can supply this callback to
+	// handle it as wished. The function BannerDisplayStderr can be used for
+	// simplistic display on Stderr.
+	BannerCallback BannerCallback
 
 	// ClientVersion contains the version identification string that will
 	// be used for the connection. If empty, a reasonable default is used.

--- a/lib/ssh/client_auth.go
+++ b/lib/ssh/client_auth.go
@@ -325,7 +325,9 @@ func handleAuthResponse(c packetConn) (bool, []string, error) {
 
 		switch packet[0] {
 		case msgUserAuthBanner:
-			// TODO: add callback to present the banner to the user
+			if err := handleBannerResponse(c, packet); err != nil {
+				return false, nil, err
+			}
 		case msgUserAuthFailure:
 			var msg userAuthFailureMsg
 			if err := Unmarshal(packet, &msg); err != nil {
@@ -338,6 +340,24 @@ func handleAuthResponse(c packetConn) (bool, []string, error) {
 			return false, nil, unexpectedMessageError(msgUserAuthSuccess, packet[0])
 		}
 	}
+}
+
+func handleBannerResponse(c packetConn, packet []byte) error {
+	var msg userAuthBannerMsg
+	if err := Unmarshal(packet, &msg); err != nil {
+		return err
+	}
+
+	transport, ok := c.(*handshakeTransport)
+	if !ok {
+		return nil
+	}
+
+	if transport.bannerCallback != nil {
+		return transport.bannerCallback(msg.Message)
+	}
+
+	return nil
 }
 
 // KeyboardInteractiveChallenge should print questions, optionally
@@ -385,7 +405,9 @@ func (cb KeyboardInteractiveChallenge) auth(session []byte, user string, c packe
 		// like handleAuthResponse, but with less options.
 		switch packet[0] {
 		case msgUserAuthBanner:
-			// TODO: Print banners during userauth.
+			if err := handleBannerResponse(c, packet); err != nil {
+				return false, nil, err
+			}
 			continue
 		case msgUserAuthInfoRequest:
 			// OK

--- a/lib/ssh/handshake.go
+++ b/lib/ssh/handshake.go
@@ -58,6 +58,10 @@ type handshakeTransport struct {
 	dialAddress     string
 	remoteAddr      net.Addr
 
+	// ClientConfig. In that case it is called during the user authentication
+	// dance to handle a custom server's message.
+	bannerCallback BannerCallback
+
 	readSinceKex uint64
 
 	// Protects the writing side of the connection
@@ -89,6 +93,7 @@ func newClientTransport(conn keyingTransport, clientVersion, serverVersion []byt
 	t.dialAddress = dialAddr
 	t.remoteAddr = addr
 	t.hostKeyCallback = config.HostKeyCallback
+	t.bannerCallback = config.BannerCallback
 	if config.HostKeyAlgorithms != nil {
 		t.hostKeyAlgorithms = config.HostKeyAlgorithms
 	} else {

--- a/lib/ssh/log.go
+++ b/lib/ssh/log.go
@@ -17,6 +17,7 @@ package ssh
 // HandshakeLog contains detailed information about each step of the
 // SSH handshake, and can be encoded to JSON.
 type HandshakeLog struct {
+	Banner             string       `json:"banner,omitempty"`
 	ServerID           *EndpointId  `json:"server_id,omitempty"`
 	ClientID           *EndpointId  `json:"client_id,omitempty"`
 	ServerKex          *kexInitMsg  `json:"server_key_exchange,omitempty"`

--- a/lib/ssh/messages.go
+++ b/lib/ssh/messages.go
@@ -27,7 +27,6 @@ const (
 
 	// Standard authentication messages
 	msgUserAuthSuccess = 52
-	msgUserAuthBanner  = 53
 )
 
 // SSH messages:
@@ -171,6 +170,15 @@ const msgUserAuthFailure = 51
 type userAuthFailureMsg struct {
 	Methods        []string `sshtype:"51"`
 	PartialSuccess bool
+}
+
+// See RFC 4252, section 5.4
+const msgUserAuthBanner = 53
+
+type userAuthBannerMsg struct {
+	Message string `sshtype:"53"`
+	// unused, but required to allow message parsing
+	Language string
 }
 
 // See RFC 4256, section 3.2

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -100,6 +100,10 @@ func (s *SSHScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 	sshConfig.GexMinBits = s.config.GexMinBits
 	sshConfig.GexMaxBits = s.config.GexMaxBits
 	sshConfig.GexPreferredBits = s.config.GexPreferredBits
+	sshConfig.BannerCallback = func(banner string) error {
+		data.Banner = strings.TrimSpace(banner)
+		return nil
+	}
 	_, err := ssh.Dial("tcp", rhost, sshConfig)
 	// TODO FIXME: Distinguish error types
 	status := zgrab2.TryGetScanStatus(err)


### PR DESCRIPTION
Add SSH banner grabbing when `userauth` enabled:
- Bump `lib/ssh` from `golang.org/x/crypto/ssh` (just banner handling, not a full update)
- Add a banner field to the SSH module info

Authors @sdnewhop

## How to Test
To test changes pass to `zgrab2` a host with SSH banner configured. E.g.
```bash
echo "yalegko.ml" | ./zgrab2 ssh --userauth
```
