### PR TITLE
fixed bug for io.EOF  on fox moudle

### DIFF
--- a/modules/fox/fox.go
+++ b/modules/fox/fox.go
@@ -57,7 +57,7 @@ func GetFoxBanner(logStruct *FoxLog, connection net.Conn) error {
 	}
 
 	data, err := zgrab2.ReadAvailable(connection)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return err
 	}
 

--- a/modules/fox/fox.go
+++ b/modules/fox/fox.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"io"
 
 	"github.com/zmap/zgrab2"
 )


### PR DESCRIPTION
fox read with  io.EOF ,but the data  has been returned

## How to Test
testip 
113.3.143.142
37.221.240.149

