### PR TITLE
Fix the formatting of IPv6 addresses

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -282,7 +283,11 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
 	ret.client.Timeout = scanner.config.Timeout
 	host := t.Domain
 	if host == "" {
-		host = t.IP.String()
+		if t.IP.To4() == nil {
+			host = fmt.Sprintf("[%s]", t.IP.String())
+		} else {
+			host = t.IP.String()
+		}
 	}
 	ret.url = getHTTPURL(scanner.config.UseHTTPS, host, uint16(scanner.config.BaseFlags.Port), scanner.config.Endpoint)
 

--- a/processing.go
+++ b/processing.go
@@ -47,6 +47,9 @@ func (target ScanTarget) String() string {
 // or the domain if not.
 func (target *ScanTarget) Host() string {
 	if target.IP != nil {
+		if target.IP.To4() == nil {
+			return fmt.Sprintf("[%s]", target.IP)
+		}
 		return target.IP.String()
 	} else if target.Domain != "" {
 		return target.Domain


### PR DESCRIPTION
This fixes `ScanTarget.Host()` and the `host == ""` check in the HTTP module to properly encode literal IPv6 addresses as per the [scan.Dial docs](https://golang.org/pkg/net/#Dial)

## How to Test

I'm working through the integration testing framework right now to figure out how to allow it to hit the IPv6 address of the `target` container
## Notes & Caveats

We use Zgrab2 and noticed consistent issues when targeting IPv6 addresses like:
```
dial tcp: lookup AAAA:BBBB:CCC:DDD:: no such host
parse http://AAAA:BBBB::CCCC:DDDD: invalid port ":DDDD" after host
```

According to the docs for [net.Dial](https://golang.org/pkg/net/#Dial) literal IPv6 addresses must be enclosed in square brackets as in "[2001:db8::1]:80" or "[fe80::1%zone]:80".

## Issue Tracking
N/A
