### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+## Build image ##
+FROM golang:1.18.3-alpine3.16 as build
+
+# System dependencies
+RUN apk add --no-cache make
+
+WORKDIR /usr/src/zgrab2
+
+# Copy and cache deps
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+# Build the actual app
+COPY . .
+RUN make all
+
+## Runtime image ##
+FROM alpine:3.16 as run
+
+COPY --from=build /usr/src/zgrab2/cmd/zgrab2/zgrab2 /usr/bin/zgrab2
+
+ENTRYPOINT ["/usr/bin/zgrab2"]


### PR DESCRIPTION
This PR allows zgrab2 to be built as a docker image so that it can be run like this for example:

```
$ echo 'xxx.xxx.xxx.xxx' | docker run -i zgrab2:latest ssh 2>/dev/null | jq
```
it could be nice to add a GitHub action that automagically build and push the docker image every time a tag is created, so that people may enjoy an official image :)