### PR TITLE
Add Install Instructions for Go v17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ ZGrab 2.0 contains a new, modular ZGrab framework, which fully supersedes https:
 
 ## Building
 
+###For Go 1.17 and later you must build from source:
+
+```
+$ git clone https://github.com/zmap/zgrab2.git
+$ cd zgrab2
+$ go build
+$ make
+$ ./zgrab2
+```
+
+
+###For Go 1.16 and below:
+
 You will need to have a valid `$GOPATH` set up, for more information about `$GOPATH`, see https://golang.org/doc/code.html.
 
 Once you have a working `$GOPATH`, run:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ZGrab 2.0 contains a new, modular ZGrab framework, which fully supersedes https:
 
 ## Building
 
-###For Go 1.17 and later you must build from source:
+For Go 1.17 and later you must build from source:
 
 ```
 $ git clone https://github.com/zmap/zgrab2.git
@@ -18,7 +18,7 @@ $ ./zgrab2
 ```
 
 
-###For Go 1.16 and below:
+For Go 1.16 and below you can install via go get:
 
 You will need to have a valid `$GOPATH` set up, for more information about `$GOPATH`, see https://golang.org/doc/code.html.
 


### PR DESCRIPTION
Edited README.md to add installation instructions due to go get being deprecated in Go 17.

