### PR TITLE
Fixes various problems (mostly syntax) in tests

### DIFF
--- a/lib/output/test/process_test.go
+++ b/lib/output/test/process_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"crypto/rsa"
-	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
 	"math/big"
@@ -21,6 +20,7 @@ import (
 	"os/exec"
 
 	"github.com/sirupsen/logrus"
+	"github.com/zmap/zcrypto/encoding/asn1"
 	jsonKeys "github.com/zmap/zcrypto/json"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zcrypto/x509"

--- a/lib/ssh/kex_test.go
+++ b/lib/ssh/kex_test.go
@@ -25,12 +25,12 @@ func TestKexes(t *testing.T) {
 		c := make(chan kexResultErr, 1)
 		var magics handshakeMagics
 		go func() {
-			r, e := kex.Client(a, rand.Reader, &magics)
+			r, e := kex.Client(a, rand.Reader, &magics, nil)
 			a.Close()
 			c <- kexResultErr{r, e}
 		}()
 		go func() {
-			r, e := kex.Server(b, rand.Reader, &magics, testSigners["ecdsa"])
+			r, e := kex.Server(b, rand.Reader, &magics, testSigners["ecdsa"], nil)
 			b.Close()
 			s <- kexResultErr{r, e}
 		}()

--- a/lib/ssh/keys_test.go
+++ b/lib/ssh/keys_test.go
@@ -6,7 +6,6 @@ package ssh
 
 import (
 	"bytes"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -26,7 +25,7 @@ func rawKey(pub PublicKey) interface{} {
 	case *rsaPublicKey:
 		return (*rsa.PublicKey)(k)
 	case *dsaPublicKey:
-		return (*dsa.PublicKey)(k)
+		return (*dsaPublicKey)(k)
 	case *ecdsaPublicKey:
 		return (*ecdsa.PublicKey)(k)
 	case ed25519PublicKey:

--- a/modules/fox/fox.go
+++ b/modules/fox/fox.go
@@ -3,10 +3,10 @@ package fox
 import (
 	"encoding/hex"
 	"errors"
+	"io"
 	"net"
 	"strconv"
 	"strings"
-	"io"
 
 	"github.com/zmap/zgrab2"
 )
@@ -63,7 +63,7 @@ func GetFoxBanner(logStruct *FoxLog, connection net.Conn) error {
 	}
 
 	responseString := string(data)
-	output := strings.Split(responseString, string(0x0a))
+	output := strings.Split(responseString, "\x0a")
 
 	if strings.HasPrefix(responseString, RESPONSE_PREFIX) {
 		logStruct.IsFox = true

--- a/modules/redis/types_test.go
+++ b/modules/redis/types_test.go
@@ -3,9 +3,11 @@ package redis
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeIO is a simple fake Reader/Writer. Read pulls data from the output
@@ -44,6 +46,41 @@ func (fakeio *fakeIO) Provide(buf []byte) {
 	}()
 }
 
+func (fakeio *fakeIO) Close() error {
+	return nil
+}
+
+func (fakeio *fakeIO) LocalAddr() net.Addr {
+	return fakeAddr{}
+}
+
+func (fakeio *fakeIO) RemoteAddr() net.Addr {
+	return fakeAddr{}
+}
+
+func (fakeio *fakeIO) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (fakeio *fakeIO) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (fakeio *fakeIO) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// A fake net.Addr
+type fakeAddr struct{}
+
+func (f fakeAddr) Network() string {
+	return "tcp"
+}
+
+func (f fakeAddr) String() string {
+	return "127.0.0.1"
+}
+
 var bigSimpleString = strings.Repeat("simple,", 1024*1024)
 var bigBulkString = "--- BEGIN BULK STRING ---\r\n" + bigSimpleString + "\r\n--- END BULK STRING---\r\n"
 
@@ -78,29 +115,29 @@ var integers = map[int64]string{
 
 // redisErrors maps error strings to their encoding
 var redisErrors = map[string]string{
-	"": "-\r\n",
+	"":                         "-\r\n",
 	"ERR something went wrong": "-ERR something went wrong\r\n",
 	"singleword":               "-singleword\r\n",
 }
 
 // redisErrors maps error strings to their prefixes
 var redisErrorPrefixes = map[string]string{
-	"": "",
+	"":                         "",
 	"ERR something went wrong": "ERR",
 	"singleword":               "singleword",
 }
 
 // redisErrorMessages maps error strings to their "messages"
 var redisErrorMessages = map[string]string{
-	"": "",
+	"":                         "",
 	"ERR something went wrong": "something went wrong",
 	"singleword":               "singleword",
 }
 
 // redisArrays maps encoded array values to the corresponding array (Note: reverse key/value order from other maps)
 var redisArrays = map[string]RedisArray{
-	"*0\r\n":                                  RedisArray{},
-	"*1\r\n+\r\n":                             RedisArray{SimpleString("")},
+	"*0\r\n":      RedisArray{},
+	"*1\r\n+\r\n": RedisArray{SimpleString("")},
 	"*2\r\n*1\r\n*0\r\n*1\r\n$5\r\n12345\r\n": RedisArray{RedisArray{RedisArray{}}, RedisArray{BulkString("12345")}},
 	"*5\r\n" +
 		"+simpleString\r\n" +


### PR DESCRIPTION
* process_test swapped from golang encoding/asn1 to zcrypto
* ssh/kex_test needed Config argument for kex.Client / kex.Server
* ssh/keys_test needed the built-in dsaPublicKey
* fox.go was throwing a `go vet` warning during tests
* redis/types_test fakeIO needed additional methods to meet interface signature

## How to Test

```
make test
```

## Notes & Caveats

_If necessary, explain the motivation for this PR, and note any caveats that apply to your changes or future work that will be needed._ 

## Issue Tracking

Fixes #387 , #388 , #389 , #390 
