### PR TITLE
modules/http: Add option to suppress errors when max redirects exceeded

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -53,6 +53,9 @@ type Flags struct {
 	// UseHTTPS causes the first request to be over TLS, without requiring a
 	// redirect to HTTPS. It does not change the port used for the connection.
 	UseHTTPS bool `long:"use-https" description:"Perform an HTTPS connection on the initial host"`
+
+	// RedirectsSucceed causes the ErrTooManRedirects error to be suppressed
+	RedirectsSucceed bool `long:"redirects-succeed" description:"Redirects are always a success, even if max-redirects is exceeded"`
 }
 
 // A Results object is returned by the HTTP module's Scanner.Scan()
@@ -354,6 +357,9 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 		case ErrRedirLocalhost:
 			break
 		case ErrTooManyRedirects:
+			if scan.scanner.config.RedirectsSucceed {
+				return nil
+			}
 			return zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, err)
 		default:
 			return zgrab2.DetectScanError(err)


### PR DESCRIPTION
If the `--max-redirects` value is exceeded, we return `SCAN_APPLICATION_ERROR` with "Too many redirect" as the error message.

Add an option (`--redirects-succeed`) to suppress this error, and return success even if we exceed the maximum specified number of redirects.

## How to Test

`echo google.com | zgrab2 http --max-redirects=0`

This should show a failure status:

```
      "timestamp": "2020-02-26T16:54:20-05:00",
      "error": "Too many redirects"
    }
{"statuses":{"http":{"successes":0,"failures":1}},"start":"2020-02-26T16:55:53-05:00","end":"2020-02-26T16:55:53-05:00","duration":"78.194261ms"}
```

With the new flag, it should succeed:
`echo google.com | zgrab2 http --max-redirects=0 --redirects-succeed`

```
      },
      "timestamp": "2020-02-26T16:55:12-05:00"
    }
{"statuses":{"http":{"successes":1,"failures":0}},"start":"2020-02-26T16:55:28-05:00","end":"2020-02-26T16:55:28-05:00","duration":"69.901353ms"}

```
