### PR TITLE
fix for smtp module

### DIFF
--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -214,7 +214,7 @@ func VerifySMTPContents(banner string) (zgrab2.ScanStatus, int) {
 	case err == nil && (code < 200 || code >= 300):
 		return zgrab2.SCAN_APPLICATION_ERROR, code
 	case err == nil,
-	     strings.Contains(banner, "STMP"),
+	     strings.Contains(banner, "SMTP"),
 	     strings.Contains(lowerBanner, "blacklist"),
 	     strings.Contains(lowerBanner, "abuse"),
 	     strings.Contains(lowerBanner, "rbl"),

--- a/modules/smtp/scanner_test.go
+++ b/modules/smtp/scanner_test.go
@@ -1,0 +1,53 @@
+package smtp
+
+import (
+	"github.com/zmap/zgrab2"
+	"testing"
+)
+
+func TestVerifySMTPContents(t *testing.T) {
+	type Test struct {
+		Banner         string
+		ExpectedStatus zgrab2.ScanStatus
+		ExpectedCode   int
+	}
+	testTable := map[string]Test{
+		"success with code": {
+			Banner: `220-some.host.com ESMTP Exim 4.93 #2 Thu, 04 Feb 2021 13:34:12 -0500 
+220-We do not authorize the use of this system to transport unsolicited, 
+220 and/or bulk e-mail.`,
+			ExpectedStatus: zgrab2.SCAN_SUCCESS,
+			ExpectedCode:   0,
+		},
+		"success without code": {
+			Banner: `ESMTP Exim 4.93 #2 Thu, 04 Feb 2021 13:34:12 -0500 
+220-We do not authorize the use of this system to transport unsolicited, 
+220 and/or bulk e-mail.`,
+			ExpectedStatus: zgrab2.SCAN_SUCCESS,
+			ExpectedCode:   0,
+		},
+		"invalid protocol": {
+			Banner:         "gibberish that doesnt match expected response",
+			ExpectedStatus: zgrab2.SCAN_PROTOCOL_ERROR,
+			ExpectedCode:   0,
+		},
+		"error response": {
+			Banner:         "500-some.host.com ESMTP something went horribly wrong.",
+			ExpectedStatus: zgrab2.SCAN_APPLICATION_ERROR,
+			ExpectedCode:   500,
+		},
+	}
+
+	for name, test := range testTable {
+		t.Run(name, func(t *testing.T) {
+			status, code := VerifySMTPContents(test.Banner)
+			if status != test.ExpectedStatus {
+				t.Errorf("recieved unexpected status: %s, wanted: %s", status, test.ExpectedStatus)
+			}
+			if code != test.ExpectedCode {
+				t.Errorf("recieved unexpected code: %d, wanted: %d", code, test.ExpectedCode)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
The SMTP module was matching on "STMP" when verifying the contents of the scan response. This PR fixes the typo and adds a test for the VerifySMTPContents() function.

## How to Test

`make test` and verify all tests pass.
