### PR TITLE
Add body support for invisible characters after encryption

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -70,7 +70,8 @@ type Flags struct {
 	CustomHeadersValues    string `long:"custom-headers-values" description:"CSV of custom HTTP header values to send to server. Should match order of custom-headers-names."`
 	CustomHeadersDelimiter string `long:"custom-headers-delimiter" description:"Delimiter for customer header name/value CSVs"`
 	// Set HTTP Request body
-	RequestBody string `long:"request-body" description:"HTTP request body to send to server"`
+	RequestBody    string `long:"request-body" description:"HTTP request body to send to server"`
+	RequestBodyHex string `long:"request-body-hex" description:"HTTP request body to send to server"`
 
 	OverrideSH bool `long:"override-sig-hash" description:"Override the default SignatureAndHashes TLS option with more expansive default"`
 
@@ -489,6 +490,9 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 	)
 	if len(scan.scanner.config.RequestBody) > 0 {
 		request, err = http.NewRequest(scan.scanner.config.Method, scan.url, strings.NewReader(scan.scanner.config.RequestBody))
+	} else if len(scan.scanner.config.RequestBodyHex) > 0 {
+		reqbody, _ := hex.DecodeString(scan.scanner.config.RequestBodyHex)
+		request, err = http.NewRequest(scan.scanner.config.Method, scan.url, bytes.NewReader(reqbody))
 	} else {
 		request, err = http.NewRequest(scan.scanner.config.Method, scan.url, nil)
 	}


### PR DESCRIPTION

## How to Test

Add body support for invisible characters after encryption

## Notes & Caveats

When I was testing, I found that when I encountered a request with encrypted characters that could not be displayed properly, the parameters passed through the string could not construct the same request as before.
For example, if the encrypted character is displayed as "." and I pass it as a parameter, but in reality, its hexadecimal is not 2e, it may be f8, and so on.
So at this point, we cannot simply pass in strings. We need to have the ability to pass in encrypted and invisible characters, in order to cope with which request bodies are sending miscellaneous content. (This is a problem I discovered during my research and communication with the C2 Trojan)

