### PR TITLE
smb: allow dynamic length fields of exact length

### DIFF
--- a/lib/smb/smb/encoder/encoder.go
+++ b/lib/smb/smb/encoder/encoder.go
@@ -441,7 +441,7 @@ func unmarshal(buf []byte, v interface{}, meta *Metadata) (interface{}, error) {
 					o = int(meta.CurrOffset)
 				}
 				// Prevent searching past the end of the buffer for variable data
-				if o+l >= len(meta.ParentBuf) {
+				if o+l > len(meta.ParentBuf) {
 					return nil, errors.New(fmt.Sprintf("field '%s' wants %d bytes but only %d bytes remain.", meta.CurrField, l, len(meta.ParentBuf)-o))
 				}
 				// Variable length data is relative to parent/outer struct. Reset reader to point to beginning of data


### PR DESCRIPTION
In order for the following line,

```
r = bytes.NewBuffer(meta.ParentBuf[o : o+l])
```

to succeed, `o+l` need only be `<= len(meta.ParentBuf)`, not `<`.

This causes fields of exactly correct length to fail to unmarshal. This would not prevent a scan from being successful, but it would stop the `targetName` and `negotiateFlags` fields from being populated due to the early exit.