### PR TITLE
Fix incorrect logging calls that don't do formatting

### DIFF
--- a/config.go
+++ b/config.go
@@ -103,7 +103,7 @@ func validateFrameworkConfiguration() {
 
 	// Validate Go Runtime config
 	if config.GOMAXPROCS < 0 {
-		log.Fatal("invalid GOMAXPROCS (must be positive, given %d)", config.GOMAXPROCS)
+		log.Fatalf("invalid GOMAXPROCS (must be positive, given %d)", config.GOMAXPROCS)
 	}
 	runtime.GOMAXPROCS(config.GOMAXPROCS)
 

--- a/conn.go
+++ b/conn.go
@@ -85,7 +85,7 @@ func (c *TimeoutConnection) Read(b []byte) (n int, err error) {
 		// we had to shrink the output buffer AND we used up the whole shrunk size, AND we're not at EOF
 		switch c.ReadLimitExceededAction {
 		case ReadLimitExceededActionTruncate:
-			logrus.Debug("Truncated read from %d bytes to %d bytes (hit limit of %d bytes)", origSize, n, c.BytesReadLimit)
+			logrus.Debugf("Truncated read from %d bytes to %d bytes (hit limit of %d bytes)", origSize, n, c.BytesReadLimit)
 			err = io.EOF
 		case ReadLimitExceededActionError:
 			return n, ErrReadLimitExceeded


### PR DESCRIPTION
The errors can be found by running `go vet`.
Found these issues while packaging. Somehow, these mistakes give a build failure in nixpkgs. I'm not sure why.

## How to Test

Check output of `go vet` before and after. I don't think these changes require much testing otherwise, zgrab2 still builds and go vet is happy now (although `go vet` still shows some other stuff, but I'm not familiar enough to fix those).
