### PR TITLE
Fix null results in fox module

### DIFF
--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -7,7 +7,6 @@ package fox
 
 import (
 	"errors"
-	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 )

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -6,6 +6,7 @@
 package fox
 
 import (
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 )
@@ -107,6 +108,10 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	err = GetFoxBanner(result, conn)
 	if !result.IsFox {
 		result = nil
+		err = &zgrab2.ScanError{
+			Err:    fmt.Errorf("host with ip %s, answer, but is not a fox service", target.IP),
+			Status: zgrab2.SCAN_PROTOCOL_ERROR,
+		}
 	}
 	return zgrab2.TryGetScanStatus(err), result, err
 }

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -6,6 +6,7 @@
 package fox
 
 import (
+	"errors"
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
@@ -109,7 +110,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	if !result.IsFox {
 		result = nil
 		err = &zgrab2.ScanError{
-			Err:    fmt.Errorf("host with ip %s, answer, but is not a fox service", target.IP),
+			Err:    errors.New("host responds, but is not a fox service"),
 			Status: zgrab2.SCAN_PROTOCOL_ERROR,
 		}
 	}

--- a/modules/postgres/connection.go
+++ b/modules/postgres/connection.go
@@ -22,6 +22,8 @@ const maxOutputSize = 1024
 // Don't read an unlimited number of tag/value pairs from the server
 const maxReadAllPackets = 64
 
+const uint32Len = 4
+
 // Connection wraps the state of a given connection to a server.
 type Connection struct {
 	// Target is the requested scan target.
@@ -143,7 +145,10 @@ func (c *Connection) tryReadPacket(header byte) (*ServerPacket, *zgrab2.ScanErro
 		log.Debugf("postgres server %s reported packet size of %d bytes; only reading %d bytes.", c.Target.String(), bodyLen, maxPacketSize)
 		sizeToRead = maxPacketSize
 	}
-	body := make([]byte, sizeToRead - 4) // Length includes the length of the Length uint32
+	if sizeToRead < uint32Len {
+		sizeToRead = uint32Len
+	}
+	body := make([]byte, sizeToRead - uint32Len) // Length includes the length of the Length uint32
 	_, err = io.ReadFull(c.Connection, body)
 	if err != nil && err != io.EOF {
 		return nil, zgrab2.DetectScanError(err)


### PR DESCRIPTION
Fix incorrect fox service recognition

if `results == null ` but `status == "success"`

## How to Test

try to make request in service with `fox` flag

