### PR TITLE
fix http retry-https and use-https default port to 443

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -471,6 +471,11 @@ func (scanner *Scanner) newHTTPScan(t *zgrab2.ScanTarget, useHTTPS bool) *scan {
 	} else {
 		port = uint16(scanner.config.BaseFlags.Port)
 	}
+
+	if useHTTPS && scanner.config.BaseFlags.Port == 80 {
+		port = uint16(protoToPort["https"])
+	}
+
 	ret.url = getHTTPURL(useHTTPS, host, port, scanner.config.Endpoint)
 
 	return &ret


### PR DESCRIPTION
fix http retry-https and use-https default port to 443

## How to Test

Before：
>echo oldpassport.ch.com|zgrab2 http --retry-https
>{"domain":"oldpassport.ch.com","data":{"http":{"status":"unknown-error","protocol":"http","result":{},"timestamp":"2022-03-29T16:07:26+08:00","error":"net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)"}}}

After repair: 
>echo oldpassport.ch.com|zgrab2 http --retry-https
>{"domain":"oldpassport.ch.com","data":{"http":{"status":"success","protocol":"http","result":{"response":{"status_line":"200 OK","status_code":200,"protocol":{"name":"HTTP/1.1","major":1,"minor":1},"headers":{"cache_control":["private"],"content_type":["text/html; charset=utf-8"],"date":["Tue, 29 Mar 2022 08:08:56 GMT"],"server":["Microsoft-IIS/10.0"],"vary":["Accept-Encoding"]},"body":"\u003c!DOCTYPE HTML\u003e\r\n\u003chtml\u003e\r\n\u003chead\u003e\r\n    \u003cmeta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\" /\u003e\r\n    \u003cmeta http-equiv=\"Cache-Control\" content=\"private,must-revalidate\" /\u003e\r\n    \u003cmeta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /\u003e\r\n    \u003cmeta property=\"qc:admins\" content=\"51560247013307246306375\" /\u003e \....,"length":48}}}}}}},"timestamp":"2022-03-29T16:09:04+08:00"}}}