### PR TITLE
Ecubit/fix false positives

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/weppos/publicsuffix-go v0.4.0 h1:YSnfg3V65LcCFKtIGKGoBhkyKolEd0hlipcXaOjdnQw=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521 h1:kKCF7VX/wTmdg2ZjEaqlq99Bjsoiz7vH6sFniF/vI4M=

--- a/modules/dnp3/dnp3.go
+++ b/modules/dnp3/dnp3.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
+	"errors"
 
 	"github.com/zmap/zgrab2"
 )
@@ -73,9 +74,10 @@ func GetDNP3Banner(logStruct *DNP3Log, connection net.Conn) (err error) {
 	if len(data) >= LINK_MIN_HEADER_LENGTH && binary.BigEndian.Uint16(data[0:2]) == LINK_START_FIELD {
 		logStruct.IsDNP3 = true
 		logStruct.RawResponse = data
+		return nil
 	}
 
-	return nil
+	return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for DNP3"))
 }
 
 func makeLinkStatusRequest(dstAddress uint16) []byte {

--- a/modules/imap/imap.go
+++ b/modules/imap/imap.go
@@ -3,8 +3,6 @@ package imap
 import (
 	"net"
 	"regexp"
-	"strings"
-	"errors"
 	"io"
 
 	"github.com/zmap/zgrab2"
@@ -20,21 +18,6 @@ type Connection struct {
 	Conn net.Conn
 }
 
-// Verify banner begins with a valid IMAP response and handle it
-func VerifyIMAPContents(n int, ret []byte) (string, error) {
-	s := string(ret[:n])
-	if strings.HasPrefix(s, "* OK"){
-		return s, nil
-	}
-	if strings.HasPrefix(s, "* NO"){
-		return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, errors.New("IMAP reported error"))
-	}
-	if strings.HasPrefix(s, "* BAD"){
-		return s, zgrab2.NewScanError(zgrab2.SCAN_UNKNOWN_ERROR, errors.New("IMAP request was malformed"))
-	}
-	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for IMAP"))
-}
-
 // ReadResponse reads from the connection until it matches the imapEndRegex. Copied from the original zgrab.
 // TODO: Catch corner cases
 func (conn *Connection) ReadResponse() (string, error) {
@@ -43,7 +26,7 @@ func (conn *Connection) ReadResponse() (string, error) {
 	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
 		return "", err
 	}
-	return VerifyIMAPContents(n, ret)
+	return string(ret[:n]), nil
 }
 
 // SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.

--- a/modules/imap/imap.go
+++ b/modules/imap/imap.go
@@ -3,6 +3,9 @@ package imap
 import (
 	"net"
 	"regexp"
+	"strings"
+	"errors"
+	"io"
 
 	"github.com/zmap/zgrab2"
 )
@@ -17,15 +20,30 @@ type Connection struct {
 	Conn net.Conn
 }
 
+// Verify banner begins with a valid IMAP response and handle it
+func VerifyIMAPContents(n int, ret []byte) (string, error) {
+	s := string(ret[:n])
+	if strings.HasPrefix(s, "* OK"){
+		return s, nil
+	}
+	if strings.HasPrefix(s, "* NO"){
+		return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, errors.New("IMAP reported error"))
+	}
+	if strings.HasPrefix(s, "* BAD"){
+		return s, zgrab2.NewScanError(zgrab2.SCAN_UNKNOWN_ERROR, errors.New("IMAP request was malformed"))
+	}
+	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for IMAP"))
+}
+
 // ReadResponse reads from the connection until it matches the imapEndRegex. Copied from the original zgrab.
