### PR TITLE
SMB1 Probing

### DIFF
--- a/lib/smb/smb/session.go
+++ b/lib/smb/smb/session.go
@@ -381,6 +381,7 @@ func (s *Session) send(req interface{}) (res []byte, err error) {
 	switch string(protID) {
 	default:
 		return nil, errors.New("Protocol Not Implemented")
+	case ProtocolSmb:
 	case ProtocolSmb2:
 	}
 

--- a/lib/smb/smb/zgrab.go
+++ b/lib/smb/smb/zgrab.go
@@ -221,11 +221,57 @@ func wstring(input []byte) string {
 	return string(utf16.Decode(u16))
 }
 
+// Temporary placeholder to detect SMB v1 by sending a simple v1
+// header with an invalid command; the response with be an error
+// code, but with a v1 ProtocolID
+// TODO: Parse the unmarshaled results.
+func (ls *LoggedSession) LoggedNegotiateProtocolv1(setup bool) error {
+	s := &ls.Session
+
+	negReq := s.NewNegotiateReqV1()
+	s.Debug("Sending LoggedNegotiateProtocolV1 request", nil)
+	buf, err := s.send(negReq)
+	if err != nil {
+		s.Debug("", err)
+		return err
+	}
+
+	logStruct := new(SMBLog)
+	ls.Log = logStruct
+
+	// s.send() will return error if buf size is < 4.
+	// Check the for the protocol identifier here, so that we at least
+	// log that this is an SMB1 server even if the full unmarshal fails.
+	if string(buf[0:4]) == ProtocolSmb {
+		ls.Log.SupportV1 = true
+		ls.Log.Version = &SMBVersions{Major: 1,
+			Minor:     0,
+			Revision:  0,
+			VerString: "SMB 1.0"}
+	} else {
+		return fmt.Errorf("Invalid v1 Protocol ID\n")
+	}
+
+	negRes := NegotiateResV1{}
+	// TODO: Unmarshal struct depends on the CIF dialect response field.
+	if err := encoder.Unmarshal(buf, &negRes); err != nil {
+		s.Debug("Raw:\n"+hex.Dump(buf), err)
+		// Not returning error here, because the NegotiationResV1 is
+		// only valid for the extended NT LM 0.12 dialect of SMB1.
+	}
+
+	// TODO: Parse capabilities and return those results
+
+	return nil
+}
+
 // LoggedNegotiateProtocol performs the same operations as
 // Session.NegotiateProtocol() up to the point where user credentials would be
 // required, and logs the server's responses.
 // If setup is false, stop after reading the response to Negotiate.
 // If setup is true, send a SessionSetup1 request.
+//
+// Note: This supports SMB2 only.
 func (ls *LoggedSession) LoggedNegotiateProtocol(setup bool) error {
 	s := &ls.Session
 	negReq := s.NewNegotiateReq()

--- a/lib/smb/smb/zgrab.go
+++ b/lib/smb/smb/zgrab.go
@@ -187,8 +187,9 @@ func fillHeaderLog(src *Header, dest *HeaderLog) *HeaderLog {
 	return dest
 }
 
-// GetSMBLog attempts to negotiate a SMB session on the given connection.
-func GetSMBLog(conn net.Conn, debug bool) (*SMBLog, error) {
+// GetSMBLog() determines the Protocol version and dialect, and optionally
+// negotiates a session.
+func GetSMBLog(conn net.Conn, session bool, debug bool) (smbLog *SMBLog, err error) {
 	opt := Options{}
 
 	s := &LoggedSession{
@@ -206,31 +207,7 @@ func GetSMBLog(conn net.Conn, debug bool) (*SMBLog, error) {
 		},
 	}
 
-	err := s.LoggedNegotiateProtocol(true)
-	return s.Log, err
-}
-
-// GetSMBBanner sends a single negotiate packet to the server to perform a scan
-// equivalent to the original ZGrab.
-func GetSMBBanner(conn net.Conn, debug bool) (*SMBLog, error) {
-	opt := Options{}
-
-	s := &LoggedSession{
-		Session: Session{
-			IsSigningRequired: false,
-			IsAuthenticated:   false,
-			debug:             debug,
-			securityMode:      0,
-			messageID:         0,
-			sessionID:         0,
-			dialect:           0,
-			conn:              conn,
-			options:           opt,
-			trees:             make(map[string]uint32),
-		},
-	}
-
-	err := s.LoggedNegotiateProtocol(false)
+	err = s.LoggedNegotiateProtocol(session)
 	return s.Log, err
 }
 

--- a/lib/smb/smb/zgrab.go
+++ b/lib/smb/smb/zgrab.go
@@ -189,7 +189,7 @@ func fillHeaderLog(src *Header, dest *HeaderLog) *HeaderLog {
 
 // GetSMBLog() determines the Protocol version and dialect, and optionally
 // negotiates a session.
-func GetSMBLog(conn net.Conn, session bool, debug bool) (smbLog *SMBLog, err error) {
+func GetSMBLog(conn net.Conn, session bool, v1 bool, debug bool) (smbLog *SMBLog, err error) {
 	opt := Options{}
 
 	s := &LoggedSession{
@@ -207,7 +207,11 @@ func GetSMBLog(conn net.Conn, session bool, debug bool) (smbLog *SMBLog, err err
 		},
 	}
 
-	err = s.LoggedNegotiateProtocol(session)
+	if v1 {
+		err = s.LoggedNegotiateProtocolv1(session)
+	} else {
+		err = s.LoggedNegotiateProtocol(session)
+	}
 	return s.Log, err
 }
 

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -111,11 +111,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	defer conn.Close()
 	var result *smb.SMBLog
-	if scanner.config.SetupSession {
-		result, err = smb.GetSMBLog(conn, scanner.config.Verbose)
-	} else {
-		result, err = smb.GetSMBBanner(conn, scanner.config.Verbose)
-	}
+	result, err = smb.GetSMBLog(conn, scanner.config.SetupSession, scanner.config.Verbose)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), result, err
 	}

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -111,9 +111,24 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	defer conn.Close()
 	var result *smb.SMBLog
-	result, err = smb.GetSMBLog(conn, scanner.config.SetupSession, scanner.config.Verbose)
+	setupSession := scanner.config.SetupSession
+	verbose := scanner.config.Verbose
+	result, err = smb.GetSMBLog(conn, setupSession, false, verbose)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), result, err
+		if result == nil {
+			conn.Close()
+			conn, err = target.Open(&scanner.config.BaseFlags)
+			if err != nil {
+				return zgrab2.TryGetScanStatus(err), nil, err
+			}
+			defer conn.Close()
+			result, err = smb.GetSMBLog(conn, setupSession, true, verbose)
+			if err != nil {
+				return zgrab2.TryGetScanStatus(err), result, err
+			}
+		} else {
+			return zgrab2.TryGetScanStatus(err), result, err
+		}
 	}
 	return zgrab2.SCAN_SUCCESS, result, nil
 }


### PR DESCRIPTION
There is currently no SMB1 support in the zgrab2's bundled libsmb.

This adds some rudimentary support to detect SMB1 servers, by implementing SMB1 header and SMB1 negotiation request messages.

While there is a negotiation response struct added as well, it currently is a placeholder to unmarshal into; future commits may implement unmarshal result parsing, and unmarshaling for each of the SMB1 dialects.