### PR TITLE
Honor port override when composing URL

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -284,7 +284,14 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
 	if host == "" {
 		host = t.IP.String()
 	}
-	ret.url = getHTTPURL(scanner.config.UseHTTPS, host, uint16(scanner.config.BaseFlags.Port), scanner.config.Endpoint)
+	// Scanner Target port overrides config flag port
+	var port uint16
+	if t.Port != nil {
+		port = uint16(*t.Port)
+	} else {
+		port = uint16(scanner.config.BaseFlags.Port)
+	}
+	ret.url = getHTTPURL(scanner.config.UseHTTPS, host, port, scanner.config.Endpoint)
 
 	return &ret
 }

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -671,8 +671,15 @@ func (scanner *Scanner) newIPPScan(target *zgrab2.ScanTarget, tls bool) *scan {
 		// FIXME: Change this, since ipp uri's cannot contain an IP address. Still valid for HTTP
 		host = target.IP.String()
 	}
+	// Scanner Target port overrides config flag port
+	var port uint16
+	if target.Port != nil {
+		port = uint16(*target.Port)
+	} else {
+		port = uint16(scanner.config.BaseFlags.Port)
+	}
 	// FIXME: ?Should just use endpoint "/", since we get the same response as "/ipp" on CUPS??
-	newScan.url = getHTTPURL(tls, host, uint16(scanner.config.BaseFlags.Port), "/ipp")
+	newScan.url = getHTTPURL(tls, host, port, "/ipp")
 	return &newScan
 }
 


### PR DESCRIPTION
Commit a38194a added an optional port override as part of the
scan target.  The HTTP and IPP modules, however, still compose
the URL (and select http vs https) by ignoring the override.

This checks for the override, and if present uses the scan target
port.  Otherwise, it falls back to the config port.

## How to Test

### Verify existing behavior works (no regression):

A) `echo hostname | zgrab2 http --use-https -p 443`
B) `echo hostname | zgrab2 http --use-https`

Run `A` should end in success, and also grab the TLS cert.
Run `B` should end in error, as it attempted against the default port 80 (assuming of course https is not running on this port on the host).

### Verify new behavior

This is a bit trickier, you need a different framework other than `cmd/zgrab2` that initializes the module, and performs a scan.  However, if that is done, then if the `ScanTarget` contains a port number, it should override both the default and cmdline passes ports, and use the port specified in `ScanTarget`