### PR TITLE
fix issue 288

### DIFF
--- a/modules/postgres/connection.go
+++ b/modules/postgres/connection.go
@@ -22,6 +22,8 @@ const maxOutputSize = 1024
 // Don't read an unlimited number of tag/value pairs from the server
 const maxReadAllPackets = 64
 
+const uint32Len = 4
+
 // Connection wraps the state of a given connection to a server.
 type Connection struct {
 	// Target is the requested scan target.
@@ -143,10 +145,10 @@ func (c *Connection) tryReadPacket(header byte) (*ServerPacket, *zgrab2.ScanErro
 		log.Debugf("postgres server %s reported packet size of %d bytes; only reading %d bytes.", c.Target.String(), bodyLen, maxPacketSize)
 		sizeToRead = maxPacketSize
 	}
-	if sizeToRead < 4 {
-		sizeToRead = 4
+	if sizeToRead < uint32Len {
+		sizeToRead = uint32Len
 	}
-	body := make([]byte, sizeToRead - 4) // Length includes the length of the Length uint32
+	body := make([]byte, sizeToRead - uint32Len) // Length includes the length of the Length uint32
 	_, err = io.ReadFull(c.Connection, body)
 	if err != nil && err != io.EOF {
 		return nil, zgrab2.DetectScanError(err)

--- a/modules/postgres/connection.go
+++ b/modules/postgres/connection.go
@@ -143,6 +143,9 @@ func (c *Connection) tryReadPacket(header byte) (*ServerPacket, *zgrab2.ScanErro
 		log.Debugf("postgres server %s reported packet size of %d bytes; only reading %d bytes.", c.Target.String(), bodyLen, maxPacketSize)
 		sizeToRead = maxPacketSize
 	}
+	if sizeToRead < 4 {
+		sizeToRead = 4
+	}
 	body := make([]byte, sizeToRead - 4) // Length includes the length of the Length uint32
 	_, err = io.ReadFull(c.Connection, body)
 	if err != nil && err != io.EOF {


### PR DESCRIPTION
## How to Test
This happened on 32 bit with Ubuntu OS
perform tests on a host that has `sizeToRead = = 0` 
## Notes & Caveats
https://github.com/golang/go/issues/38673
https://stackoverflow.com/questions/27647737/maximum-length-of-a-slice-in-go
## Issue Tracking

https://github.com/zmap/zgrab2/issues/288