-// TODO: Catch corner cases, parse out success/error character.
+// TODO: Catch corner cases
 func (conn *Connection) ReadResponse() (string, error) {
 	ret := make([]byte, readBufferSize)
 	n, err := zgrab2.ReadUntilRegex(conn.Conn, ret, imapStatusEndRegex)
-	if err != nil {
-		return "", nil
+	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
+		return "", err
 	}
-	return string(ret[0:n]), nil
+	return VerifyIMAPContents(n, ret)
 }
 
 // SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -151,16 +151,24 @@ func getIMAPError(response string) error {
 
 // Check the contents of the IMAP banner and return a relevant ScanStatus
 func VerifyIMAPContents(banner string) zgrab2.ScanStatus {
+	lowerBanner := strings.ToLower(banner)
 	switch {
-	case strings.HasPrefix(banner, "* OK"),
-	     strings.HasPrefix(banner, "* PREAUTH"),
-	     strings.HasPrefix(banner, "* BYE"):
-			return zgrab2.SCAN_SUCCESS
 	case strings.HasPrefix(banner, "* NO"),
 	     strings.HasPrefix(banner, "* BAD"):
-			return zgrab2.SCAN_APPLICATION_ERROR
+		return zgrab2.SCAN_APPLICATION_ERROR
+	case strings.HasPrefix(banner, "* OK"),
+	     strings.HasPrefix(banner, "* PREAUTH"),
+	     strings.HasPrefix(banner, "* BYE"),
+	     strings.HasPrefix(banner, "* OKAY"),
+	     strings.Contains(banner, "IMAP"),
+	     strings.Contains(lowerBanner, "blacklist"),
+	     strings.Contains(lowerBanner, "abuse"),
+	     strings.Contains(lowerBanner, "rbl"),
+	     strings.Contains(lowerBanner, "spamhaus"),
+	     strings.Contains(lowerBanner, "relay"):
+		return zgrab2.SCAN_SUCCESS
 	default:
-			return zgrab2.SCAN_PROTOCOL_ERROR
+		return zgrab2.SCAN_PROTOCOL_ERROR
 	}
 }
 

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -24,6 +24,7 @@ package imap
 
 import (
 	"fmt"
+	"errors"
 
 	"strings"
 
@@ -148,6 +149,21 @@ func getIMAPError(response string) error {
 	return fmt.Errorf("error: %s", response)
 }
 
+// Check the contents of the IMAP banner and return a relevant ScanStatus
+func VerifyIMAPContents(banner string) zgrab2.ScanStatus {
+	switch {
+	case strings.HasPrefix(banner, "* OK"),
+	     strings.HasPrefix(banner, "* PREAUTH"),
+	     strings.HasPrefix(banner, "* BYE"):
+			return zgrab2.SCAN_SUCCESS
+	case strings.HasPrefix(banner, "* NO"),
+	     strings.HasPrefix(banner, "* BAD"):
+			return zgrab2.SCAN_APPLICATION_ERROR
+	default:
+			return zgrab2.SCAN_PROTOCOL_ERROR
+	}
+}
+
 // Scan performs the IMAP scan.
 // 1. Open a TCP connection to the target port (default 143).
 // 2. If --imaps is set, perform a TLS handshake using the command-line
@@ -180,6 +196,12 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
+	// Quit early if we didn't get a valid response
+	// OR save a valid scan result for later
+	sr := VerifyIMAPContents(banner)
+	if (sr == zgrab2.SCAN_PROTOCOL_ERROR){
+		return sr, nil, errors.New("Invalid response for IMAP")
+	}
 	result.Banner = banner
 	if scanner.config.StartTLS {
 		ret, err := conn.SendCommand("a001 STARTTLS")
@@ -209,5 +231,5 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		}
 		result.CLOSE = ret
 	}
-	return zgrab2.SCAN_SUCCESS, result, nil
+	return sr, result, nil
 }

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -199,7 +199,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	// Quit early if we didn't get a valid response
 	// OR save a valid scan result for later
 	sr := VerifyIMAPContents(banner)
-	if (sr == zgrab2.SCAN_PROTOCOL_ERROR){
+	if sr == zgrab2.SCAN_PROTOCOL_ERROR {
 		return sr, nil, errors.New("Invalid response for IMAP")
 	}
 	result.Banner = banner

--- a/modules/pop3/pop3.go
+++ b/modules/pop3/pop3.go
@@ -1,8 +1,14 @@
+// Scanner for POP3 protocol
+// https://www.ietf.org/rfc/rfc1939.txt
+
 package pop3
 
 import (
 	"net"
 	"regexp"
+	"errors"
+	"strings"
+	"io"
 
 	"github.com/zmap/zgrab2"
 )
@@ -17,15 +23,34 @@ type Connection struct {
 	Conn net.Conn
 }
 
+// Verifies that a POP3 banner begins with a valid status indicator
+func VerifyPOP3Contents(n int, ret []byte) (string, error) {
+	s := string(ret[0:n])
+	iword := strings.Index(s, " ")
+	if iword > 2 {
+		subst := s[:iword]
+		if subst == "+OK" {
+			return s, nil
+		}
+		if subst == "+ERR" {
+			return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR,
+																		errors.New("POP3 Reported Error"))
+		}
+	}
+	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR,
+																errors.New("Invalid response for POP3"))
+}
+
 // ReadResponse reads from the connection until it matches the pop3EndRegex. Copied from the original zgrab.
