### PR TITLE
Add ModuleSet object

### DIFF
--- a/bin/default_modules.go
+++ b/bin/default_modules.go
@@ -1,0 +1,65 @@
+package bin
+
+import (
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules"
+	"github.com/zmap/zgrab2/modules/bacnet"
+	"github.com/zmap/zgrab2/modules/banner"
+	"github.com/zmap/zgrab2/modules/dnp3"
+	"github.com/zmap/zgrab2/modules/fox"
+	"github.com/zmap/zgrab2/modules/ftp"
+	"github.com/zmap/zgrab2/modules/http"
+	"github.com/zmap/zgrab2/modules/imap"
+	"github.com/zmap/zgrab2/modules/ipp"
+	"github.com/zmap/zgrab2/modules/modbus"
+	"github.com/zmap/zgrab2/modules/mongodb"
+	"github.com/zmap/zgrab2/modules/mssql"
+	"github.com/zmap/zgrab2/modules/mysql"
+	"github.com/zmap/zgrab2/modules/ntp"
+	"github.com/zmap/zgrab2/modules/oracle"
+	"github.com/zmap/zgrab2/modules/pop3"
+	"github.com/zmap/zgrab2/modules/postgres"
+	"github.com/zmap/zgrab2/modules/redis"
+	"github.com/zmap/zgrab2/modules/siemens"
+	"github.com/zmap/zgrab2/modules/smb"
+	"github.com/zmap/zgrab2/modules/smtp"
+	"github.com/zmap/zgrab2/modules/telnet"
+)
+
+var defaultModules zgrab2.ModuleSet
+
+func init() {
+	defaultModules = map[string]zgrab2.ScanModule{
+		"bacnet":   &bacnet.Module{},
+		"banner":   &banner.Module{},
+		"dnp3":     &dnp3.Module{},
+		"fox":      &fox.Module{},
+		"ftp":      &ftp.Module{},
+		"http":     &http.Module{},
+		"imap":     &imap.Module{},
+		"ipp":      &ipp.Module{},
+		"modbus":   &modbus.Module{},
+		"mongodb":  &mongodb.Module{},
+		"mssql":    &mssql.Module{},
+		"mysql":    &mysql.Module{},
+		"ntp":      &ntp.Module{},
+		"oracle":   &oracle.Module{},
+		"pop3":     &pop3.Module{},
+		"postgres": &postgres.Module{},
+		"redis":    &redis.Module{},
+		"siemens":  &siemens.Module{},
+		"smb":      &smb.Module{},
+		"smtp":     &smtp.Module{},
+		"ssh":      &modules.SSHModule{},
+		"telnet":   &telnet.Module{},
+		"tls":      &modules.TLSModule{},
+	}
+}
+
+// NewModuleSetWithDefaults returns a newly allocated ModuleSet containing all
+// ScanModules implemented by the ZGrab2 framework.
+func NewModuleSetWithDefaults() zgrab2.ModuleSet {
+	out := zgrab2.ModuleSet{}
+	defaultModules.CopyInto(out)
+	return out
+}

--- a/bin/doc.go
+++ b/bin/doc.go
@@ -1,0 +1,6 @@
+// Package bin contains functions useful for creating a binary version of
+// ZGrab2.
+//
+// This package can import "github.com/zmap/zgrab2", and should be imported by
+// targets within "github.com/zmap/zgrab2/cmd"
+package bin

--- a/module_set.go
+++ b/module_set.go
@@ -1,0 +1,30 @@
+package zgrab2
+
+// ModuleSet is a container holding named scan modules. It is a wrapper around a
+// map.
+type ModuleSet map[string]ScanModule
+
+// AddModule adds m to the ModuleSet, accessible via the given name. If the name
+// is already in the ModuleSet, it is overwritten.
+func (s ModuleSet) AddModule(name string, m ScanModule) {
+	s[name] = m
+}
+
+// RemoveModule removes the module at the specified name. If the name is not in
+// the module set, nothing happens.
+func (s ModuleSet) RemoveModule(name string) {
+	delete(s, name)
+}
+
+// CopyInto copies the modules in s to destination. The sets will be unique, but
+// the underlying ScanModule instances will be the same.
+func (s ModuleSet) CopyInto(destination ModuleSet) {
+	for name, m := range s {
+		destination[name] = m
+	}
+}
+
+// NewModuleSet returns an empty ModuleSet.
+func NewModuleSet() ModuleSet {
+	return make(ModuleSet)
+}


### PR DESCRIPTION
Eventually this can be used to replace AddCommand, allowing the use of a
non-global config object.

## How to Test

_Add brief instructions on how to test your changes._

## Notes & Caveats

_If necessary, explain the motivation for this PR, and note any caveats that apply to your changes or future work that will be needed._ 

## Issue Tracking

_Add a link to the relevant GitHub issue(s) if the pull request resolves it._
