### PR TITLE
SMB: Bounds check slice index before access

### DIFF
--- a/lib/smb/smb/session.go
+++ b/lib/smb/smb/session.go
@@ -363,7 +363,7 @@ func (s *Session) send(req interface{}) (res []byte, err error) {
 		s.Debug("", err)
 		return
 	}
-	if size > 0x00FFFFFF {
+	if size > 0x00FFFFFF || size < 4 {
 		return nil, errors.New("Invalid NetBIOS Session message")
 	}
 


### PR DESCRIPTION
The smb library bounds checks for a message size that is too large, but
does not check for a message size that is way too small.  Error out if
the message size is not at least as large as the ProtocolID 4-byte
preamble.

This fixes slice out of bound panics when checking the buffer for the
protID string for certain hosts.