-// TODO: Catch corner cases, parse out success/error character.
+// TODO: Catch corner cases
 func (conn *Connection) ReadResponse() (string, error) {
 	ret := make([]byte, readBufferSize)
 	n, err := zgrab2.ReadUntilRegex(conn.Conn, ret, pop3EndRegex)
-	if err != nil {
-		return "", nil
+	// Don't quit for timeouts since we might have gotten relevant data still
+	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
+		return "", err
 	}
-	return string(ret[0:n]), nil
+	return VerifyPOP3Contents(n, ret)
 }
 
 // SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.

--- a/modules/pop3/pop3.go
+++ b/modules/pop3/pop3.go
@@ -26,16 +26,12 @@ type Connection struct {
 // Verifies that a POP3 banner begins with a valid status indicator
 func VerifyPOP3Contents(n int, ret []byte) (string, error) {
 	s := string(ret[0:n])
-	iword := strings.Index(s, " ")
-	if iword > 2 {
-		subst := s[:iword]
-		if subst == "+OK" {
+	if strings.HasPrefix(s, "+OK "){
 			return s, nil
-		}
-		if subst == "+ERR" {
+	}
+	if strings.HasPrefix(s, "+ERR "){
 			return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR,
 																		errors.New("POP3 Reported Error"))
-		}
 	}
 	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR,
 																errors.New("Invalid response for POP3"))

--- a/modules/pop3/pop3.go
+++ b/modules/pop3/pop3.go
@@ -6,8 +6,6 @@ package pop3
 import (
 	"net"
 	"regexp"
-	"errors"
-	"strings"
 	"io"
 
 	"github.com/zmap/zgrab2"
@@ -23,18 +21,6 @@ type Connection struct {
 	Conn net.Conn
 }
 
-// Verifies that a POP3 banner begins with a valid status indicator
-func VerifyPOP3Contents(n int, ret []byte) (string, error) {
-	s := string(ret[0:n])
-	if strings.HasPrefix(s, "+OK "){
-			return s, nil
-	}
-	if strings.HasPrefix(s, "+ERR "){
-			return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, errors.New("POP3 Reported Error"))
-	}
-	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for POP3"))
-}
-
 // ReadResponse reads from the connection until it matches the pop3EndRegex. Copied from the original zgrab.
 // TODO: Catch corner cases
 func (conn *Connection) ReadResponse() (string, error) {
@@ -44,7 +30,7 @@ func (conn *Connection) ReadResponse() (string, error) {
 	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
 		return "", err
 	}
-	return VerifyPOP3Contents(n, ret)
+	return string(ret[:n]), nil
 }
 
 // SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.

--- a/modules/pop3/pop3.go
+++ b/modules/pop3/pop3.go
@@ -30,11 +30,9 @@ func VerifyPOP3Contents(n int, ret []byte) (string, error) {
 			return s, nil
 	}
 	if strings.HasPrefix(s, "+ERR "){
-			return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR,
-																		errors.New("POP3 Reported Error"))
+			return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, errors.New("POP3 Reported Error"))
 	}
-	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR,
-																errors.New("Invalid response for POP3"))
+	return s, zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for POP3"))
 }
 
 // ReadResponse reads from the connection until it matches the pop3EndRegex. Copied from the original zgrab.

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -211,7 +211,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	// Quit early if no valid response
 	// OR save it to return later
 	sr := VerifyPOP3Contents(banner)
