### PR TITLE
wip: bug: use source address for real

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	InputFileName      string          `short:"f" long:"input-file" default:"-" description:"Input filename, use - for stdin"`
 	MetaFileName       string          `short:"m" long:"metadata-file" default:"-" description:"Metadata filename, use - for stderr"`
 	LogFileName        string          `short:"l" long:"log-file" default:"-" description:"Log filename, use - for stderr"`
-	LocalAddress       string          `long:"source-ip" description:"Local source IP address to use for making connections"`
 	Senders            int             `short:"s" long:"senders" default:"1000" description:"Number of send goroutines to use"`
 	Debug              bool            `long:"debug" description:"Include debug fields in the output."`
 	GOMAXPROCS         int             `long:"gomaxprocs" default:"0" description:"Set GOMAXPROCS"`
@@ -31,7 +30,7 @@ type Config struct {
 	logFile            *os.File
 	inputTargets       InputTargetsFunc
 	outputResults      OutputResultsFunc
-	localAddr          *net.TCPAddr
+	sourceIPs          []net.IP
 }
 
 // SetInputFunc sets the target input function to the provided function.
@@ -64,14 +63,6 @@ func validateFrameworkConfiguration() {
 	}
 	SetInputFunc(InputTargetsCSV)
 
-	if config.LocalAddress != "" {
-		parsed := net.ParseIP(config.LocalAddress)
-		if parsed == nil {
-			log.Fatalf("Error parsing local interface %s as IP", config.LocalAddress)
-		}
-		config.localAddr = &net.TCPAddr{parsed, 0, ""}
-	}
-
 	if config.InputFileName == "-" {
 		config.inputFile = os.Stdin
 	} else {
@@ -102,7 +93,7 @@ func validateFrameworkConfiguration() {
 
 	// Validate Go Runtime config
 	if config.GOMAXPROCS < 0 {
-		log.Fatal("invalid GOMAXPROCS (must be positive, given %d)", config.GOMAXPROCS)
+		log.Fatalf("invalid GOMAXPROCS (must be positive, given %d)", config.GOMAXPROCS)
 	}
 	runtime.GOMAXPROCS(config.GOMAXPROCS)
 
@@ -135,6 +126,8 @@ func validateFrameworkConfiguration() {
 	if config.ReadLimitPerHost > 0 {
 		DefaultBytesReadLimit = config.ReadLimitPerHost * 1024
 	}
+
+	// Set up source IPs
 }
 
 // GetMetaFile returns the file to which metadata should be output

--- a/module.go
+++ b/module.go
@@ -1,6 +1,10 @@
 package zgrab2
 
-import "time"
+import (
+	"math/rand"
+	"net"
+	"time"
+)
 
 // Scanner is an interface that represents all functions necessary to run a scan
 type Scanner interface {
@@ -63,17 +67,46 @@ type ScanFlags interface {
 
 // BaseFlags contains the options that every flags type must embed
 type BaseFlags struct {
-	Port           uint          `short:"p" long:"port" description:"Specify port to grab on"`
-	Name           string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
-	Timeout        time.Duration `short:"t" long:"timeout" description:"Set connection timeout (0 = no timeout)" default:"10s"`
-	Trigger        string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
-	BytesReadLimit int           `short:"m" long:"maxbytes" description:"Maximum byte read limit per scan (0 = defaults)"`
+	Port            uint          `short:"p" long:"port" description:"Specify port to grab on"`
+	Name            string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
+	Timeout         time.Duration `short:"t" long:"timeout" description:"Set connection timeout (0 = no timeout)" default:"10s"`
+	Trigger         string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
+	BytesReadLimit  int           `short:"m" long:"maxbytes" description:"Maximum byte read limit per scan (0 = defaults)"`
+	SourceIPv4Range string        `long:"source-ip" description:"Local source IP address to use for making connections (IPv4 only)"`
+	sourceIPs       []net.IP
 }
 
 // UDPFlags contains the common options used for all UDP scans
 type UDPFlags struct {
 	LocalPort    uint   `long:"local-port" description:"Set an explicit local port for UDP traffic"`
 	LocalAddress string `long:"local-addr" description:"Set an explicit local address for UDP traffic"`
+}
+
+// AfterParse is called after the flags are parsed by the module, to perform
+// additional verification or initialization.
+func (b *BaseFlags) AfterParse() error {
+	if b.SourceIPv4Range != "" {
+		ips, err := ParseIPv4RangeString(b.SourceIPv4Range)
+		if err != nil {
+			return err
+		}
+		b.sourceIPs = ips
+	}
+	return nil
+}
+
+// GetRandomSourceIP (non-cryptographically) randomly selects an IP from its set
+// of source IPs. If no source IPs were specified, this function returns nil.
+func (b *BaseFlags) GetRandomSourceIP() net.IP {
+	sourceIPCount := len(b.sourceIPs)
+	if sourceIPCount == 0 {
+		return nil
+	}
+	if sourceIPCount == 1 {
+		return b.sourceIPs[0]
+	}
+	idx := rand.Intn(sourceIPCount)
+	return b.sourceIPs[idx]
 }
 
 // GetName returns the name of the respective scanner

--- a/processing.go
+++ b/processing.go
@@ -64,9 +64,9 @@ func (target *ScanTarget) Open(flags *BaseFlags) (net.Conn, error) {
 	} else {
 		port = flags.Port
 	}
-
 	address := net.JoinHostPort(target.Host(), fmt.Sprintf("%d", port))
-	return DialTimeoutConnection("tcp", address, flags.Timeout, flags.BytesReadLimit)
+	sourceIP := flags.GetRandomSourceIP()
+	return DialTimeoutConnection("tcp", address, flags.Timeout, flags.BytesReadLimit, sourceIP)
 }
 
 // OpenTLS connects to the ScanTarget using the configured flags, then performs

--- a/utility_test.go
+++ b/utility_test.go
@@ -1,0 +1,107 @@
+package zgrab2
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+type ipRangeTest struct {
+	input             string
+	output            []net.IP
+	outputErrorString string
+}
+
+func TestParseSourceIPRange(t *testing.T) {
+	tests := []ipRangeTest{
+		ipRangeTest{
+			input:  "192.168.1.10",
+			output: []net.IP{net.ParseIP("192.168.1.10")},
+		},
+		ipRangeTest{
+			input:             "blah192.168.1.10",
+			outputErrorString: "invalid starting source",
+		},
+		ipRangeTest{
+			input:             "192.168.1.10blah   ",
+			outputErrorString: "invalid starting source",
+		},
+		ipRangeTest{
+			input:             "192.168.1.10 -   ",
+			outputErrorString: "invalid ending source",
+		},
+		ipRangeTest{
+			input:             "192.168.1.10 - blah   ",
+			outputErrorString: "invalid ending source",
+		},
+		ipRangeTest{
+			input:  "     192.168.1.10   ",
+			output: []net.IP{net.ParseIP("192.168.1.10")},
+		},
+		ipRangeTest{
+			input:  "     192.168.1.10",
+			output: []net.IP{net.ParseIP("192.168.1.10")},
+		},
+		ipRangeTest{
+			input:  "192.168.1.10-192.168.1.12",
+			output: []net.IP{net.ParseIP("192.168.1.10"), net.ParseIP("192.168.1.11"), net.ParseIP("192.168.1.12")},
+		},
+		ipRangeTest{
+			input:  "    192.168.1.10-     192.168.1.12   ",
+			output: []net.IP{net.ParseIP("192.168.1.10"), net.ParseIP("192.168.1.11"), net.ParseIP("192.168.1.12")},
+		},
+		ipRangeTest{
+			input:  "    192.168.1.10   -192.168.1.12   ",
+			output: []net.IP{net.ParseIP("192.168.1.10"), net.ParseIP("192.168.1.11"), net.ParseIP("192.168.1.12")},
+		},
+		ipRangeTest{
+			input:  "    192.168.1.10   -    192.168.1.12   ",
+			output: []net.IP{net.ParseIP("192.168.1.10"), net.ParseIP("192.168.1.11"), net.ParseIP("192.168.1.12")},
+		},
+		ipRangeTest{
+			input:             "2607:f8b0:4009:80c::200e",
+			outputErrorString: "got a v6 address",
+		},
+		ipRangeTest{
+			input:             "2607:f8b0:4009:80c::200e - ",
+			outputErrorString: "got a v6 address",
+		},
+		ipRangeTest{
+			input:             "2607:f8b0:4009:80c::200e - 2607:f8b0:4009:80c::200f",
+			outputErrorString: "got a v6 address",
+		},
+		ipRangeTest{
+			input:             "   2607:f8b0:4009:80c::200e    ",
+			outputErrorString: "got a v6 address",
+		},
+	}
+	for idx, test := range tests {
+		ips, err := ParseIPv4RangeString(test.input)
+		if err != nil && test.outputErrorString == "" {
+			t.Logf("test input: %v", test)
+			t.Errorf("got unexpected error on test at index %d: %s", idx, err.Error())
+			continue
+		}
+		if err != nil && test.outputErrorString != "" {
+			if !strings.Contains(err.Error(), test.outputErrorString) {
+				t.Logf("test input: %v", test)
+				t.Errorf("got unexpected error on test at index %d: got %s, wanted %s", idx, err.Error(), test.outputErrorString)
+			}
+			continue
+		}
+		t.Logf("test %d input: %v", idx, test)
+		t.Logf("test %d output: %v", idx, ips)
+		if len(ips) != len(test.output) {
+			t.Errorf("mismatched output lengths: got %d, wanted %d", len(ips), len(test.output))
+			continue
+		}
+		for idx := range test.output {
+			if test.output[idx] == nil {
+				t.Fatalf("invalid test")
+			}
+			if ips[idx].String() != test.output[idx].String() {
+				t.Errorf("output index %d: got %s, expected %s", idx, ips[idx], test.output[idx])
+			}
+		}
+	}
+}


### PR DESCRIPTION
The root issue is `--source-ip` is not respected.

I updated the CLI parsing code to handle source IP ranges, similar to how we handle them in ZMap. In an ideal world, this would work with ranges and CIDRs for IPv4 and IPv6. I only implemented small ranges for IPv4, to make my life easier.

The tricky part is actually getting ZGrab2 to use one of the addresses.

For starters, the config state is global-ish, so I'm wary of just reading into `config.go:config`, since if ZGrab is imported as a library, who knows what would happen.

So I hooked source IP as optional into BaseFlags, which means you would be able to specify it on a per-scan-module basis. This would probably mostly work if I can get `BaseFlags::AfterParse` wired up correctly. Unfortunately, not all connections in ZGrab2 use the `ScanTarget::Open(BaseFlags)` API. Some use a different custom `Dialer`, from `dialer.go` in ZGrab2, to set timeouts. These don't have access to base flags.

The proper fix is probably to explicitly expose a custom dialer to each ZGrab scan module. This dialer should be prepopulated based on a non-global set of settings passed as either CLI args to ZGrab, args to the specific scan module, or as structs in code using this as a library. This is vague and complicated enough I'm not even sure what I said makes sense to anyone except me.

@codyprime, any ideas on how to not refactor everything here?

## How to Test

On the plus side, lots of tests for the CLI parsing!

## Notes & Caveats

_If necessary, explain the motivation for this PR, and note any caveats that apply to your changes or future work that will be needed._ 

## Issue Tracking

_Add a link to the relevant GitHub issue(s) if the pull request resolves it._
