### PR TITLE
Add support for decoded and encoded HTTP body hashes

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -68,9 +68,9 @@ type Flags struct {
 	// using the specified algorithm, allowing a user of the response to recompute a matching hash
 	ComputeDecodedBodyHashAlgorithm string `long:"compute-decoded-body-hash-algorithm" choice:"sha256" choice:"sha1" description:"Choose algorithm for BodyHash field"`
 
-	// ComputeEncodedBodyHashAlgorithm enables sha256 hashes of the page fingerprint.
+	// ComputeRawBodyHash enables sha256 hashes of the page fingerprint.
 	// Enabled by default. Disabled by default if ComputeDecodedBodyHashAlgorithm is set
-	ComputeEncodedBodyHash bool `long:"compute-encoded-body-hash" description:"Enable sha256 hash for page fingerprint"`
+	ComputeRawBodyHash bool `long:"compute-raw-body-hash" description:"Enable sha256 hash for page fingerprint"`
 
 	// WithBodyLength enables adding the body_size field to the Response
 	WithBodyLength bool `long:"with-body-size" description:"Enable the body_size attribute, for how many bytes actually read"`
@@ -162,7 +162,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
   // If ComputeDecodedBodyHashAlgorithm is not set, enable sha256 encoded body hash by default
   // can also be explicitly enabled in conjunction with ComputeDecodedBodyHashAlgorithm
 	if fl.ComputeDecodedBodyHashAlgorithm == "" {
-		fl.ComputeEncodedBodyHash = true
+		fl.ComputeRawBodyHash = true
 	}
 	return nil
 }
