### PR TITLE
Remove Scanner.Name()

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -125,7 +125,7 @@ func ZGrab2Main() {
 			mod := zgrab2.GetModule(modTypes[i])
 			s := mod.NewScanner()
 			s.Init(f)
-			zgrab2.RegisterScan(s.GetName(), s)
+			zgrab2.RegisterScan(mod.Attributes().Name, s)
 		}
 	} else {
 		mod := zgrab2.GetModule(moduleType)

--- a/module.go
+++ b/module.go
@@ -11,9 +11,6 @@ type Scanner interface {
 	// subset of the input scan targets
 	InitPerSender(senderID int) error
 
-	// Returns the name passed at init
-	GetName() string
-
 	// Returns the trigger passed at init
 	GetTrigger() string
 

--- a/module.go
+++ b/module.go
@@ -38,6 +38,11 @@ type ScanResponse struct {
 	Error     *string     `json:"error,omitempty"`
 }
 
+type ScanModuleAttributes struct {
+	Name        string
+	DefaultPort uint
+}
+
 // ScanModule is an interface which represents a module that the framework can
 // manipulate
 type ScanModule interface {
@@ -52,6 +57,8 @@ type ScanModule interface {
 	// Description returns a string suitable for use as an overview of this
 	// module within usage text.
 	Description() string
+
+	Attributes() ScanModuleAttributes
 }
 
 // ScanFlags is an interface which must be implemented by all types sent to

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -20,6 +20,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var bacnetModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "bacnet",
+	DefaultPort: 0xBAC0,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -51,6 +56,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns text uses in the help for this module.
 func (module *Module) Description() string {
 	return "Probe for devices that speak Bacnet, commonly used for HVAC control."
+}
+
+// Attributes returns a ScanModuleAttributes for Bacnet.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return bacnetModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -23,6 +23,11 @@ type Flags struct {
 	MaxTries int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
 }
 
+var bannerModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "banner",
+	DefaultPort: 80,
+}
+
 // Module is the implementation of the zgrab2.Module interface.
 type Module struct {
 }
@@ -86,6 +91,11 @@ func (f *Flags) Validate(args []string) error {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Fetch a raw banner by sending a static probe and checking the result against a regular expression"
+}
+
+// Attributes returns a ScanModuleAttributes for the banner module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return bannerModuleAttributes
 }
 
 // Help returns the module's help string.

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -18,6 +18,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var dnp3ModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "dnp3",
+	DefaultPort: 20000,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -49,6 +54,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for DNP3, a SCADA protocol"
+}
+
+// Attributes return the ScanModuleAttributes for DNP3.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return dnp3ModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -18,6 +18,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var foxModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "fox",
+	DefaultPort: 1911,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -49,6 +54,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for Tridium Fox"
+}
+
+// Attributes returns the ScanModuleAttributes for the Tridium Fox module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return foxModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -48,6 +48,11 @@ type Flags struct {
 	FTPAuthTLS bool `long:"authtls" description:"Collect FTPS certificates in addition to FTP banners"`
 }
 
+var ftpModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "ftp",
+	DefaultPort: 21,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -91,6 +96,11 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (m *Module) Description() string {
 	return "Grab an FTP banner"
+}
+
+// Attributes returns the ScanModuleAttributes for FTP.
+func (m *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return ftpModuleAttributes
 }
 
 // Validate does nothing in this module.

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -69,6 +69,11 @@ type Results struct {
 	RedirectResponseChain []*http.Response `json:"redirect_response_chain,omitempty"`
 }
 
+var httpModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "http",
+	DefaultPort: 80,
+}
+
 // Module is an implementation of the zgrab2.Module interface.
 type Module struct {
 }
@@ -104,6 +109,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Send an HTTP request and read the response, optionally following redirects."
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return httpModuleAttributes
 }
 
 // Validate performs any needed validation on the arguments

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -65,6 +65,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var imapModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "imap",
+	DefaultPort: 143,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -96,6 +101,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Fetch an IMAP banner, optionally over TLS"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return imapModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -99,6 +99,11 @@ type Flags struct {
 	IPPSecure bool `long:"ipps" description:"Perform a TLS handshake immediately upon connecting."`
 }
 
