### PR TITLE
[CEN-1492] Update test.sh to work with Censys' zgrab2

### DIFF
--- a/integration_tests/redis/test.sh
+++ b/integration_tests/redis/test.sh
@@ -6,6 +6,17 @@ ZGRAB_ROOT=$MODULE_DIR/../..
 ZGRAB_OUTPUT=$ZGRAB_ROOT/zgrab-output
 CONTAINER_DIR="./integration_tests/redis/container"
 
+test_for_vendor() {
+    pwd | grep -q vendor
+}
+
+retval=0
+test_for_vendor || retval=$? && true
+if [ $retval -eq 0 ]
+then
+    CONTAINER_DIR="./vendor/github.com/zmap/zgrab2/integration_tests/redis/container"
+fi
+
 mkdir -p $ZGRAB_OUTPUT/redis
 
 echo "redis/test: Tests runner for redis"


### PR DESCRIPTION
Edited `integration_tests/redis/test.sh` to account for when it's being run from Censys' integration tests.

##  How to Test
`make integration-test TEST_MODULES=redis`

## Notes & Caveats
If you want to test on Censys' zgrab2, checkout `master`, cd into `vendor/zmap/zgrab2` and checkout `0f149b06b358797afa0bd3c2637e26a529100c90`. Then run `make integration-test TEST_MODULES=redis` from Censys' zgrab2 root directory.

## Issue Tracking
[[CEN-1492]](https://censysio.atlassian.net/browse/CEN-1492)
