### PR TITLE
Add option to flush output after each line of output

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	LocalAddress       string          `long:"source-ip" description:"Local source IP address to use for making connections"`
 	Senders            int             `short:"s" long:"senders" default:"1000" description:"Number of send goroutines to use"`
 	Debug              bool            `long:"debug" description:"Include debug fields in the output."`
+	Flush              bool            `long:"flush" description:"Flush after each line of output."`
 	GOMAXPROCS         int             `long:"gomaxprocs" default:"0" description:"Set GOMAXPROCS"`
 	ConnectionsPerHost int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	ReadLimitPerHost   int             `long:"read-limit-per-host" default:"96" description:"Maximum total kilobytes to read for a single host (default 96kb)"`

--- a/output.go
+++ b/output.go
@@ -145,6 +145,9 @@ func OutputResultsFile(results <-chan []byte) error {
 		if err := out.WriteByte('\n'); err != nil {
 			return err
 		}
+		if config.Flush {
+			out.Flush()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds an option to flush output after each line of output. This may be desirable in streaming applications, where a program continually ingests zgrab2's output.

## How to Test

Run zgrab2 with the flag `--flush`. Observe that the output will be flushed after each line, rather than at the end.