+var ippModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "ipp",
+	DefaultPort: 631,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 	// TODO: Add any module-global state if necessary
@@ -137,6 +142,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for printers via IPP"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return ippModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -40,6 +40,11 @@ type Flags struct {
 	Verbose   bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var modbusModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "modbus",
+	DefaultPort: 502,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -71,6 +76,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for Modbus devices, usually PLCs as part of a SCADA system"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return modbusModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -10,6 +10,11 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+var mongodbModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "mongodb",
+	DefaultPort: 27017,
+}
+
 // Module implements the zgrab2.Module interface
 type Module struct {
 }
@@ -239,6 +244,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Perform a handshake with a MongoDB server"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return mongodbModuleAttributes
 }
 
 // StartScan opens a connection to the target and sets up a scan instance for it.

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -49,6 +49,11 @@ type Flags struct {
 	Verbose     bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var mssqlModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "mssql",
+	DefaultPort: 1433,
+}
+
 // Module is the implementation of zgrab2.Module for the MSSQL protocol.
 type Module struct {
 }
@@ -72,6 +77,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Perform a handshake for MSSQL databases"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return mssqlModuleAttributes
 }
 
 // Validate does nothing in this module.

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -137,6 +137,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var mysqlModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "mysql",
+	DefaultPort: 3306,
+}
+
 // Module is the implementation of the zgrab2.Module interface.
 type Module struct {
 }
@@ -168,6 +173,11 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (m *Module) Description() string {
 	return "Perform a handshake with a MySQL database"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (m *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return mysqlModuleAttributes
 }
 
 // Validate validates the flags and returns nil on success.

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -803,6 +803,11 @@ type Flags struct {
 	RequestCode   string `long:"request-code" description:"Specify a request code for MonList other than ReqMonGetList" default:"REQ_MON_GETLIST"`
 }
 
+var ntpModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "ntp",
+	DefaultPort: 123,
+}
+
 // Module is the zgrab2 module implementation
 type Module struct {
 }
@@ -834,6 +839,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Scan for NTP"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return ntpModuleAttributes
 }
 
 // Validate checks that the flags are valid

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -94,6 +94,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var oracleModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "oracle",
+	DefaultPort: 1521,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -125,6 +130,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Perform a handshake with Oracle database servers"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return oracleModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -80,6 +80,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var pop3ModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "pop3",
+	DefaultPort: 110,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -111,6 +116,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Fetch POP3 banners, optionally over TLS"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return pop3ModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -131,6 +131,11 @@ type Scanner struct {
 	Config *Flags
 }
 
+var postgresModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "postgres",
+	DefaultPort: 5432,
+}
+
 // Module is the zgrab2 module for the postgres protocol
 type Module struct {
 }
@@ -283,6 +288,11 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (m *Module) Description() string {
 	return "Perform a handshake with a PostgreSQL server"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return postgresModuleAttributes
 }
 
 // Validate checks the arguments; on success, returns nil.

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -39,6 +39,11 @@ type Flags struct {
 	Verbose          bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var redisModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "redis",
+	DefaultPort: 6379,
+}
+
 // Module implements the zgrab2.Module interface
 type Module struct {
 }
@@ -178,6 +183,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for Redis"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return redisModuleAttributes
 }
 
 // Validate checks that the flags are valid

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -18,6 +18,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var siemensModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "siemens",
+	DefaultPort: 102,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -49,6 +54,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for Siemens S7 devices"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return siemensModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -20,6 +20,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var smbModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "smb",
+	DefaultPort: 445,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -51,6 +56,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Probe for SMB servers (Windows filesharing / SAMBA)"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return smbModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -96,6 +96,11 @@ type Flags struct {
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var smtpModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "smtp",
+	DefaultPort: 25,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -127,6 +132,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Fetch an SMTP server banner, optionally over TLS"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return smtpModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -24,6 +24,11 @@ type SSHFlags struct {
 	Verbose           bool   `long:"verbose" description:"Output additional information, including SSH client properties from the SSH handshake."`
 }
 
