### PR TITLE
jarm: update jarm to not fail on handshake failure

### DIFF
--- a/utility.go
+++ b/utility.go
@@ -145,9 +145,7 @@ func ReadAvailableWithOptions(conn net.Conn, bufferSize int, readTimeout time.Du
 			}
 			return ret, err
 		}
-		if err != nil {
-			return ret, err
-		}
+
 		if n >= maxReadSize {
 			return ret, err
 		}


### PR DESCRIPTION
This PR removes the error handling for a JARM probe response. The reason is that a handshake failure should still be processed the same as any other response. Currently a handshake failure results in the ZeroHash value being returned. This does not match the salesforce jarm module which should be treated as the correct implementation.

After this change, the salesforce and zgrab2 modules will both return the same fingerprint for services that return a handshake failure to one of the probes.

## How to Test

go test ./...

## Notes & Caveats

This PR is being created to bring the zgrab2 JARM module in line with the behavior of the salesforce jarm tool.
