### PR TITLE
make http(s) request connect to given ip

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -261,6 +261,11 @@ func getHTTPURL(https bool, host string, port uint16, endpoint string) string {
 
 // NewHTTPScan gets a new Scan instance for the given target
 func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
+	if scanner.config.UseHTTPS {
+		scanner.config.BaseFlags.Port = 443
+	} else {
+		scanner.config.BaseFlags.Port = 80
+	}
 	ret := scan{
 		scanner: scanner,
 		target:  t,
@@ -305,6 +310,10 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 	}
 	// TODO: Headers from input?
 	request.Header.Set("Accept", "*/*")
+	//request.RemoteAddr = scan.target.IP
+	if scan.target.IP != nil {
+		request.RemoteAddr = scan.target.IP.String()
+	}
 	resp, err := scan.client.Do(request)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
make http(s) request connect to given ip

## How to Test

run a port listener: `socat tcp-l:80 -`
run the go run command `echo 127.0.0.1,www.google.com | go run main.go http`, if listener got like following, then it fixed

```
GET / HTTP/1.1
Host: www.google.com
User-Agent: Mozilla/5.0 zgrab/0.x
Accept: */*
Accept-Encoding: gzip
```

## Notes & Caveats

these code didn't alter core code but just add a little compatible for this issue.

## Issue Tracking

https://github.com/zmap/zgrab2/issues/234
