### PR TITLE
http: ignore EOF when reading headers

### DIFF
--- a/lib/http/client.go
+++ b/lib/http/client.go
@@ -831,9 +831,11 @@ func (b *cancelTimerBody) Read(p []byte) (n int, err error) {
 }
 
 func (b *cancelTimerBody) Close() error {
-	err := b.rc.Close()
-	b.stop()
-	return err
+	defer b.stop()
+	if b.rc != nil {
+		return b.rc.Close()
+	}
+	return nil
 }
 
 func shouldCopyHeaderOnRedirect(headerKey string, initial, dest *url.URL) bool {

--- a/lib/http/response.go
+++ b/lib/http/response.go
@@ -215,8 +215,10 @@ func readResponse(tc *TeeConn, req *Request) (*Response, error) {
 	// Parse the response headers.
 	mimeHeader, err := tp.ReadMIMEHeader()
 	if err != nil {
+		// Ignore EOF, so long as we got a valid status line
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF
+			return resp, nil
 		}
 		return resp, err
 	}

--- a/lib/http/response_test.go
+++ b/lib/http/response_test.go
@@ -880,7 +880,7 @@ func TestReadResponseErrors(t *testing.T) {
 
 	tests := []testCase{
 		{"", "", nil, io.ErrUnexpectedEOF},
-		{"", "HTTP/1.1 301 Moved Permanently\r\nFoo: bar", nil, io.ErrUnexpectedEOF},
+		{"", "HTTP/1.1 404 Not Found", nil, nil},
 		{"", "HTTP/1.1", nil, "malformed HTTP response"},
 		{"", "HTTP/2.0", nil, "malformed HTTP response"},
 		status("20X Unknown", true),


### PR DESCRIPTION
To acknowledge banners such as `HTTP/1.1 404 Not Found` (note the lack of trailing carriage returns) as HTTP, ignore EOF errors while reading headers.

## How to Test

_Add brief instructions on how to test your changes._

## Notes & Caveats

_If necessary, explain the motivation for this PR, and note any caveats that apply to your changes or future work that will be needed._ 

## Issue Tracking

_Add a link to the relevant GitHub issue(s) if the pull request resolves it._
