### PR TITLE
Add brackets to IPv6 literals with standard ports in http module

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -427,9 +427,15 @@ func getHTTPURL(https bool, host string, port uint16, endpoint string) string {
 	} else {
 		proto = "http"
 	}
-	if protoToPort[proto] == port {
+	if protoToPort[proto] == port && strings.Contains(host, ":") {
+		//If the host has a ":" in it, assume literal IPv6 address
+		return proto + "://[" + host + "]" + endpoint
+	} else if protoToPort[proto] == port {
+		//Otherwise, just concatenate host and endpoint
 		return proto + "://" + host + endpoint
 	}
+
+	//For non-default ports, net.JoinHostPort will handle brackets for IPv6 literals
 	return proto + "://" + net.JoinHostPort(host, strconv.FormatUint(uint64(port), 10)) + endpoint
 }
 


### PR DESCRIPTION
The HTTP module will currently fail when given IPv6 literals using standard ports (80/http and 443/https). This is because the function `getHTTPURL()` simply concatenates `proto + "://" + host + endpoint`. For non-standard ports (e.g. 8080/http), the function `net.JoinHostPort()` is used, which *will* add brackets to IPv6 literals.

## How to Test

1. Create a file with an IPv6 literal, e.g. `2001:558:6000:1234:5678:abcd:ef` in `input.txt`.
2. Run `./zgrab2 http -f ~/input.txt`. Observe error `"error":"parse \"http://2001:558:6000:1234:5678:abcd:ef/\": invalid port \":ef\" after host"`
3. Run `./zgrab2 http -f ~/input.txt  -p 8080`. Observe connection timeout.
4. Apply patch.  Observe connection timeout for 2.
