### PR TITLE
Add TLS support for redis

### DIFF
--- a/modules/redis/types.go
+++ b/modules/redis/types.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
+	"net"
 	"strconv"
 	"strings"
 
@@ -329,11 +329,9 @@ var readers map[byte]redisDataReader
 // Connection holds the state for a single connection within a scan
 type Connection struct {
 	scanner *Scanner
-	conn    interface {
-		io.Reader
-		io.Writer
-	}
-	buffer []byte
+	conn    net.Conn
+	buffer  []byte
+	isSSL   bool
 }
 
 // write writes data to the connection, and returns an error if the write fails
@@ -423,6 +421,13 @@ func (conn *Connection) ReadRedisValue() (RedisValue, error) {
 		return nil, ErrInvalidData
 	}
 	return reader(conn)
+}
+
+func (conn *Connection) GetTLSLog() *zgrab2.TLSLog {
+	if !conn.isSSL {
+		return nil
+	}
+	return conn.conn.(*zgrab2.TLSConnection).GetLog()
 }
 
 type CustomResponse struct {


### PR DESCRIPTION
Add TLS support for the redis module (`--use-tls`). Let me know if anything else needs to be done.

## How to Test

Setup a redis-server using [this configuration](https://redis.io/docs/management/security/encryption/) and run 

```
$ echo 127.0.0.1 | ./zgrab redis --use-tls -p 6379
```
 
## Notes & Caveats

Started seeing a recent trend of REDIS servers on port 6380 utilizing TLS which zgrab2 could not handle.

## Issue Tracking

_Add a link to the relevant GitHub issue(s) if the pull request resolves it._