+var sshModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "ssh",
+	DefaultPort: 22,
+}
+
 type SSHModule struct {
 }
 
@@ -54,6 +59,11 @@ func (m *SSHModule) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (m *SSHModule) Description() string {
 	return "Fetch an SSH server banner and collect key exchange information"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (m *SSHModule) Attributes() zgrab2.ScanModuleAttributes {
+	return sshModuleAttributes
 }
 
 func (f *SSHFlags) Validate(args []string) error {

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -24,6 +24,11 @@ type Flags struct {
 	Verbose     bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
+var telnetModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "telnet",
+	DefaultPort: 23,
+}
+
 // Module implements the zgrab2.Module interface.
 type Module struct {
 }
@@ -55,6 +60,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (module *Module) Description() string {
 	return "Fetch a telnet banner"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (module *Module) Attributes() zgrab2.ScanModuleAttributes {
+	return telnetModuleAttributes
 }
 
 // Validate checks that the flags are valid.

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -10,6 +10,11 @@ type TLSFlags struct {
 	zgrab2.TLSFlags
 }
 
+var tlsModuleAttributes = zgrab2.ScanModuleAttributes{
+	Name:        "tls",
+	DefaultPort: 443,
+}
+
 type TLSModule struct {
 }
 
@@ -36,6 +41,11 @@ func (m *TLSModule) NewScanner() zgrab2.Scanner {
 // Description returns an overview of this module.
 func (m *TLSModule) Description() string {
 	return "Perform a TLS handshake"
+}
+
+// Attributes returns the ScanModuleAttributes for this module.
+func (m *TLSModule) Attributes() zgrab2.ScanModuleAttributes {
+	return tlsModuleAttributes
 }
 
 func (f *TLSFlags) Validate(args []string) error {

--- a/processing.go
+++ b/processing.go
@@ -165,8 +165,8 @@ func grabTarget(input ScanTarget, m *Monitor) []byte {
 				panic(e)
 			}
 		}(scannerName)
-		name, res := RunScanner(*scanner, m, input)
-		moduleResult[name] = res
+		res := RunScanner(*scanner, m, input, scannerName)
+		moduleResult[scannerName] = res
 		if res.Error != nil && !config.Multiple.ContinueOnError {
 			break
 		}

--- a/scanner.go
+++ b/scanner.go
@@ -27,20 +27,20 @@ func PrintScanners() {
 }
 
 // RunScanner runs a single scan on a target and returns the resulting data
-func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanResponse) {
+func RunScanner(s Scanner, mon *Monitor, target ScanTarget, name string) ScanResponse {
 	t := time.Now()
 	status, res, e := s.Scan(target)
 	var err *string
 	if e == nil {
-		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusSuccess}
+		mon.statusesChan <- moduleStatus{name: name, st: statusSuccess}
 		err = nil
 	} else {
-		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusFailure}
+		mon.statusesChan <- moduleStatus{name: name, st: statusFailure}
 		errString := e.Error()
 		err = &errString
 	}
 	resp := ScanResponse{Result: res, Protocol: s.Protocol(), Error: err, Timestamp: t.Format(time.RFC3339), Status: status}
-	return s.GetName(), resp
+	return resp
 }
 
 func init() {


### PR DESCRIPTION

Introduce ScanModuleAttributes

Remove Scanner.Name()

Rather than add a bunch of accessor functions that return static values
for each module, abstract the into ScanModuleAttributes, and add a
single function that exposes this. Previously, much of this information
was exposed as part of the call to RegisterModule. That remains there
for backwards compatibility (for now), but this allows it to be exposed
programatically, and continues work towards removing global state.

Ultimately, name was already tracked separately from the Scanner instance
itself.

## How to Test

Ensure output still works as expected

## Notes & Caveats

This helps with #249, which I have rebased on top of this branch.