-	if (sr == zgrab2.SCAN_PROTOCOL_ERROR){
+	if sr == zgrab2.SCAN_PROTOCOL_ERROR {
 		return sr, nil, errors.New("Invalid response for POP3")
 	}
 	result.Banner = banner

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -165,13 +165,23 @@ func getPOP3Error(response string) error {
 
 // Check the contents of the POP3 header and return a relevant ScanStatus
 func VerifyPOP3Contents(banner string) zgrab2.ScanStatus {
-	if strings.HasPrefix(banner, "+OK "){
-		return zgrab2.SCAN_SUCCESS
-	}
-	if strings.HasPrefix(banner, "-ERR "){
+	lowerBanner := strings.ToLower(banner)
+	switch {
+	case strings.HasPrefix(banner, "-ERR "):
 		return zgrab2.SCAN_APPLICATION_ERROR
+	case strings.HasPrefix(banner, "+OK "),
+	     strings.Contains(banner, "POP3"),
+	     // These are rare for POP3 if they happen at all,
+	     // But it won't hurt to check just in case as a backup
+	     strings.Contains(lowerBanner, "blacklist"),
+	     strings.Contains(lowerBanner, "abuse"),
+	     strings.Contains(lowerBanner, "rbl"),
+	     strings.Contains(lowerBanner, "spamhaus"),
+	     strings.Contains(lowerBanner, "relay"):
+		return zgrab2.SCAN_SUCCESS
+	default:
+		return zgrab2.SCAN_PROTOCOL_ERROR
 	}
-	return zgrab2.SCAN_PROTOCOL_ERROR
 }
 
 // Scan performs the POP3 scan.

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -205,13 +205,21 @@ func getCommand(cmd string, arg string) string {
 // Return code on SCAN_APPLICATION_ERROR for better info
 func VerifySMTPContents(banner string) (zgrab2.ScanStatus, int) {
 	code, err := getSMTPCode(banner)
-	if err != nil {
+	lowerBanner := strings.ToLower(banner)
+	switch {
+	case err == nil && (code < 200 || code >= 300):
+		return zgrab2.SCAN_APPLICATION_ERROR, code
+	case err == nil,
+	     strings.Contains(banner, "STMP"),
+	     strings.Contains(lowerBanner, "blacklist"),
+	     strings.Contains(lowerBanner, "abuse"),
+	     strings.Contains(lowerBanner, "rbl"),
+	     strings.Contains(lowerBanner, "spamhaus"),
+	     strings.Contains(lowerBanner, "relay"):
+		return zgrab2.SCAN_SUCCESS, 0
+	default:
 		return zgrab2.SCAN_PROTOCOL_ERROR, 0
 	}
-	if code < 200 || code >= 300 {
-		return zgrab2.SCAN_APPLICATION_ERROR, code
-	}
-	return zgrab2.SCAN_SUCCESS, 0
 }
 
 // Scan performs the SMTP scan.

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -36,7 +36,7 @@ import (
 )
 
 // ErrInvalidResponse is returned when the server returns an invalid or unexpected response.
-var ErrInvalidResponse = errors.New("invalid response")
+var ErrInvalidResponse = zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for SMTP"))
 
 // ScanResults instances are returned by the module's Scan function.
 type ScanResults struct {

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -201,6 +201,19 @@ func getCommand(cmd string, arg string) string {
 	return cmd + " " + arg
 }
 
+// Verify that an SMTP code was returned, and that it is a successful one!
+// Return code on SCAN_APPLICATION_ERROR for better info
+func VerifySMTPContents(banner string) (zgrab2.ScanStatus, int) {
+	code, err := getSMTPCode(banner)
+	if err != nil {
+		return zgrab2.SCAN_PROTOCOL_ERROR, 0
+	}
+	if code < 200 || code >= 300 {
+		return zgrab2.SCAN_APPLICATION_ERROR, code
+	}
+	return zgrab2.SCAN_SUCCESS, 0
+}
+
 // Scan performs the SMTP scan.
 // 1. Open a TCP connection to the target port (default 25).
 // 2. If --smtps is set, perform a TLS handshake.
@@ -237,6 +250,12 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 			result = nil
 		}
 		return zgrab2.TryGetScanStatus(err), result, err
+	}
+	// Quit early if we didn't get a valid response
+	// OR save response to return later
+	sr, bannerResponseCode := VerifySMTPContents(banner)
+	if sr == zgrab2.SCAN_PROTOCOL_ERROR {
+		return sr, nil, errors.New("Invalid response for SMTP")
 	}
 	result.Banner = banner
 	if scanner.config.SendHELO {
@@ -292,5 +311,8 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		}
 		result.QUIT = ret
 	}
-	return zgrab2.SCAN_SUCCESS, result, nil
+	if sr == zgrab2.SCAN_APPLICATION_ERROR {
+		return sr, result, fmt.Errorf("SMTP error code %d returned in banner grab", bannerResponseCode)
+	}
+	return sr, result, nil
 }

--- a/modules/smtp/smtp.go
+++ b/modules/smtp/smtp.go
@@ -3,7 +3,6 @@ package smtp
 import (
 	"net"
 	"regexp"
-	"fmt"
 	"io"
 
 	"github.com/zmap/zgrab2"
@@ -20,19 +19,6 @@ type Connection struct {
 	Conn net.Conn
 }
 
-// Verify that an SMTP code was returned, and that it is a successful one!
-func VerifySMTPContents(n int, ret []byte) (string, error){
-	s := string(ret[:n])
-	code, err := getSMTPCode(s)
-	if err != nil {
-		return s, err
-	}
-	if code < 200 || code >= 300 {
-		return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, fmt.Errorf("SMTP returned error code %d", code))
-	}
-	return s, nil
-}
-
 // ReadResponse reads from the connection until it matches the smtpEndRegex. Copied from the original zgrab.
 // TODO: Catch corner cases
 func (conn *Connection) ReadResponse() (string, error) {
@@ -41,7 +27,7 @@ func (conn *Connection) ReadResponse() (string, error) {
 	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
 		return "", err
 	}
-	return VerifySMTPContents(n, ret)
+	return string(ret[:n]), nil
 }
 
 // SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.

--- a/modules/smtp/smtp.go
+++ b/modules/smtp/smtp.go
@@ -3,6 +3,8 @@ package smtp
 import (
 	"net"
 	"regexp"
+	"fmt"
+	"io"
 
 	"github.com/zmap/zgrab2"
 )
@@ -18,15 +20,28 @@ type Connection struct {
 	Conn net.Conn
 }
 
+// Verify that an SMTP code was returned, and that it is a successful one!
+func VerifySMTPContents(n int, ret []byte) (string, error){
+	s := string(ret[:n])
+	code, err := getSMTPCode(s)
+	if err != nil {
+		return s, err
+	}
+	if code < 200 || code >= 300 {
+		return s, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, fmt.Errorf("SMTP returned error code %d", code))
+	}
+	return s, nil
+}
+
 // ReadResponse reads from the connection until it matches the smtpEndRegex. Copied from the original zgrab.
-// TODO: Catch corner cases, parse out response code.
+// TODO: Catch corner cases
 func (conn *Connection) ReadResponse() (string, error) {
 	ret := make([]byte, readBufferSize)
 	n, err := zgrab2.ReadUntilRegex(conn.Conn, ret, smtpEndRegex)
-	if err != nil {
-		return "", nil
+	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
+		return "", err
 	}
-	return string(ret[0:n]), nil
+	return VerifySMTPContents(n, ret)
 }
 
 // SendCommand sends a command, followed by a CRLF, then wait for / read the server's response.

--- a/modules/telnet/telnet.go
+++ b/modules/telnet/telnet.go
@@ -117,8 +117,7 @@ func GetTelnetBanner(logStruct *TelnetLog, conn net.Conn, maxReadSize int) (err 
 	}
 	// Make sure it is a telnet banner
 	if !logStruct.isTelnet() {
-		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR,
-																errors.New("Invalid response for Telnet"))
+		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR, errors.New("Invalid response for Telnet"))
 	}
 	return nil
 }

