### PR TITLE
Change to support early TLS renegotiation (--renegotiate-freely)

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -30,6 +30,7 @@ import (
 type TLSFlags struct {
 	Config *tls.Config // Config is ready to use TLS configuration
 
+	RenegotiateFreely    bool `long:"renegotiate-freely" description:"Allow renegotiations when requested by server"`
 	SessionTicket        bool `long:"session-ticket" description:"Send support for TLS Session Tickets and output ticket if presented" json:"session"`
 	ExtendedMasterSecret bool `long:"extended-master-secret" description:"Offer RFC 7627 Extended Master Secret extension" json:"extended"`
 	ExtendedRandom       bool `long:"extended-random" description:"Send TLS Extended Random Extension" json:"extran"`
@@ -131,6 +132,12 @@ func (t *TLSFlags) GetTLSConfigForTarget(target *ScanTarget) (*tls.Config, error
 	if t.CertificateMap != "" {
 		// TODO FIXME: Implement
 		log.Fatalf("--certificate-map not implemented")
+	}
+	if t.RenegotiateFreely {
+		// Allow the server to request renegotiate, required by some servers
+		// The following erroring in output means you need this option:
+		// "error":"local error: no renegotiation"
+		ret.Renegotiation = tls.RenegotiateFreelyAsClient
 	}
 	if t.RootCAs != "" {
 		var fd *os.File


### PR DESCRIPTION
This is described in detail in #334 which I accidentally submitted as PR based against master. I didn't realize that the feature/TLS1.3 branch has not yet been merged

This should merge without conflict to TLS1.3

@dadrian are you handling merged to feature/TLS1.3 or is that being worked on separately? If you're the right one for the job, can you please merge this?

As always, thanks!