### PR TITLE
retry-https considered harmful: use original result when retry-https encounters an error

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -609,7 +609,7 @@ func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{
 			defer retry.Cleanup()
 			retryError := retry.Grab()
 			if retryError != nil {
-				return retryError.Unpack(&retry.results)
+				return err.Unpack(&scan.results)
 			}
 			return zgrab2.SCAN_SUCCESS, &retry.results, nil
 		}


### PR DESCRIPTION
Use original result when retry-https encounters an error

## How to Test

Start with retry-https disable and find a page that redirects to a SSO page -> get a nice "Too many redirects" error.
Now enable retry-https and rescan -> you should still get the "Too many redirects" error, not a timeout or "tls oversized record received with length 20527"

## Notes & Caveats

Currently, whenever _any_ error is encountered and retry-https is enabled, the original, often still useful error is thrown away and instead you get either timeouts or "tls oversized record received with length 20527" when it fails, too. Especially with errors like "Too many redirects", which still can be  useful given that the body and HTTP headers are still included, this retry behavior is infuriating and harmful at best, given that the retry error usually is super useless unless this port actually uses HTTPS.

Therefore, let's keep the original error when retry-https fails too, and only use retry-https' result when it actually succeeds.