### PR TITLE
Add Description() to ScanModule

### DIFF
--- a/module.go
+++ b/module.go
@@ -48,6 +48,10 @@ type ScanModule interface {
 	// NewScanner is called by the framework for each time an individual scan is specified in the config or on
 	// the command-line. The framework will then call scanner.Init(name, flags).
 	NewScanner() Scanner
+
+	// Description returns a string suitable for use as an overview of this
+	// module within usage text.
+	Description() string
 }
 
 // ScanFlags is an interface which must be implemented by all types sent to

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -32,7 +32,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("bacnet", "bacnet", "Probe for bacnet", 0xBAC0, &module)
+	_, err := zgrab2.AddCommand("bacnet", "bacnet", module.Description(), 0xBAC0, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,6 +46,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns text uses in the help for this module.
+func (module *Module) Description() string {
+	return "Probe for devices that speak Bacnet, commonly used for HVAC control."
 }
 
 // Validate checks that the flags are valid.

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -42,7 +42,7 @@ type Results struct {
 // RegisterModule is called by modules/banner.go to register the scanner.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("banner", "Banner", "Grab banner by sending probe and match with regexp", 80, &module)
+	_, err := zgrab2.AddCommand("banner", "Banner", module.Description(), 80, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -81,6 +81,11 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 // Validate validates the flags and returns nil on success.
 func (f *Flags) Validate(args []string) error {
 	return nil
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Fetch a raw banner by sending a static probe and checking the result against a regular expression"
 }
 
 // Help returns the module's help string.

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -30,7 +30,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("dnp3", "dnp3", "Probe for dnp3", 20000, &module)
+	_, err := zgrab2.AddCommand("dnp3", "dnp3", module.Description(), 20000, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -44,6 +44,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Probe for DNP3, a SCADA protocol"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -30,7 +30,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("fox", "fox", "Probe for Tridium Fox", 1911, &module)
+	_, err := zgrab2.AddCommand("fox", "fox", module.Description(), 1911, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -44,6 +44,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Probe for Tridium Fox"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -71,7 +71,7 @@ type Connection struct {
 // RegisterModule registers the ftp zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("ftp", "FTP", "Grab an FTP banner", 21, &module)
+	_, err := zgrab2.AddCommand("ftp", "FTP", module.Description(), 21, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -86,6 +86,11 @@ func (m *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (m *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (m *Module) Description() string {
+	return "Grab an FTP banner"
 }
 
 // Validate does nothing in this module.

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -98,6 +98,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
 }
 
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Send an HTTP request and read the response, optionally following redirects."
+}
+
 // Validate performs any needed validation on the arguments
 func (flags *Flags) Validate(args []string) error {
 	return nil
@@ -401,7 +406,7 @@ func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{
 func RegisterModule() {
 	var module Module
 
-	_, err := zgrab2.AddCommand("http", "HTTP Banner Grab", "Grab a banner over HTTP", 80, &module)
+	_, err := zgrab2.AddCommand("http", "HTTP Banner Grab", module.Description(), 80, &module)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -25,9 +25,10 @@ package imap
 import (
 	"fmt"
 
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"strings"
 )
 
 // ScanResults instances are returned by the module's Scan function.
@@ -76,7 +77,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("imap", "imap", "Probe for IMAP", 143, &module)
+	_, err := zgrab2.AddCommand("imap", "imap", module.Description(), 143, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -90,6 +91,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Fetch an IMAP banner, optionally over TLS"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -52,7 +52,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("modbus", "modbus", "Probe for modbus", 502, &module)
+	_, err := zgrab2.AddCommand("modbus", "modbus", module.Description(), 502, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,6 +66,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Probe for Modbus devices, usually PLCs as part of a SCADA system"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -12,9 +12,10 @@
 package mssql
 
 import (
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"strings"
 )
 
 // ScanResults contains detailed information about each step of the
@@ -66,6 +67,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Perform a handshake for MSSQL databases"
 }
 
 // Validate does nothing in this module.
@@ -172,7 +178,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 // RegisterModule is called by modules/mssql.go's init()
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("mssql", "MSSQL", "Grab a mssql handshake", 1433, &module)
+	_, err := zgrab2.AddCommand("mssql", "MSSQL", module.Description(), 1433, &module)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -149,7 +149,7 @@ type Scanner struct {
 // RegisterModule is called by modules/mysql.go to register the scanner.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("mysql", "MySQL", "Grab a MySQL handshake", 3306, &module)
+	_, err := zgrab2.AddCommand("mysql", "MySQL", module.Description(), 3306, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -163,6 +163,11 @@ func (m *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner object.
 func (m *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (m *Module) Description() string {
+	return "Perform a handshake with a MySQL database"
 }
 
 // Validate validates the flags and returns nil on success.

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -815,7 +815,7 @@ type Scanner struct {
 // RegisterModule registers the module with zgrab2
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("ntp", "NTP", "Scan for NTP", 123, &module)
+	_, err := zgrab2.AddCommand("ntp", "NTP", module.Description(), 123, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -829,6 +829,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new NTP scanner instance
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Scan for NTP"
 }
 
 // Validate checks that the flags are valid

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -106,7 +106,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("oracle", "oracle", "Probe for oracle", 1521, &module)
+	_, err := zgrab2.AddCommand("oracle", "oracle", module.Description(), 1521, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -120,6 +120,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Perform a handshake with Oracle database servers"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -28,9 +28,10 @@ package pop3
 import (
 	"fmt"
 
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"strings"
 )
 
 // ScanResults instances are returned by the module's Scan function.
@@ -91,7 +92,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("pop3", "pop3", "Probe for pop3", 110, &module)
+	_, err := zgrab2.AddCommand("pop3", "pop3", module.Description(), 110, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -105,6 +106,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Fetch POP3 banners, optionally over TLS"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 )
@@ -279,6 +280,11 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
 }
 
+// Description returns an overview of this module.
+func (m *Module) Description() string {
+	return "Perform a handshake with a PostgreSQL server"
+}
+
 // Validate checks the arguments; on success, returns nil.
 func (f *Flags) Validate(args []string) error {
 	return nil
@@ -533,7 +539,7 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 // the postgres module with the zgrab2 framework.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("postgres", "Postgres", "Grab a Postgres handshake", 5432, &module)
+	_, err := zgrab2.AddCommand("postgres", "Postgres", module.Description(), 5432, &module)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -159,7 +159,7 @@ type Result struct {
 // RegisterModule registers the zgrab2 module
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("redis", "redis", "Probe for redis", 6379, &module)
+	_, err := zgrab2.AddCommand("redis", "redis", module.Description(), 6379, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -173,6 +173,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner provides a new scanner instance
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Probe for Redis"
 }
 
 // Validate checks that the flags are valid

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -4,9 +4,10 @@
 package siemens
 
 import (
+	"net"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
-	"net"
 )
 
 // Flags holds the command-line configuration for the siemens scan module.
@@ -29,7 +30,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("siemens", "siemens", "Probe for Siemens S7", 102, &module)
+	_, err := zgrab2.AddCommand("siemens", "siemens", module.Description(), 102, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -43,6 +44,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Probe for Siemens S7 devices"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -32,7 +32,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("smb", "smb", "Probe for smb", 445, &module)
+	_, err := zgrab2.AddCommand("smb", "smb", module.Description(), 445, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -46,6 +46,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Probe for SMB servers (Windows filesharing / SAMBA)"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -108,7 +108,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("smtp", "smtp", "Probe for smtp", 25, &module)
+	_, err := zgrab2.AddCommand("smtp", "smtp", module.Description(), 25, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -122,6 +122,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Fetch an SMTP server banner, optionally over TLS"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -33,7 +33,7 @@ type SSHScanner struct {
 
 func init() {
 	var sshModule SSHModule
-	cmd, err := zgrab2.AddCommand("ssh", "SSH Banner Grab", "Grab a banner over SSH", 22, &sshModule)
+	cmd, err := zgrab2.AddCommand("ssh", "SSH Banner Grab", sshModule.Description(), 22, &sshModule)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -49,6 +49,11 @@ func (m *SSHModule) NewFlags() interface{} {
 
 func (m *SSHModule) NewScanner() zgrab2.Scanner {
 	return new(SSHScanner)
+}
+
+// Description returns an overview of this module.
+func (m *SSHModule) Description() string {
+	return "Fetch an SSH server banner and collect key exchange information"
 }
 
 func (f *SSHFlags) Validate(args []string) error {

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -36,7 +36,7 @@ type Scanner struct {
 // RegisterModule registers the zgrab2 module.
 func RegisterModule() {
 	var module Module
-	_, err := zgrab2.AddCommand("telnet", "telnet", "Probe for telnet", 23, &module)
+	_, err := zgrab2.AddCommand("telnet", "telnet", module.Description(), 23, &module)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -50,6 +50,11 @@ func (module *Module) NewFlags() interface{} {
 // NewScanner returns a new Scanner instance.
 func (module *Module) NewScanner() zgrab2.Scanner {
 	return new(Scanner)
+}
+
+// Description returns an overview of this module.
+func (module *Module) Description() string {
+	return "Fetch a telnet banner"
 }
 
 // Validate checks that the flags are valid.

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -19,7 +19,7 @@ type TLSScanner struct {
 
 func init() {
 	var tlsModule TLSModule
-	_, err := zgrab2.AddCommand("tls", "TLS Banner Grab", "Grab banner over TLS", 443, &tlsModule)
+	_, err := zgrab2.AddCommand("tls", "TLS Banner Grab", tlsModule.Description(), 443, &tlsModule)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -31,6 +31,11 @@ func (m *TLSModule) NewFlags() interface{} {
 
 func (m *TLSModule) NewScanner() zgrab2.Scanner {
 	return new(TLSScanner)
+}
+
+// Description returns an overview of this module.
+func (m *TLSModule) Description() string {
+	return "Perform a TLS handshake"
 }
 
 func (f *TLSFlags) Validate(args []string) error {


### PR DESCRIPTION
This abstracts more of the help text into the ScanModule definition,
removing some more of the need for `zgrab2.AddCommand()`

## How to Test

`zgrab2 help`