### PR TITLE
Make it a non-fatal error when EncodeGrab fails to marshal data

### DIFF
--- a/processing.go
+++ b/processing.go
@@ -178,7 +178,7 @@ func grabTarget(input ScanTarget, m *Monitor) []byte {
 	raw := BuildGrabFromInputResponse(&input, moduleResult)
 	result, err := EncodeGrab(raw, includeDebugOutput())
 	if err != nil {
-		log.Fatalf("unable to marshal data: %s", err)
+		log.Errorf("unable to marshal data: %s", err)
 	}
 
 	return result


### PR DESCRIPTION
Make it a non-fatal error when `EncodeGrab` fails to marshal data when called by `grabTarget`. Previously, if a result couldn't be encoded, the process crashed. Now, it logs an error and continues.

The proximate cause for this is https://github.com/zmap/zgrab2/issues/318 (SSH certificates with dates too large crash the process), and the workaround is due to @TrueSkrillor in that same issue. The source of the error is the go standard library's [time module](https://cs.opensource.google/go/go/+/master:src/time/time.go;drc=41b9d8c75e45636a153c2a31d117196a22a7fc6c;l=1317), and it points us to https://github.com/golang/go/issues/4556#c15. Essentially, time is trying to produce a RFC3339 string, and refuses to do so with a year that's out of range.

We began seeing this problem about the week of June 6, 2022, and this change got us past that problem.

## How to Test

The most direct test would be to scan a server vending certificates that trigger this problem. That's potentially hard because I can't provide a list of such servers (they weren't consistent from one day to the next in our testing). Otherwise, I'm not sure how to get the invalid data into `grabTarget`; I admit I haven't looked at the test suite for this project at all (sorry!).

## Notes & Caveats

However, this does appear to be a global change, applying to all scanners. We aren't currently affected by this (or we would have had other uses of zgrab2 crashing with a similar error), but in the future, should we hit bad data, we won't crash, we'll just get a logged warning that we may not notice. That's both good and bad, and I certainly understand if this doesn't get merged because of its global nature.

I don't know go well. I was a bit concerned about passing what must be the `nil` return value back from `grabTarget`, into the `outputQueue` `byte[]` channel, and ultimately into the `OutputResults` function which wants to write it to the (buffered) output file. However, from reading the go stdlib's source, it appears that, because `len(v)`, where v is a `byte[]`, is 0, nothing actually happens: the empty result is swallowed by the buffered writer.

## Issue Tracking

https://github.com/zmap/zgrab2/issues/318