--- a/modules/telnet/telnet.go
+++ b/modules/telnet/telnet.go
@@ -115,6 +115,11 @@ func GetTelnetBanner(logStruct *TelnetLog, conn net.Conn, maxReadSize int) (err 
 	if err != nil && err != io.EOF && !zgrab2.IsTimeoutError(err) {
 		return err
 	}
+	// Make sure it is a telnet banner
+	if !logStruct.isTelnet() {
+		return zgrab2.NewScanError(zgrab2.SCAN_PROTOCOL_ERROR,
+																errors.New("Invalid response for Telnet"))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Contents
Check contents of banners to make sure they match their protocol before returning success.
Fixes telnet, ssh, smtp, pop3, imap, and dnp3

## How to Test

Test each protocol against a few protocol servers and ssh running on localhost to verify results:
Docker images used:
Telnet: jaredharringtongibbs/telnet-server on :23
pop3, imap: instrumentisto/dovecot on :110 and :143
smtp: bytemark/smtp on :25

Testing for pop3:
$ nc -l 9999 &
$ ./zgrab2 pop3 --port 9999 --timeout 2 <<< "127.0.0.1"
$ ./zgrab2 pop3 --port {23|143|25|22} --timeout 2 <<< "127.0.0.1"
$ > success = false
$ ./zgrab2 pop3 --port 110 --timeout 2 <<< "127.0.0.1"
$ > success = true

Repeat for each protocol, only port running correct protocol should have success=true.

Didn't have a dnp3 server locally to test with; found an open system at 216.164.167.23 to test against for the success case.
