### PR TITLE
Add custom regexp banner grabber

### DIFF
--- a/modules/banner.go
+++ b/modules/banner.go
@@ -1,0 +1,9 @@
+package modules
+
+import (
+	"github.com/zmap/zgrab2/modules/banner"
+)
+
+func init() {
+	banner.RegisterModule()
+}

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -1,0 +1,124 @@
+// Package banner provides simple banner grab and matching implementation of the zgrab2.Module.
+// It sends a customizble probe (default to "\n") and filters the results based on custom input (--match)
+
+package banner
+
+import (
+	"errors"
+	"io"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/zmap/zgrab2"
+)
+
+// Flags give the command-line flags for the banner module.
+type Flags struct {
+	zgrab2.BaseFlags
+	Probe   string `long:"probe" default:"\n" description:"Probe to send to the server."`
+	Pattern string `long:"pattern" description:"Pattern to match, must be vaild regexp."`
+}
+
+// Module is the implementation of the zgrab2.Module interface.
+type Module struct {
+}
+
+// Scanner is the implementation of the zgrab2.Scanner interface.
+type Scanner struct {
+	config *Flags
+	regex  *regexp.Regexp
+}
+
+type Results struct {
+	Banner string `json:"banner,omitempty"`
+	Length int    `json:"length,omitempty"`
+}
+
+// RegisterModule is called by modules/banner.go to register the scanner.
+func RegisterModule() {
+	var module Module
+	_, err := zgrab2.AddCommand("banner", "Banner", "Grab banner by sending probe and match with regexp", 80, &module)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// NewFlags returns a new default flags object.
+func (m *Module) NewFlags() interface{} {
+	return new(Flags)
+}
+
+// GetName returns the Scanner name defined in the Flags.
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
+}
+
+// GetTrigger returns the Trigger defined in the Flags.
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
+}
+
+// Protocol returns the protocol identifier of the scan.
+func (scanner *Scanner) Protocol() string {
+	return "banner"
+}
+
+// GetPort returns the port being scanned.
+func (scanner *Scanner) GetPort() uint {
+	return scanner.config.Port
+}
+
+// InitPerSender initializes the scanner for a given sender.
+func (scanner *Scanner) InitPerSender(senderID int) error {
+	return nil
+}
+
+// NewScanner returns a new Scanner object.
+func (m *Module) NewScanner() zgrab2.Scanner {
+	return new(Scanner)
+}
+
+// Validate validates the flags and returns nil on success.
+func (f *Flags) Validate(args []string) error {
+	return nil
+}
+
+// Help returns the module's help string.
+func (f *Flags) Help() string {
+	return ""
+}
+
+// Init initializes the Scanner with the command-line flags.
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
+	f, _ := flags.(*Flags)
+	scanner.config = f
+	scanner.regex = regexp.MustCompile(scanner.config.Pattern)
+	return nil
+}
+
+var NoMatchError = errors.New("pattern did not match")
+
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+	conn, err := target.Open(&scanner.config.BaseFlags)
+	if err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	defer conn.Close()
+	r := strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t")
+	probe := r.Replace(scanner.config.Probe)
+	conn.Write([]byte(probe))
+	// buf := make([]byte, 8192)
+	//buflen, err := zgrab2.ReadUntilRegex(conn, buf, scanner.regex)
+	ret, err := zgrab2.ReadAvailable(conn)
+	if err != io.EOF && err != nil {
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
+	results := Results{Banner: string(ret), Length: len(ret)}
+	if scanner.regex.Match(ret) {
+		return zgrab2.SCAN_SUCCESS, &results, nil
+	}
+
+	return zgrab2.SCAN_PROTOCOL_ERROR, &results, NoMatchError
+
+}

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -1,5 +1,5 @@
 // Package banner provides simple banner grab and matching implementation of the zgrab2.Module.
-// It sends a customizble probe (default to "\n") and filters the results based on custom input (--match)
+// It sends a customizble probe (default to "\n") and filters the results based on a custom regexp (--pattern)
 
 package banner
 

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -120,7 +120,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
 	defer conn.Close()
-	r := strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t")
+	r := strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t",`\x`,"\x")
 	probe := r.Replace(scanner.config.Probe)
 	var ret []byte
 	try = 0

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -115,7 +115,6 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		err     error
 		readerr error
 	)
