### PR TITLE
[DATA-970] Increase buffer size in FTP scanner

### DIFF
--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -156,7 +156,6 @@ func (ftp *Connection) isOKResponse(retCode string) bool {
 // readResponse reads an FTP response chunk from the server.
 // It returns the full response, as well as the status code alone.
 func (ftp *Connection) readResponse() (string, string, error) {
-	log.Errorf("buffer size: %d", len(ftp.buffer))
 	respLen, err := zgrab2.ReadUntilRegex(ftp.conn, ftp.buffer[:], ftpEndRegex)
 	if err != nil {
 		return "", "", err

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -68,7 +68,7 @@ type Scanner struct {
 type Connection struct {
 	// buffer is a temporary buffer for sending commands -- so, never interleave
 	// sendCommand calls on a given connection
-	buffer  [1024]byte
+	buffer  [10000]byte
 	config  *Flags
 	results ScanResults
 	conn    net.Conn
@@ -156,6 +156,7 @@ func (ftp *Connection) isOKResponse(retCode string) bool {
 // readResponse reads an FTP response chunk from the server.
 // It returns the full response, as well as the status code alone.
 func (ftp *Connection) readResponse() (string, string, error) {
+	log.Fatalf("buffer size: %d", len(ftp.buffer))
 	respLen, err := zgrab2.ReadUntilRegex(ftp.conn, ftp.buffer[:], ftpEndRegex)
 	if err != nil {
 		return "", "", err

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -156,7 +156,7 @@ func (ftp *Connection) isOKResponse(retCode string) bool {
 // readResponse reads an FTP response chunk from the server.
 // It returns the full response, as well as the status code alone.
 func (ftp *Connection) readResponse() (string, string, error) {
-	log.Fatalf("buffer size: %d", len(ftp.buffer))
+	log.Errorf("buffer size: %d", len(ftp.buffer))
 	respLen, err := zgrab2.ReadUntilRegex(ftp.conn, ftp.buffer[:], ftpEndRegex)
 	if err != nil {
 		return "", "", err

--- a/utility.go
+++ b/utility.go
@@ -162,7 +162,6 @@ var InsufficientBufferError = errors.New("not enough buffer space")
 func ReadUntilRegex(connection net.Conn, res []byte, expr *regexp.Regexp) (int, error) {
 	buf := res[0:]
 	length := 0
-	logrus.Errorf("res size: %d", len(res))
 	for finished := false; !finished; {
 		n, err := connection.Read(buf)
 		length += n

--- a/utility.go
+++ b/utility.go
@@ -9,9 +9,10 @@ import (
 
 	"time"
 
-	"github.com/zmap/zflags"
-	"github.com/sirupsen/logrus"
 	"runtime/debug"
+
+	"github.com/sirupsen/logrus"
+	flags "github.com/zmap/zflags"
 )
 
 var parser *flags.Parser
@@ -161,6 +162,7 @@ var InsufficientBufferError = errors.New("not enough buffer space")
 func ReadUntilRegex(connection net.Conn, res []byte, expr *regexp.Regexp) (int, error) {
 	buf := res[0:]
 	length := 0
+	logrus.Errorf("res size: %d", len(res))
 	for finished := false; !finished; {
 		n, err := connection.Read(buf)
 		length += n

--- a/utility.go
+++ b/utility.go
@@ -9,10 +9,9 @@ import (
 
 	"time"
 
-	"runtime/debug"
-
+	"github.com/zmap/zflags"
 	"github.com/sirupsen/logrus"
-	flags "github.com/zmap/zflags"
+	"runtime/debug"
 )
 
 var parser *flags.Parser


### PR DESCRIPTION
Port 21 on 134.223.117.55 failed an FTP scan. The buffer size in the FTP scanner was 1024, and this scan was failing because the buffer size was too small. I increased it to 10k.



## Issue Tracking

https://censysio.atlassian.net/browse/DATA-970
