### PR TITLE
Use host header, and always connect to IP

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -280,9 +280,9 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget) *scan {
 	ret.client.Transport = ret.transport
 	ret.client.Jar = nil // Don't send or receive cookies (otherwise use CookieJar)
 	ret.client.Timeout = scanner.config.Timeout
-	host := t.Domain
-	if host == "" {
-		host = t.IP.String()
+	host := t.IP.String()
+	if t.IP == nil {
+		host = t.Domain
 	}
 	// Scanner Target port overrides config flag port
 	var port uint16
@@ -305,6 +305,9 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 	}
 	// TODO: Headers from input?
 	request.Header.Set("Accept", "*/*")
+	if scan.target.Domain != "" {
+		request.Host = scan.target.Domain
+	}
 	resp, err := scan.client.Do(request)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
This is an alternate approach to PR #240 and PR #239, that forces use of the host header, while always preferring the IP address for the host.

The only drawback is when zgrab2 is populating the HTTP Request, the ip address will be used as the host in the URL.  Whether or not this is important will depend on what is parsing the results, I think.  
 
According to the go documentation, overwriting the Request.Host field is supported and will be honored when executing:

From https://golang.org/src/net/http/request.go?#L233:
```go
    // For client requests, Host optionally overrides the Host
    // header to send. If empty, the Request.Write method uses
    // the value of URL.Host. Host may contain an international
    // domain name.
    Host string
```

## How to Test

```
echo 172.217.9.78,google.com | ./zgrab2 http --port 443 --use-https
```
This should return valid results.  Replace the IP address with something like 127.0.0.1:
```
echo 127.0.0.1,google.com | ./zgrab2 http --port 443 --use-https
```
Assuming no web server is running there, it will return a failure.

## Notes & Caveats

The HTTP Request struct will have the ip address in the URL field, instead of the domain name.
If we make proxy requests in the future, the absolute-uri will not contain the domain name, and we may want something like the FakeResolver from PR #240.