### PR TITLE
add option to stop scanning host after first successful protocol

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ func SetOutputFunc(f OutputResultsFunc) {
 
 func init() {
 	config.Multiple.ContinueOnError = true // set default for multiple value
+	config.Multiple.BreakOnSuccess = false // set default for multiple value
 }
 
 var config Config

--- a/multiple.go
+++ b/multiple.go
@@ -6,6 +6,7 @@ import "errors"
 type MultipleCommand struct {
 	ConfigFileName  string `short:"c" long:"config-file" default:"-" description:"Config filename, use - for stdin"`
 	ContinueOnError bool   `long:"continue-on-error" description:"If proceeding protocols error, do not run following protocols (default: true)"`
+	BreakOnSuccess  bool   `long:"break-on-success" description:"If proceeding protocols succeed, do not run following protocols (default: false)"`
 }
 
 // Validate the options sent to MultipleCommand

--- a/processing.go
+++ b/processing.go
@@ -135,6 +135,9 @@ func grabTarget(input ScanTarget, m *Monitor) []byte {
 		if res.Error != nil && !config.Multiple.ContinueOnError {
 			break
 		}
+		if res.Status == SCAN_SUCCESS && config.Multiple.BreakOnSuccess {
+			break
+		}
 	}
 
 	var ipstr string


### PR DESCRIPTION
Sometimes we don't know for sure, what protocol is running on some port and we want to try all supported protocols until first success. Then we can create ini file for multiple mode with the same port in all protocols, e.g.:

```ini
...
[http]
port=80
[ssh]
port=80
[ftp]
port=80
...
```

But even though http probe will probably succeed, all other specified protocols will be still tried also wasting time. For such situations it would be nice to have an option to break after first successful protocol.

So `break-on-success` option support is added.

## How to Test

Run multiple mode with `break-on-success` option with e.g. all supported protocols on port 80 (as in example above) for some http host e.g. icanhazip.com. Make sure no protocols are probed after successful http.

## Notes & Caveats

Unfortunetly we can't specify order for protocol probes for now, as zflags doesn't preserve ini sections order (at least in release mode). For descripted situations it would be nice to make sure that protocol probes are ordered by protocol probability estimation descending. See [my companion PR to zflags](https://github.com/zmap/zflags/pull/14)
