### PR TITLE
Add option to compute http BodySHA256 on decoded BodyText

### DIFF
--- a/lib/http/response.go
+++ b/lib/http/response.go
@@ -63,6 +63,8 @@ type Response struct {
 	// BodyHash is the hash digest hex of the decoded http body, formatted `<kind>:<hex>`
 	// e.g. `sha256:deadbeef100020003000400050006000700080009000a000b000c000d000e000`
 	BodyHash string `json:"body_hash,omitempty"`
+	// Number of bytes read from the server and encoded into BodyText
+	BodyTextLength int64 `json:"body_length,omitempty"`
 
 	// ContentLength records the length of the associated content. The
 	// value -1 indicates that the length is unknown. Unless Request.Method

--- a/lib/http/response.go
+++ b/lib/http/response.go
@@ -60,6 +60,9 @@ type Response struct {
 	Body       io.ReadCloser   `json:"-"`
 	BodyText   string          `json:"body,omitempty"`
 	BodySHA256 PageFingerprint `json:"body_sha256,omitempty"`
+	// BodyHash is the hash digest hex of the decoded http body, formatted `<kind>:<hex>`
+	// e.g. `sha256:deadbeef100020003000400050006000700080009000a000b000c000d000e000`
+	BodyHash string `json:"body_hash,omitempty"`
 
 	// ContentLength records the length of the associated content. The
 	// value -1 indicates that the length is unknown. Unless Request.Method

--- a/modules/http/http_readlimit_test.go
+++ b/modules/http/http_readlimit_test.go
@@ -157,6 +157,7 @@ func (cfg *readLimitTestConfig) getScanner(t *testing.T) *Scanner {
 	flags.Timeout = 1 * time.Second
 	flags.Port = uint(cfg.port)
 	flags.UseHTTPS = cfg.tls
+	flags.BodyHashAlgorithm = "sha1"
 	zgrab2.DefaultBytesReadLimit = cfg.maxReadSize
 	scanner := module.NewScanner()
 	scanner.Init(flags)

--- a/modules/http/http_readlimit_test.go
+++ b/modules/http/http_readlimit_test.go
@@ -157,7 +157,6 @@ func (cfg *readLimitTestConfig) getScanner(t *testing.T) *Scanner {
 	flags.Timeout = 1 * time.Second
 	flags.Port = uint(cfg.port)
 	flags.UseHTTPS = cfg.tls
-	flags.BodyHashAlgorithm = "sha1"
 	zgrab2.DefaultBytesReadLimit = cfg.maxReadSize
 	scanner := module.NewScanner()
 	scanner.Init(flags)

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -306,9 +306,13 @@ func (scan *scan) getCheckRedirect() func(*http.Request, *http.Response, []*http
 		io.CopyN(b, res.Body, readLen)
 		res.BodyText = b.String()
 		if len(res.BodyText) > 0 {
-			m := sha256.New()
-			m.Write(b.Bytes())
-			res.BodySHA256 = m.Sum(nil)
+			if scan.scanner.decodedHashFn != nil {
+				res.BodyHash = scan.scanner.decodedHashFn([]byte(res.BodyText))
+			} else {
+				m := sha256.New()
+				m.Write(b.Bytes())
+				res.BodySHA256 = m.Sum(nil)
+			}
 		}
 
 		if len(via) > scan.scanner.config.MaxRedirects {

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -415,7 +415,8 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 	if resp.ContentLength >= 0 && resp.ContentLength < maxReadLen {
 		readLen = resp.ContentLength
 	}
-	io.CopyN(buf, resp.Body, readLen)
+	// EOF ignored here because that's the way it was, CopyN goes up to readLen bytes
+	scan.results.Response.BodyTextLength, _ = io.CopyN(buf, resp.Body, readLen)
 	bufAsString := buf.String()
 
 	// do best effort attempt to determine the response's encoding

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -152,7 +152,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 			return fmt.Sprintf("sha256:%s", hex.EncodeToString(raw_hash[:]))
 		}
 	} else {
-		log.Panicf("Invalid BodhHashAlgorithm choice made it throug zflags: %s", scanner.config.BodyHashAlgorithm)
+		log.Panicf("Invalid BodhHashAlgorithm choice made it through zflags: %s", scanner.config.BodyHashAlgorithm)
 	}
 
 	return nil

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -416,9 +416,9 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 	}
 
 	if len(scan.results.Response.BodyText) > 0 {
-		if scan.ComputeDecodedBodyHash {
+		if scan.scanner.config.ComputeDecodedBodyHash {
 			raw_hash := sha256.Sum256([]byte(scan.results.Response.BodyText))
-			scan.results.Response.BodyHash = fmt.Sprintf("sha256:%s", hex.EncodeToString(raw_hash))
+			scan.results.Response.BodyHash = fmt.Sprintf("sha256:%s", hex.EncodeToString(raw_hash[:]))
 		} else {
 			m := sha256.New()
 			m.Write(buf.Bytes())

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -152,7 +152,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 			return fmt.Sprintf("sha256:%s", hex.EncodeToString(raw_hash[:]))
 		}
 	} else {
-		log.Panicf("Invalid BodhHashAlgorithm choice made it through zflags: %s", scanner.config.BodyHashAlgorithm)
+		log.Panicf("Invalid BodyHashAlgorithm choice made it through zflags: %s", scanner.config.BodyHashAlgorithm)
 	}
 
 	return nil


### PR DESCRIPTION
Adds a new way to compute the BodyHash for http scanner.

## How to Test


```
echo <ip> | ./zgrab2 http --port 443 --compute-decoded-body-hash-algorithm=sha256 | jq
 "body_hash": "sha256:ff990fc95970bd2fc6333663ae043aaef308117190507bbd7b4831244cd97c2d",

echo <ip> | ./zgrab2 http --port 443 --compute-decoded-body-hash-algorithm=sha1 | jq
"body_hash": "sha1:a829c753bb3e30296c1faeea6783edf7dd23824f",

./zgrab2 http --port 443 --compute-decoded-body-hash-algorithm=md5 | jq
Invalid value `md5' for option `--compute-decoded-body-hash-algorithm'. Allowed values are: sha256 or sha1
```

## Notes & Caveats

_If necessary, explain the motivation for this PR, and note any caveats that apply to your changes or future work that will be needed._ 

## Issue Tracking

_Add a link to the relevant GitHub issue(s) if the pull request resolves it._
