### PR TITLE
Fix panics in Modbus scanner

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/weppos/publicsuffix-go v0.4.0 h1:YSnfg3V65LcCFKtIGKGoBhkyKolEd0hlipcXaOjdnQw=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/zmap/rc2 v0.0.0-20131011165748-24b9757f5521 h1:kKCF7VX/wTmdg2ZjEaqlq99Bjsoiz7vH6sFniF/vI4M=

--- a/integration_tests/postgres/setup.sh
+++ b/integration_tests/postgres/setup.sh
@@ -37,8 +37,13 @@ function waitFor() {
       sleep 1
     done
   else
-    while ! (docker exec $CONTAINER_NAME ps -Af | grep -q "postgres: logger process" > /dev/null); do
-      echo -n "*"
+    CNT=0
+    while ! (docker exec $CONTAINER_NAME ps -Af | grep -q "postgres: logger process"); do
+      echo -n "*" 
+      CNT=$((CNT+1))
+      if [ $CNT > 20 ]; then
+        break
+      fi
       sleep 1
     done
     while ! (docker exec -t $CONTAINER_NAME cat //var/lib/postgresql/data/pg_log/postgres.log | grep -q "STARTED; state"); do

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -171,10 +171,6 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 
 	res, err := c.GetModbusResponse()
 	if res == nil {
-		if err == nil {
-			// unreachable
-			log.Fatalf("Unreachable: no result, no error from modbus.GetModbusResponse()")
-		}
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
 


### PR DESCRIPTION
## Technical Changes
- removes fatalf in `scan()`
- check message and body length in `GetModbusResponse()` 


## How to Test
I looked at a couple of the modbus panic logs and tested against those IPs

```
./zgrab2 modbus -p 7000 <<< 221.132.95.154
./zgrab2 modbus <<< 133.34.157.97
./zgrab2 modbus <<< 133.34.157.117
./zgrab2 modbus <<< 133.34.157.24
./zgrab2 modbus <<< 133.34.157.25
./zgrab2 modbus <<< 61.155.174.55
./zgrab2 modbus <<< 210.253.251.215
./zgrab2 modbus <<< 218.45.180.18
./zgrab2 modbus -p 3001 <<< 60.221.39.185
``` 



