### PR TITLE
smb: fix panic in ntlmssp when unmarshaling

### DIFF
--- a/lib/smb/ntlmssp/ntlmssp.go
+++ b/lib/smb/ntlmssp/ntlmssp.go
@@ -172,16 +172,21 @@ func (s *AvPairSlice) UnmarshalBinary(buf []byte, meta *encoder.Metadata) error 
 	if !ok {
 		return errors.New(fmt.Sprintf("Cannot unmarshal field '%s'. Missing offset\n", meta.CurrField))
 	}
-	for i := l; i > 0; {
+	offset := int64(o)
+	length := int64(l)
+	if offset+length > int64(len(meta.ParentBuf)) {
+		return fmt.Errorf("AvPairSlice.UnmarshalBinary: ParentBuf overrun")
+	}
+	for i := length; i > 0; {
 		var avPair AvPair
-		err := encoder.Unmarshal(meta.ParentBuf[o:o+i], &avPair)
+		err := encoder.Unmarshal(meta.ParentBuf[offset:offset+i], &avPair)
 		if err != nil {
 			return err
 		}
 		slice = append(slice, avPair)
 		size := avPair.Size()
-		o += size
-		i -= size
+		offset += int64(size)
+		i -= int64(size)
 	}
 	*s = slice
 	return nil

--- a/lib/smb/ntlmssp/ntlmssp.go
+++ b/lib/smb/ntlmssp/ntlmssp.go
@@ -174,6 +174,10 @@ func (s *AvPairSlice) UnmarshalBinary(buf []byte, meta *encoder.Metadata) error 
 	}
 	offset := int64(o)
 	length := int64(l)
+	if offset < 0 || length < 0 {
+		return fmt.Errorf("AvPairSlice.UnmarshalBinary: offset (%d) and length (%d) should be positive",
+			offset, length)
+	}
 	if offset+length > int64(len(meta.ParentBuf)) {
 		return fmt.Errorf("AvPairSlice.UnmarshalBinary: ParentBuf overrun")
 	}
@@ -184,9 +188,12 @@ func (s *AvPairSlice) UnmarshalBinary(buf []byte, meta *encoder.Metadata) error 
 			return err
 		}
 		slice = append(slice, avPair)
-		size := avPair.Size()
-		offset += int64(size)
-		i -= int64(size)
+		size := int64(avPair.Size())
+		if size < 0 {
+			return fmt.Errorf("AvPairSlice.UnmarshalBinary: Invalid avPair.Size() %d", size)
+		}
+		offset += size
+		i -= size
 	}
 	*s = slice
 	return nil


### PR DESCRIPTION
There are two errors here:

1. The offsets to the ParentBuf are not checked to be in-bounds
2. Types are uint64, but subtracted and compared to > 0.  This allows
   underflow during subtraction of the size.

## How to Test

Unfortunately, I do not have a reproducer.  I have only seen this occur once, and have not been able to reproduce it again.

However, here is the relevant panic.  (I have omitted some lines that are sensitive, but they are not relevant)

```
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:16 +0x19
github.com/zmap/zgrab2/lib/smb/ntlmssp.(*AvPairSlice).UnmarshalBinary(0xc014b78fd8, {0x117ae40, 0xc014b78fd8, 0x20c2778}, 0xc007ad0cc0)
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/lib/smb/ntlmssp/ntlmssp.go:177 +0x405
github.com/zmap/zgrab2/lib/smb/smb/encoder.unmarshal({0xc000a0f988, 0xc007521fe8, 0x0}, {0x117ae40, 0xc014b78fd8}, 0xc007ad0cc0)
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/lib/smb/smb/encoder/encoder.go:323 +0x1b1
github.com/zmap/zgrab2/lib/smb/smb/encoder.unmarshal({0xc000a0f950, 0xc024c5ecd8, 0xc007199600}, {0x10be3a0, 0xc007521f80}, 0x0)
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/lib/smb/smb/encoder/encoder.go:368 +0x16ba
github.com/zmap/zgrab2/lib/smb/smb/encoder.Unmarshal(...)
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/lib/smb/smb/encoder/encoder.go:468
github.com/zmap/zgrab2/lib/smb/smb.(*LoggedSession).LoggedNegotiateProtocol(0xc005417288, 0x1)
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/lib/smb/smb/zgrab.go:527 +0x1745
github.com/zmap/zgrab2/lib/smb/smb.GetSMBLog({0x1606050, 0xc0091cbea0}, 0x1, 0x0, 0x0)
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/lib/smb/smb/zgrab.go:223 +0x16c
github.com/zmap/zgrab2/modules/smb.(*Scanner).Scan(0xc00ced40a0, {{0xc0231ea040, 0x10, 0x10}, {0x0, 0x0}, {0x0, 0x0}, 0xc01837dbc8})
        /go/pkg/mod/github.com/zmap/zgrab2@v0.1.8-0.20210930194046-00fe9ca9af83/modules/smb/scanner.go:116 +0x128

```

## Notes & Caveats

## Issue Tracking
