### PR TITLE
remove masking of s7 protocols errors

### DIFF
--- a/modules/siemens/s7.go
+++ b/modules/siemens/s7.go
@@ -57,14 +57,14 @@ func GetS7Banner(logStruct *S7Log, connection net.Conn, reconnect ReconnectFunct
 	// Make Module Identification request
 	moduleIdentificationResponse, err := readRequest(connection, S7_SZL_MODULE_IDENTIFICATION)
 	if err != nil {
-		return nil // mask errors after detecting IsS7
+		return err
 	}
 	parseModuleIdentificatioNRequest(logStruct, &moduleIdentificationResponse)
 
 	// Make Component Identification request
 	componentIdentificationResponse, err := readRequest(connection, S7_SZL_COMPONENT_IDENTIFICATION)
 	if err != nil {
-		return nil // mask errors after detecting IsS7
+		return err
 	}
 	parseComponentIdentificationResponse(logStruct, &componentIdentificationResponse)
 


### PR DESCRIPTION
This MR removes the masking of errors for the siemens s7 protocol scanner. 

The current behaviour:
```
➜  zgrab2 git:(hmcguinn/s7-misidentification) ✗ echo $IP | ./zgrab2 siemens                   
INFO[0000] started grab at 2021-07-20T20:58:16-04:00    
{"ip":"$IP","data":{"siemens":{"status":"success","protocol":"siemens","result":{"is_s7":true},"timestamp":"2021-07-20T20:58:16-04:00"}}}
INFO[0001] finished grab at 2021-07-20T20:58:18-04:00   
{"statuses":{"siemens":{"successes":1,"failures":0}},"start":"2021-07-20T20:58:16-04:00","end":"2021-07-20T20:58:18-04:00","duration":"1.552316484s"}
```

The scan is marked as a success when no information is returned.


The updated behaviour:
```
➜  zgrab2 git:(hmcguinn/s7-misidentification) ✗ echo $IP | ./zgrab2 siemens         
INFO[0000] started grab at 2021-07-20T20:44:09-04:00    
{"ip":"$IP","data":{"siemens":{"status":"unknown-error","protocol":"siemens","result":{"is_s7":true},"timestamp":"2021-07-20T20:44:09-04:00","error":"not a S7 packet"}}}

```
## How to Test

```echo $IP | ./zgrab2 siemens```
## Notes & Caveats

The S7 protocol scanner currently masks errors and will silently fail if a host responds with a ISO 8327-1 "Abort" packet. The scan will be incorrectly marked as a false positive. 