### PR TITLE
Use Target Domain name in SNI when using HTTP

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -173,13 +173,13 @@ func (scan *scan) dialContext(ctx context.Context, net string, addr string) (net
 
 // getTLSDialer returns a Dial function that connects using the
 // zgrab2.GetTLSConnection()
-func (scan *scan) getTLSDialer() func(net, addr string) (net.Conn, error) {
+func (scan *scan) getTLSDialer(t *zgrab2.ScanTarget) func(net, addr string) (net.Conn, error) {
 	return func(net, addr string) (net.Conn, error) {
 		outer, err := scan.dialContext(context.Background(), net, addr)
 		if err != nil {
 			return nil, err
 		}
-		tlsConn, err := scan.scanner.config.TLSFlags.GetTLSConnection(outer)
+		tlsConn, err := scan.scanner.config.TLSFlags.GetTLSConnectionForTarget(outer, t)
 		if err != nil {
 			return nil, err
 		}
@@ -273,7 +273,7 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
 		client:         http.MakeNewClient(),
 		globalDeadline: time.Now().Add(scanner.config.Timeout),
 	}
-	ret.transport.DialTLS = ret.getTLSDialer()
+	ret.transport.DialTLS = ret.getTLSDialer(t)
 	ret.transport.DialContext = ret.dialContext
 	ret.client.UserAgent = scanner.config.UserAgent
 	ret.client.CheckRedirect = ret.getCheckRedirect()


### PR DESCRIPTION
Previous addition of GetTLSConfigForTarget (811eb38) did not modify
HTTP module to use SNI. This let to the very cryptic unknown-error:
remote error: internal error. Some servers give Fatal alerts when
they don't get an SNI extension. Discovered on a `Pagely-ARES/1.3.21`
Server. 

## How to Test

Currently tested manually. Examine a network capture of the following command:

`echo "https://benvds.com" | zgrab2 http`

Look at the TLS ClientHello's extensions and ensure that it includes the Extension Server Name Indication.

## Notes & Caveats

Only HTTP. I'm not sure the behavior of other modules that use TLS. 

## Issue Tracking

Related to #147 
