### PR TITLE
New functionality for zgrab2-banner: md5, sha1, sha256, base64

### DIFF
--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -4,6 +4,7 @@
 package banner
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -25,7 +26,8 @@ type Flags struct {
 	Pattern   string `long:"pattern" description:"Pattern to match, must be valid regexp."`
 	UseTLS    bool   `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options."`
 	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
-	Hex       bool   `long:"hex" description:"Store banner value in hex."`
+	Hex       bool   `long:"hex" description:"Store banner value in hex. Mutually exclusive with --base64."`
+	Base64    bool   `long:"base64" description:"Store banner value in base64. Mutually exclusive with --hex."`
 	zgrab2.TLSFlags
 }
 
@@ -183,11 +185,12 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 
 	if scanner.config.Hex {
 		results.Banner = hex.EncodeToString(data)
-		results.Length = len(data)
+	} else if scanner.config.Base64 {
+		results.Banner = base64.StdEncoding.EncodeToString(data)
 	} else {
 		results.Banner = string(data)
-		results.Length = len(data)
 	}
+	results.Length = len(data)
 
 	if scanner.regex.Match(data) {
 		return zgrab2.SCAN_SUCCESS, &results, nil

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -4,6 +4,9 @@
 package banner
 
 import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -28,6 +31,9 @@ type Flags struct {
 	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
 	Hex       bool   `long:"hex" description:"Store banner value in hex. Mutually exclusive with --base64."`
 	Base64    bool   `long:"base64" description:"Store banner value in base64. Mutually exclusive with --hex."`
+	MD5       bool   `long:"md5" description:"Calculate MD5 hash of banner value."`
+	SHA1      bool   `long:"sha1" description:"Calculate SHA1 hash of banner value."`
+	SHA256    bool   `long:"sha256" description:"Calculate SHA256 hash of banner value."`
 	zgrab2.TLSFlags
 }
 
@@ -46,6 +52,9 @@ type Scanner struct {
 type Results struct {
 	Banner string `json:"banner,omitempty"`
 	Length int    `json:"length,omitempty"`
+	MD5    string `json:"md5,omitempty"`
+	SHA1   string `json:"sha1,omitempty"`
+	SHA256 string `json:"sha25,omitempty"`
 }
 
 // RegisterModule is called by modules/banner.go to register the scanner.
@@ -191,6 +200,19 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		results.Banner = string(data)
 	}
 	results.Length = len(data)
+
+	if scanner.config.MD5 {
+		digest := md5.Sum(data)
+		results.MD5 = hex.EncodeToString(digest[:])
+	}
+	if scanner.config.SHA1 {
+		digest := sha1.Sum(data)
+		results.SHA1 = hex.EncodeToString(digest[:])
+	}
+	if scanner.config.SHA256 {
+		digest := sha256.Sum256(data)
+		results.SHA256 = hex.EncodeToString(digest[:])
+	}
 
 	if scanner.regex.Match(data) {
 		return zgrab2.SCAN_SUCCESS, &results, nil

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -201,17 +201,19 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	results.Length = len(data)
 
-	if scanner.config.MD5 {
-		digest := md5.Sum(data)
-		results.MD5 = hex.EncodeToString(digest[:])
-	}
-	if scanner.config.SHA1 {
-		digest := sha1.Sum(data)
-		results.SHA1 = hex.EncodeToString(digest[:])
-	}
-	if scanner.config.SHA256 {
-		digest := sha256.Sum256(data)
-		results.SHA256 = hex.EncodeToString(digest[:])
+	if len(data) > 0 {
+		if scanner.config.MD5 {
+			digest := md5.Sum(data)
+			results.MD5 = hex.EncodeToString(digest[:])
+		}
+		if scanner.config.SHA1 {
+			digest := sha1.Sum(data)
+			results.SHA1 = hex.EncodeToString(digest[:])
+		}
+		if scanner.config.SHA256 {
+			digest := sha256.Sum256(data)
+			results.SHA256 = hex.EncodeToString(digest[:])
+		}
 	}
 
 	if scanner.regex.Match(data) {

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -24,8 +24,8 @@ import (
 // Flags give the command-line flags for the banner module.
 type Flags struct {
 	zgrab2.BaseFlags
-	Probe     string `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file".`
-	ProbeFile string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe".`
+	Probe     string `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file."`
+	ProbeFile string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe."`
 	Pattern   string `long:"pattern" description:"Pattern to match, must be valid regexp."`
 	UseTLS    bool   `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options."`
 	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -120,7 +120,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	var err error
 	f, _ := flags.(*Flags)
 	scanner.config = f
-	scanner.regex = regexp.MustCompile(scanner.config.Pattern)
+	if scanner.config.Pattern != "" {
+		scanner.regex = regexp.MustCompile(scanner.config.Pattern)
+	}
 	if len(f.ProbeFile) != 0 {
 		scanner.probe, err = ioutil.ReadFile(f.ProbeFile)
 		if err != nil {
@@ -134,7 +136,6 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		}
 		scanner.probe = []byte(strProbe)
 	}
-
 	return nil
 }
 
@@ -214,6 +215,10 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 			digest := sha256.Sum256(data)
 			results.SHA256 = hex.EncodeToString(digest[:])
 		}
+	}
+
+	if scanner.regex == nil {
+		return zgrab2.SCAN_SUCCESS, &results, nil
 	}
 
 	if scanner.regex.Match(data) {


### PR DESCRIPTION
Hello! While using the banner module for zgrab2, there was a need for some functionality that was missing there.

I added the following:
1. calc md5, sha1 and sha256 of `body`
1. base64 encoding of an answer `body`
1. check for empty pattern

I also refactored the code a little.

Thank you!

p.s: I’m plannig to add similar functionality to the http module. Is it okay?