-	fmt.Printf("Probe: %v", scanner.probe)
 	for try < scanner.config.MaxTries {
 		try += 1
 		conn, err = target.Open(&scanner.config.BaseFlags)

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -108,8 +108,6 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	r := strings.NewReplacer(`\n`, "\n", `\r`, "\r", `\t`, "\t")
 	probe := r.Replace(scanner.config.Probe)
 	conn.Write([]byte(probe))
-	// buf := make([]byte, 8192)
-	//buflen, err := zgrab2.ReadUntilRegex(conn, buf, scanner.regex)
 	ret, err := zgrab2.ReadAvailable(conn)
 	if err != io.EOF && err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -17,7 +17,7 @@ import (
 type Flags struct {
 	zgrab2.BaseFlags
 	Probe   string `long:"probe" default:"\n" description:"Probe to send to the server."`
-	Pattern string `long:"pattern" description:"Pattern to match, must be vaild regexp."`
+	Pattern string `long:"pattern" description:"Pattern to match, must be valid regexp."`
 }
 
 // Module is the implementation of the zgrab2.Module interface.

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -19,7 +19,7 @@ type Flags struct {
 	zgrab2.BaseFlags
 	Probe    string `long:"probe" default:"\n" description:"Probe to send to the server."`
 	Pattern  string `long:"pattern" description:"Pattern to match, must be valid regexp."`
-	MaxTries int    `long:"maxtries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
+	MaxTries int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
 }
 
 // Module is the implementation of the zgrab2.Module interface.

--- a/zgrab2_schemas/zgrab2/__init__.py
+++ b/zgrab2_schemas/zgrab2/__init__.py
@@ -20,3 +20,4 @@ from . import smtp
 from . import ssh
 from . import telnet
 from . import ipp
+from . import banner

--- a/zgrab2_schemas/zgrab2/banner.py
+++ b/zgrab2_schemas/zgrab2/banner.py
@@ -7,7 +7,7 @@ import zschema.registry
 import zcrypto_schemas.zcrypto as zcrypto
 from . import zgrab2
 
-# modules/cassandra.go - CassandraScanResults
+# modules/banner/scanner.go - Results
 banner_scan_response = SubRecord({
     "result": SubRecord({
         "banner": String(),

--- a/zgrab2_schemas/zgrab2/banner.py
+++ b/zgrab2_schemas/zgrab2/banner.py
@@ -11,7 +11,7 @@ from . import zgrab2
 banner_scan_response = SubRecord({
     "result": SubRecord({
         "banner": String(),
-        "length": Int()
+        "length": Unsigned32BitInteger()
     })
 }, extends=zgrab2.base_scan_response)
 

--- a/zgrab2_schemas/zgrab2/banner.py
+++ b/zgrab2_schemas/zgrab2/banner.py
@@ -1,0 +1,20 @@
+# zschema sub-schema for zgrab2's banner module
+# Registers zgrab2-banner globally, and banner with the main zgrab2 schema.
+from zschema.leaves import *
+from zschema.compounds import *
+import zschema.registry
+
+import zcrypto_schemas.zcrypto as zcrypto
+from . import zgrab2
+
+# modules/cassandra.go - CassandraScanResults
+banner_scan_response = SubRecord({
+    "result": SubRecord({
+        "banner": String(),
+        "length": Int()
+    })
+}, extends=zgrab2.base_scan_response)
+
+zschema.registry.register_schema("zgrab2-banner", banner_scan_response)
+
+zgrab2.register_scan_response_type("banner", banner_scan_response)


### PR DESCRIPTION
New Banner module that can grab banner and match against a custom regexp. It will still get the banner and create protocol error  If "--pattern" is defined and the results did not match.

options:

          --probe=            Probe to send to the server. Use triple slashes
                                    to escape, for example \\\n is literal \n
                                    (default: \n)
          --pattern=          Pattern to match, must be valid regexp.
          --max-tries=       Number of tries for timeouts and connection
                                    errors before giving up. (default: 1)



## How to Test

echo 'google.com'|./zgrab2 banner -p 80 --pattern="asfgqwg" --probe "GET / \n\n"

Should output {"domain":"google.com","data":{"banner":{"status":"protocol-error","protocol":"banner","result":{"banner":"HTTP/1.0 .... ","error":"pattern did not match"}}}


echo 'google.com'|./zgrab2 banner -p 80 --pattern="HTTP" --probe "GET / \n\n"

Should output ... "data":{"banner":{"status":"success" ....

## Notes & Caveats
Still work in progress and I haven't got time to write proper tests...


## Issue Tracking
Use issues page.
