### PR TITLE
Fix http module panic

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -550,6 +550,12 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 		if readLen < sliceLen {
 			sliceLen = readLen
 		}
+
+		bodyTextLen := int64(len(bodyText))
+		if bodyTextLen < sliceLen {
+			sliceLen = bodyTextLen
+		}
+
 		sliceBuf := bodyText[:sliceLen]
 		if strings.Contains(sliceBuf, "The plain HTTP request was sent to HTTPS port") ||
 			strings.Contains(sliceBuf, "You're speaking plain HTTP") ||


### PR DESCRIPTION
Fix possible http module panic 
it can happend when `io.CopyN` retrun error and `readLen != len(bodyText)`
https://pkg.go.dev/io#CopyN

## How to Test

Test based on http requests

## Issue Tracking

https://github.com/zmap/zgrab2/issues/319