### PR TITLE
fix schema in redis for nonexistent_response being required

### DIFF
--- a/zgrab2_schemas/zgrab2/redis.py
+++ b/zgrab2_schemas/zgrab2/redis.py
@@ -20,7 +20,7 @@ redis_scan_response = SubRecord({
             "(Error: NOAUTH Authentication required.)",
         ]),
         "auth_response": String(doc="The response from the AUTH command, if sent."),
-        "nonexistent_response": String("The response from the NONEXISTENT command.", examples=[
+        "nonexistent_response": String(doc="The response from the NONEXISTENT command.", examples=[
             "(Error: ERR unknown command 'NONEXISTENT')",
         ]),
         "quit_response": String(doc="The response to the QUIT command.", examples=["OK"]),


### PR DESCRIPTION
Fixes Small bug in the zschema for the Redis scanner, which made the field nonexistent_response required instead of nullable when generating BQ schema