@@ -340,7 +340,7 @@ func (scan *scan) getCheckRedirect() func(*http.Request, *http.Response, []*http
 			if scan.scanner.decodedHashFn != nil {
 				res.BodyHash = scan.scanner.decodedHashFn([]byte(res.BodyText))
 			}
-			if scan.scanner.config.ComputeEncodedBodyHash {
+			if scan.scanner.config.ComputeRawBodyHash {
 				m := sha256.New()
 				m.Write(b.Bytes())
 				res.BodySHA256 = m.Sum(nil)
@@ -487,7 +487,7 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 		if scan.scanner.decodedHashFn != nil {
 			scan.results.Response.BodyHash = scan.scanner.decodedHashFn([]byte(scan.results.Response.BodyText))
 		}
-		if scan.scanner.config.ComputeEncodedBodyHash {
+		if scan.scanner.config.ComputeRawBodyHash {
 			m := sha256.New()
 			m.Write(buf.Bytes())
 			scan.results.Response.BodySHA256 = m.Sum(nil)

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -68,9 +68,9 @@ type Flags struct {
 	// using the specified algorithm, allowing a user of the response to recompute a matching hash
 	ComputeDecodedBodyHashAlgorithm string `long:"compute-decoded-body-hash-algorithm" choice:"sha256" choice:"sha1" description:"Choose algorithm for BodyHash field"`
 
-	// ComputeEncodedBodyHashAlgorithm enables choosing sha256 hashes of the page fingerprint.
+	// ComputeEncodedBodyHashAlgorithm enables sha256 hashes of the page fingerprint.
 	// Enabled by default. Disabled by default if ComputeDecodedBodyHashAlgorithm is set
-	ComputeEncodedBodyHashAlgorithm bool `long:"compute-encoded-body-hash-algorithm" description:"Enable sha256 hash for page fingerprint"`
+	ComputeEncodedBodyHash bool `long:"compute-encoded-body-hash" description:"Enable sha256 hash for page fingerprint"`
 
 	// WithBodyLength enables adding the body_size field to the Response
 	WithBodyLength bool `long:"with-body-size" description:"Enable the body_size attribute, for how many bytes actually read"`
@@ -159,8 +159,10 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		log.Panicf("Invalid ComputeDecodedBodyHashAlgorithm choice made it through zflags: %s", scanner.config.ComputeDecodedBodyHashAlgorithm)
 	}
 
+  // If ComputeDecodedBodyHashAlgorithm is not set, enable sha256 encoded body hash by default
+  // can also be explicitly enabled in conjunction with ComputeDecodedBodyHashAlgorithm
 	if fl.ComputeDecodedBodyHashAlgorithm == "" {
-		fl.ComputeEncodedBodyHashAlgorithm = true
+		fl.ComputeEncodedBodyHash = true
 	}
 	return nil
 }
@@ -338,7 +340,7 @@ func (scan *scan) getCheckRedirect() func(*http.Request, *http.Response, []*http
 			if scan.scanner.decodedHashFn != nil {
 				res.BodyHash = scan.scanner.decodedHashFn([]byte(res.BodyText))
 			}
-			if scan.scanner.config.ComputeEncodedBodyHashAlgorithm {
+			if scan.scanner.config.ComputeEncodedBodyHash {
 				m := sha256.New()
 				m.Write(b.Bytes())
 				res.BodySHA256 = m.Sum(nil)
@@ -485,7 +487,7 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 		if scan.scanner.decodedHashFn != nil {
 			scan.results.Response.BodyHash = scan.scanner.decodedHashFn([]byte(scan.results.Response.BodyText))
 		}
-		if scan.scanner.config.ComputeEncodedBodyHashAlgorithm {
+		if scan.scanner.config.ComputeEncodedBodyHash {
 			m := sha256.New()
 			m.Write(buf.Bytes())
 			scan.results.Response.BodySHA256 = m.Sum(nil)


### PR DESCRIPTION
This merge requests adds the flag ```ComputeRawBodyHash``` that allows for a sha256 hash to be computed on the HTTP undecoded body. This change updates logic in ```modules/http/scanner.go``` to be if/if instead of if/else. A code snippet of the primary logic change is below: 


New: 
```
if scan.scanner.decodedHashFn != nil {
	res.BodyHash = scan.scanner.decodedHashFn([]byte(res.BodyText))
}
if scan.scanner.config.ComputeEncodedBodyHashAlgorithm {
       m := sha256.New()
       m.Write(b.Bytes())
       res.BodySHA256 = m.Sum(nil)
}
```

Old: 
```
if scan.scanner.decodedHashFn != nil {
       res.BodyHash = scan.scanner.decodedHashFn([]byte(res.BodyText))
} else {
       m := sha256.New()
       m.Write(b.Bytes())
       res.BodySHA256 = m.Sum(nil)
```
```ComputeRawBodyHash``` is implemented as a boolean zGrab2 flag. It is true by default, mimicking the current functionality, unless ```ComputeDecodedBodyHashAlgorithm``` is set, then it is false by default. This keeps the if/else logic zgrab2 currently has in place unless explicitly set otherwise. 

Both ```ComputeRawBodyHash``` and ```ComputeDecodedBodyHashAlgorithm``` can be set in which case a hash for the encoded body and decoded body will both be returned.

## How to Test

This change can be tested from my branch. 

Testing examples:

This is the added feature for this merge request. A sha1 hash will be returned for the encoded body and a sha256 hash for the decoded body. 
```
make && echo <IP> | ./zgrab2 http --compute-decoded-body-hash-algorithm=sha256 --compute-encoded-body-hash | jq
```

This is the current functionality with no change. Internally the ```--compute-raw-body-hash``` flag will be set to true and a sha1 hash will be returned for the encoded body.
```
make && echo <IP> | ./zgrab2 http | jq
```

This also maintains current functionality. ```--compute-raw-body-hash``` will not be enabled and the user provided hash function will be used for the decoded body. 
```
make && echo <IP> | ./zgrab2 http --compute-decoded-body-hash-algorithm=sha256 | jq
```

## Notes & Caveats

Users should be able to access hashes for encoded and decoded http bodies. This MR adds support for that.

