### PR TITLE
Adds --hex option to `banner` module

### DIFF
--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"regexp"
 	"strconv"
+	"encoding/hex"
 
 	"github.com/zmap/zgrab2"
 )
@@ -24,6 +25,7 @@ type Flags struct {
 	Pattern   string `long:"pattern" description:"Pattern to match, must be valid regexp."`
 	UseTLS    bool   `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options. "`
 	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
+	Hex       bool   `long:"hex" description:"Store banner value in hex. "`
 	zgrab2.TLSFlags
 }
 
@@ -179,7 +181,12 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	if readerr != io.EOF && readerr != nil {
 		return zgrab2.TryGetScanStatus(readerr), nil, readerr
 	}
-	results := Results{Banner: string(ret), Length: len(ret)}
+	var results Results
+	if scanner.config.Hex {
+		results = Results{Banner: hex.EncodeToString(ret), Length: len(ret)}
+	} else {
+		results = Results{Banner: string(ret), Length: len(ret)}
+	}
 	if scanner.regex.Match(ret) {
 		return zgrab2.SCAN_SUCCESS, &results, nil
 	}


### PR DESCRIPTION
Conversion of binary responses to UTF8 occasionally yields U+FFFD [replacement characters](https://en.wikipedia.org/wiki/Specials_(Unicode_block)) (see #197, #263 for examples). As a result it is not possible to restore the original response.

This introduces the `--hex` option to the `banner` module. When enabled, the `banner` value will contain server response in hex.

## How to Test

Lets grab `favicon.ico` from ur.ru:
```sh
$ echo 212.23.93.60 | zgrab2  banner -p 80 --probe 'GET /favicon.ico\n'
INFO[0000] started grab at 2021-08-20T15:47:03+05:00
{"ip":"212.23.93.60","data":{"banner":{"status":"success","protocol":"banner","result":{"banner":"\u0000\u0000\u0001\u0000\u0001\u0000\u0010\u0010\u0000\u0000\u0001\u0000\u0018\u0000h\u0003\u0000\u0000\u0016\u0000\u0000\u0000(\u0000\u0000\u0000\u0010\u0000\u0000\u0000 \u0000\u0000\u0000\u0001\u0000\u0018\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\ufffd\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\u0000\u0000\u0000w\ufffd\u0000\ufffd\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000|\ufffd\u0000w\ufffd\u0000q\ufffd\u0000m\ufffd\u0000m\ufffd\u0000j\ufffd\u0000j\ufffd\u0000g\ufffd\u0000g\ufffd\u0000f\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\n\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000w\ufffd?\ufffd\ufffdj\ufffd\ufffdj\ufffd\ufffd^\ufffd\ufffd\u0000j\ufffd\u0000g\ufffd\u0000g\ufffd\u0000g\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\u0000g\ufffd\u0000g\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdr\ufffd\ufffd?\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\u0000j\ufffd\u0000j\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0003\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdz\ufffd\ufffd\u0000\ufffd\ufffd\u0000|\ufffdz\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\u0000m\ufffd\u0000j\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffd\u0001\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd?\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\u0000q\ufffd\u0000m\ufffd\u0000f\ufffd\u0000f\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd?\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffdN\ufffd\ufffd\ufffd\ufffd\ufffda\ufffd\ufffd\u0000q\ufffd\u0000q\ufffd\u0000f\ufffd\u0000f\ufffd\u0001\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdm\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0007\ufffd\ufffd\u0012\ufffd\ufffd\u0000|\ufffd\u0000w\ufffd\u0000j\ufffd\u0000q\ufffd\u0001\ufffd\ufffd\u001e\ufffd\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdX\ufffd\ufffd\u0003\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000|\ufffd\u0000q\ufffd\u0000w\ufffd\u0001\ufffd\ufffdI\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdX\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\n\ufffd\ufffd\ufffd\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0000\ufffd\ufffd\u0001\ufffd\ufffdX\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd-\ufffd\ufffd\u0017\ufffd\ufffd\u0000\ufffd\ufffd\u0000w\ufffd\u0000w\ufffd\u0001\ufffd\ufffd\ufffd\ufffd\ufffd\u0026\ufffd\ufffd\u0016\ufffd\ufffd\u0016\ufffd\ufffd\u0016\ufffd\ufffd\u0019\ufffd\ufffd\u0019\ufffd\ufffd\u0019\ufffd\ufffd\u0019\ufffd\ufffd%\ufffd\ufffd\u0018\ufffd\ufffd%\ufffd\ufffd\n\ufffd\ufffd\n\ufffd\ufffd\u0010\ufffd\u0000\ufffd\ufffdp\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdI\ufffd\ufffd\u0003\ufffd\ufffd\u0003\ufffd\ufffd\u0000\u0000\u0000\u0001\ufffd\ufffd\n\ufffd\ufffd\n\ufffd\ufffd\u0001\ufffd\ufffd\n\ufffd\ufffd\n\ufffd\ufffd\n\ufffd\ufffd\u0001\ufffd\ufffd\u0001\ufffd\ufffd\n\ufffd\ufffd\n\ufffd\ufffd\n\ufffd\ufffd\u0001\ufffd\ufffd\n\ufffd\ufffd\u0000\u0000\u0000\ufffd\u0001\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\ufffd\u0001\u0000\u0000","length":894},"timestamp":"2021-08-20T15:47:03+05:00"}}}
INFO[0000] finished grab at 2021-08-20T15:47:03+05:00
{"statuses":{"banner":{"successes":1,"failures":0}},"start":"2021-08-20T15:47:03+05:00","end":"2021-08-20T15:47:03+05:00","duration":"321.202258ms"}
```
Notice the multiple `\ufffd` characters which actually correspond to different byte sequences in the original response that can not be represented as UTF8 characters.

With `--hex`:
```sh
$ echo 212.23.93.60 | zgrab2  banner -p 80 --probe 'GET /favicon.ico\n' --hex
INFO[0000] started grab at 2021-08-20T15:48:26+05:00
{"ip":"212.23.93.60","data":{"banner":{"status":"success","protocol":"banner","result":{"banner":"00000100010010100000010018006803000016000000280000001000000020000000010018000000000000000000000000000000000000000000000000000000000088ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0000000077ff0095ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0088ff01a8ff008dff0081ff007cff0077ff0071ff006dff006dff006aff006aff0067ff0067ff0066ff0066ff0066ff0088ff0abdff0095ff0088ff0081ff0077ff3f8ef66aa1f76aa1f75e9af6006aff0067ff0067ff0067ff0066ff0066ff0088ff00ccff01a8ff008dff0088ff8cbaf9ecf4feffffffffffffffffffecf4fe8cbaf90067ff0067ff0066ff0066ff0088ff00edff01a8ff0095ff8cbaf9ffffffeef8ff72aaf83f8ef6a8ccfaffffffa8ccfa006aff006aff0066ff0066ff0095ff00fdff00b5ff039affecf4feffffff7ab1f90081ff007cff7ab1f9ffffffa8ccfa006dff006aff0066ff0066ff0095ff00fdff01bbfe01a8fffffffff5faff3f8ef60088ff0081ff8cbaf9ffffffa8ccfa0071ff006dff0066ff0066ff0095ff00fdff00c4ff01a8ffffffffeef8ff3f8ef60095ff0088ff4ea6f996cafb61acf90071ff0071ff0066ff0066ff01a8ff00fdff00ccff00b5fff5faffffffff6db8fa0095ff008dff0088ff0786f6128bf6007cff0077ff006aff0071ff01a8ff1efffe00ccff01bbfe00b5ffffffffe4f2fe58b7fa039aff0095ff008dff0081ff0081ff007cff0071ff0077ff01a8ff49f5ff00daff00ccff00c4ffb3defdffffffffffffe4f2fee4f2fef5faff58b7fa0095ff0095ff0081ff0081ff0abdff92fbfe00daff00ccff00ccff01bbfe58b7fa98d3fcb3defdaadbfd82cbfc2dacfa17a7fa008dff0077ff0077ff01a8fffffff726f3ff16e3ff16e3ff16e3ff19d7ff19d7ff19d7ff19d7ff25c8ff18c6ff25c8ff0abdff0a8bff107fff0095ff70d0fcf6f7f7fffffffffffff5faffeef8ffdcf5fec0ffffc0ffffc0ffffaaf7ff92fbfe49dafe039aff039aff00000001a8ff0abdff0abdff01bbfe0abdff0abdff0abdff01bbfe01bbfe0abdff0abdff0abdff01bbfe0abdff00000080010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080010000","length":894},"timestamp":"2021-08-20T15:48:26+05:00"}}}
INFO[0000] finished grab at 2021-08-20T15:48:26+05:00
{"statuses":{"banner":{"successes":1,"failures":0}},"start":"2021-08-20T15:48:26+05:00","end":"2021-08-20T15:48:26+05:00","duration":"337.329256ms"}
```
Resulting hex string can be used to restore original binary value or for other processing:
```sh
$ echo "00000100010010100000010018006803000016000000280000001000000020000000010018000000000000000000000000000000000000000000000000000000000088ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0000000077ff0095ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0066ff0088ff01a8ff008dff0081ff007cff0077ff0071ff006dff006dff006aff006aff0067ff0067ff0066ff0066ff0066ff0088ff0abdff0095ff0088ff0081ff0077ff3f8ef66aa1f76aa1f75e9af6006aff0067ff0067ff0067ff0066ff0066ff0088ff00ccff01a8ff008dff0088ff8cbaf9ecf4feffffffffffffffffffecf4fe8cbaf90067ff0067ff0066ff0066ff0088ff00edff01a8ff0095ff8cbaf9ffffffeef8ff72aaf83f8ef6a8ccfaffffffa8ccfa006aff006aff0066ff0066ff0095ff00fdff00b5ff039affecf4feffffff7ab1f90081ff007cff7ab1f9ffffffa8ccfa006dff006aff0066ff0066ff0095ff00fdff01bbfe01a8fffffffff5faff3f8ef60088ff0081ff8cbaf9ffffffa8ccfa0071ff006dff0066ff0066ff0095ff00fdff00c4ff01a8ffffffffeef8ff3f8ef60095ff0088ff4ea6f996cafb61acf90071ff0071ff0066ff0066ff01a8ff00fdff00ccff00b5fff5faffffffff6db8fa0095ff008dff0088ff0786f6128bf6007cff0077ff006aff0071ff01a8ff1efffe00ccff01bbfe00b5ffffffffe4f2fe58b7fa039aff0095ff008dff0081ff0081ff007cff0071ff0077ff01a8ff49f5ff00daff00ccff00c4ffb3defdffffffffffffe4f2fee4f2fef5faff58b7fa0095ff0095ff0081ff0081ff0abdff92fbfe00daff00ccff00ccff01bbfe58b7fa98d3fcb3defdaadbfd82cbfc2dacfa17a7fa008dff0077ff0077ff01a8fffffff726f3ff16e3ff16e3ff16e3ff19d7ff19d7ff19d7ff19d7ff25c8ff18c6ff25c8ff0abdff0a8bff107fff0095ff70d0fcf6f7f7fffffffffffff5faffeef8ffdcf5fec0ffffc0ffffc0ffffaaf7ff92fbfe49dafe039aff039aff00000001a8ff0abdff0abdff01bbfe0abdff0abdff0abdff01bbfe01bbfe0abdff0abdff0abdff01bbfe0abdff00000080010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080010000" | xxd -r -p > /tmp/favicon.ico
```

## Issue Tracking

Refs #197, #263