### PR TITLE
Remove reference to global config in monitor.go

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -132,7 +132,7 @@ func ZGrab2Main() {
 		s.Init(flag)
 		zgrab2.RegisterScan(moduleType, s)
 	}
-	monitor := zgrab2.MakeMonitor()
+	monitor := zgrab2.MakeMonitor(1)
 	monitor.Callback = func(_ string) {
 		dumpHeapProfile()
 	}

--- a/monitor.go
+++ b/monitor.go
@@ -6,7 +6,7 @@ type Monitor struct {
 	states       map[string]*State
 	statusesChan chan moduleStatus
 	// Callback is invoked after each scan.
-	Callback     func(string)
+	Callback func(string)
 }
 
 // State contains the respective number of successes and failures
@@ -36,9 +36,9 @@ func (m *Monitor) GetStatuses() map[string]*State {
 
 // MakeMonitor returns a Monitor object that can be used to collect and send
 // the status of a running scan
-func MakeMonitor() *Monitor {
+func MakeMonitor(statusChanSize int) *Monitor {
 	m := new(Monitor)
-	m.statusesChan = make(chan moduleStatus, config.Senders*4)
+	m.statusesChan = make(chan moduleStatus, statusChanSize)
 	m.states = make(map[string]*State, 10)
 	go func() {
 		for s := range m.statusesChan {

--- a/monitor.go
+++ b/monitor.go
@@ -1,5 +1,7 @@
 package zgrab2
 
+import "sync"
+
 // Monitor is a collection of states per scans and a channel to communicate
 // those scans to the monitor
 type Monitor struct {
@@ -34,13 +36,22 @@ func (m *Monitor) GetStatuses() map[string]*State {
 	return m.states
 }
 
+// Stop indicates the monitor is done and the internal channel should be closed.
+// This function does not block, but will allow a call to Wait() on the
+// WaitGroup passed to MakeMonitor to return.
+func (m *Monitor) Stop() {
+	close(m.statusesChan)
+}
+
 // MakeMonitor returns a Monitor object that can be used to collect and send
 // the status of a running scan
-func MakeMonitor(statusChanSize int) *Monitor {
+func MakeMonitor(statusChanSize int, wg *sync.WaitGroup) *Monitor {
 	m := new(Monitor)
 	m.statusesChan = make(chan moduleStatus, statusChanSize)
 	m.states = make(map[string]*State, 10)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for s := range m.statusesChan {
 			if m.states[s.name] == nil {
 				m.states[s.name] = new(State)


### PR DESCRIPTION
This updates MakeMonitor() to take the channel size as a parameter,
instead of reading it from the global `config` object. Unfortunately,
the caller of MakeMonitor() doesn't actually have access to the global,
since it's in a different package (bin vs the root package). Luckily,
there doesn't appear to be a reason to have a buffer in this channel.
This updates the caller to pass a hardcoded size of 1.

## Notes & Caveats

@codyprime what do you think about channel size here?