### PR TITLE
Add NativeOS, NTLM, and GroupName to SMBv1 results

### DIFF
--- a/lib/smb/smb/encoder/unicode.go
+++ b/lib/smb/smb/encoder/unicode.go
@@ -27,3 +27,21 @@ func ToUnicode(s string) []byte {
 	binary.Write(&b, binary.LittleEndian, &uints)
 	return b.Bytes()
 }
+
+func ToSmbString(s string) []byte {
+	res := ToUnicode(s)
+	res = append(res, 0x0, 0x0)
+	return res
+}
+
+func FromSmbString(d []byte) (string, error) {
+	res, err := FromUnicode(d)
+	if err != nil {
+		return "", err
+	}
+	if len(res) == 0 {
+		return "", nil
+	}
+	// Trim null terminator
+	return res[:len(res)-1], nil
+}

--- a/lib/smb/smb/smb.go
+++ b/lib/smb/smb/smb.go
@@ -95,6 +95,10 @@ const (
 	ShareCapAsymmetric             uint32 = 0x00000080
 )
 
+const (
+	SmbHeaderV1Length = 32
+)
+
 type HeaderV1 struct {
 	ProtocolID       []byte `smb:"fixed:4"`
 	Command          uint8
@@ -133,6 +137,24 @@ type NegotiateReqV1 struct {
 	Dialects  []uint8 `smb:"fixed:12"`
 }
 
+type SessionSetupV1Req struct {
+	HeaderV1
+	WordCount             uint8
+	AndCommand            uint8
+	Reserved1             uint8
+	AndOffset             uint16
+	MaxBuffer             uint16
+	MaxMPXCount           uint16
+	VCNumber              uint16
+	SessionKey            uint32
+	OEMPasswordLength     uint16
+	UnicodePasswordLength uint16
+	Reserved2             uint32
+	Capabilities          uint32
+	ByteCount             uint16
+	VarData               []byte
+}
+
 type NegotiateResV1 struct {
 	HeaderV1
 	WordCount       uint8
@@ -147,8 +169,9 @@ type NegotiateResV1 struct {
 	SystemTime      uint64
 	ServerTimezon   uint16
 	ChallengeLength uint8
-	ByteCount       uint16
-	// variable data afterwords that we don't care about
+	ByteCount       uint16 `smb:"len:VarData"`
+	// variable data afterwards that we don't care about
+	VarData []byte
 }
 
 type NegotiateReq struct {
@@ -260,6 +283,17 @@ type TreeDisconnectRes struct {
 func newHeaderV1() HeaderV1 {
 	return HeaderV1{
 		ProtocolID: []byte(ProtocolSmb),
+		Status:     0,
+		Flags:      0x18,
+		Flags2:     0xc843,
+		PIDHigh:    0,
+		// These bytes must be explicit here
+		SecurityFeatures: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+		Reserved:         0,
+		TID:              0xffff,
+		PIDLow:           0xfeff,
+		UID:              0,
+		MID:              0,
 	}
 }
 
@@ -287,8 +321,21 @@ func (s *Session) NewNegotiateReqV1() NegotiateReqV1 {
 	return NegotiateReqV1{
 		HeaderV1:  header,
 		WordCount: 0,
-		ByteCount: 14,
+		ByteCount: 12,
 		Dialects:  []uint8(DialectSmb_1_0),
+	}
+}
+
+func (s *Session) NewSessionSetupV1Req() SessionSetupV1Req {
+	header := newHeaderV1()
+	header.Command = 0x73 // SMB1 Session Setup
+	return SessionSetupV1Req{
+		HeaderV1:    header,
+		WordCount:   0xd,
+		AndCommand:  0xff,
+		MaxBuffer:   0x1111,
+		MaxMPXCount: 0xa,
+		VarData:     []byte{},
 	}
 }
 

--- a/lib/smb/smb/smb.go
+++ b/lib/smb/smb/smb.go
@@ -170,7 +170,6 @@ type NegotiateResV1 struct {
 	ServerTimezon   uint16
 	ChallengeLength uint8
 	ByteCount       uint16 `smb:"len:VarData"`
-	// variable data afterwards that we don't care about
 	VarData []byte
 }
 

--- a/lib/smb/smb/zgrab.go
+++ b/lib/smb/smb/zgrab.go
@@ -133,7 +133,7 @@ type SMBLog struct {
 
 	// If present, represent the NativeOS, NTLM, and GroupName fields of SMBv1 Session Setup Negotiation
 	// An empty string for these values indicate the data was not available
-	OsName    string `json:"os_name"`
+	NativeOs  string `json:"native_os"`
 	NTLM      string `json:"ntlm"`
 	GroupName string `json:"group_name"`
 
@@ -323,7 +323,7 @@ func (ls *LoggedSession) LoggedSessionSetupV1() (err error) {
 	// These fields are technically all optional, but guaranteed to be in this order
 	fields := strings.Split(decoded, "\000")
 	if len(fields) > 0 {
-		ls.Log.OsName = fields[0]
+		ls.Log.NativeOs = fields[0]
 	}
 	if len(fields) > 1 {
 		ls.Log.NTLM = fields[1]

--- a/lib/smb/smb/zgrab.go
+++ b/lib/smb/smb/zgrab.go
@@ -299,12 +299,13 @@ func (ls *LoggedSession) LoggedSessionSetupV1() (err error) {
 	paddingLength := int((buf[11] >> 7) & 1)
 	// Skip header
 	buf = buf[SmbHeaderV1Length:]
-	// The byte after the header holds the number of words in uint16s
-	if len(buf) < (int(buf[0])*2)+3+paddingLength {
+	// The byte after the header holds the number of words remaining in uint16s
+	// words + 3 bytes for wordlength & bytecount + potential unicode padding
+	claimedRemainingSize := int(buf[0])*2 + 3 + paddingLength
+	if len(buf) < claimedRemainingSize {
 		return nil
 	}
-	// words + 3 bytes for wordlength & bytecount + potential unicode padding
-	buf = buf[(int(buf[0])*2)+3+paddingLength:]
+	buf = buf[claimedRemainingSize:]
 
 	var decoded string
 	if paddingLength == 1 {

--- a/zgrab2_schemas/zgrab2/smb.py
+++ b/zgrab2_schemas/zgrab2/smb.py
@@ -52,6 +52,9 @@ smb_scan_response = SubRecord({
             "revision": Unsigned8BitInteger(doc="Protocol Revision"),
             "version_string": String(doc="Full SMB Version String"),
             }),
+        "native_os": String(doc="Operating system claimed by server"),
+        "ntlm": String(doc="Native LAN Manager"),
+        "group_name": String(doc="Group name"),
         "smb_capabilities": SubRecord({
             "smb_dfs_support": Boolean(doc="Server supports Distributed File System"),
             "smb_leasing_support": Boolean(doc="Server supports Leasing"),
@@ -62,7 +65,7 @@ smb_scan_response = SubRecord({
             "smb_encryption_support": Boolean(doc="Server supports encryption"),
             }, doc="Capabilities flags for the connection. See [MS-SMB2] Sect. 2.2.4."),
         'negotiation_log': negotiate_log,
-        'has_ntlm': Boolean(),
+        'has_ntlm': Boolean(doc="Server supports the NTLM authentication method"),
         'session_setup_log': session_setup_log,
     })
 }, extends=zgrab2.base_scan_response)


### PR DESCRIPTION
Performs session setup during SMBv1 negotiations to get these fields.

## How to Test

I tested this locally against [this](https://hub.docker.com/r/dperson/samba) samba image, with the settings modified to allow SMBv1 (it is disabled by default).

via `./zgrab2 smb --setup-session <<< "127.0.0.1,," | jq`:

```
{
  "ip": "x.x.x.x",
  "data": {
    "smb": {
      "status": "success",
      "protocol": "smb",
      "result": {
        "smbv1_support": true,
        "smb_version": {
          "major": 1,
          "minor": 0,
          "revision": 0,
          "version_string": "SMB 1.0"
        },
        "os_name": "Unix",
        "ntlm": "Samba 3.0.37",
        "group_name": "WORKGROUP",
        "has_ntlm": false
      },
      "timestamp": "2020-12-10T16:20:08Z"
    }
  }
}
```

I also tested against various hosts in the wild, though the results aren't interesting.

Against a host that doesn't support SMBv1 or requires credentials during session setup, these string fields will be empty.

## Notes & Caveats

This also includes a small bugfix; in the SMBv1 negotiation, a `ByteCount` field was set to 14 rather than the correct 12.

## Issue Tracking
