### PR TITLE
Add support for local network interfaces

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	logFile            *os.File
 	inputTargets       InputTargetsFunc
 	outputResults      OutputResultsFunc
+	localAddr          *net.TCPAddr
 }
 
 // SetInputFunc sets the target input function to the provided function.
@@ -60,6 +61,14 @@ func validateFrameworkConfiguration() {
 		log.SetOutput(config.logFile)
 	}
 	SetInputFunc(InputTargetsCSV)
+
+	if config.Interface != "" {
+		parsed := net.ParseIP(config.Interface)
+		if parsed == nil {
+			log.Fatalf("Error parsing local interface %s as IP\n", config.Interface)
+		}
+		config.localAddr = &net.TCPAddr{parsed, 0, ""}
+	}
 
 	if config.InputFileName == "-" {
 		config.inputFile = os.Stdin

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package zgrab2
 
 import (
+	"net"
 	"net/http"
 	"os"
 	"runtime"

--- a/conn.go
+++ b/conn.go
@@ -298,6 +298,11 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 	// ensure that our aux dialer is up-to-date; copied from http/transport.go
 	d.Dialer.Timeout = d.getTimeout(d.ConnectTimeout)
 	d.Dialer.KeepAlive = d.Timeout
+
+	if config.Interface != "" {
+		d.Dialer.LocalAddr = config.localAddr
+	}
+
 	dialContext, cancelDial := context.WithTimeout(ctx, d.Dialer.Timeout)
 	defer cancelDial()
 	conn, err := d.Dialer.DialContext(dialContext, network, address)


### PR DESCRIPTION
This PR adds support for specifying local network interfaces for HTTP requests.

## How to Test

Run zgrab2 with the flag "-i local_ip", where local_ip is a valid local IP address.
