### PR TITLE
Add port number to CSV input and output

### DIFF
--- a/input_test.go
+++ b/input_test.go
@@ -39,8 +39,27 @@ func TestParseCSVTarget(t *testing.T) {
 		ipnet   *net.IPNet
 		domain  string
 		tag     string
+		port    string
 		success bool
 	}{
+		// IP DOMAIN TAG PORT
+		{
+			fields:  []string{"10.0.0.1", "example.com", "tag", "443"},
+			ipnet:   parseIP("10.0.0.1"),
+			domain:  "example.com",
+			tag:     "tag",
+			port:    "443",
+			success: true,
+		},
+		// IP DOMAIN TAG PORT
+		{
+			fields:  []string{"10.0.0.1", "example.com", "tag"},
+			ipnet:   parseIP("10.0.0.1"),
+			domain:  "example.com",
+			tag:     "tag",
+			port:    "",
+			success: true,
+		},
 		// IP DOMAIN TAG
 		{
 			fields:  []string{"10.0.0.1", "example.com", "tag"},
@@ -129,14 +148,14 @@ func TestParseCSVTarget(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ipnet, domain, tag, err := ParseCSVTarget(test.fields)
+		ipnet, domain, tag, port, err := ParseCSVTarget(test.fields)
 		if (err == nil) != test.success {
 			t.Errorf("wrong error status (got err=%v, success should be %v): %q", err, test.success, test.fields)
 			return
 		}
 		if err == nil {
-			if ipnetString(ipnet) != ipnetString(test.ipnet) || domain != test.domain || tag != test.tag {
-				t.Errorf("wrong result (got %v,%v,%v; expected %v,%v,%v): %q", ipnetString(ipnet), domain, tag, ipnetString(test.ipnet), test.domain, test.tag, test.fields)
+			if ipnetString(ipnet) != ipnetString(test.ipnet) || domain != test.domain || tag != test.tag || port != test.port {
+				t.Errorf("wrong result (got %v,%v,%v,%v ; expected %v,%v,%v,%v): %q", ipnetString(ipnet), domain, tag, port, ipnetString(test.ipnet), test.domain, test.tag, test.port, test.fields)
 				return
 			}
 		}
@@ -150,8 +169,11 @@ func TestGetTargetsCSV(t *testing.T) {
 10.0.0.1
 ,example.com
 example.com
-2.2.2.2/30,, tag`
-
+2.2.2.2/30,, tag
+10.0.0.1,example.com,tag,443
+10.0.0.1,,,443
+`
+	port := uint(443)
 	expected := []ScanTarget{
 		ScanTarget{IP: net.ParseIP("10.0.0.1"), Domain: "example.com", Tag: "tag"},
 		ScanTarget{IP: net.ParseIP("10.0.0.1"), Domain: "example.com"},
@@ -162,6 +184,8 @@ example.com
 		ScanTarget{IP: net.ParseIP("2.2.2.1"), Tag: "tag"},
 		ScanTarget{IP: net.ParseIP("2.2.2.2"), Tag: "tag"},
 		ScanTarget{IP: net.ParseIP("2.2.2.3"), Tag: "tag"},
+		ScanTarget{IP: net.ParseIP("10.0.0.1"), Domain: "example.com", Tag: "tag", Port: &port},
+		ScanTarget{IP: net.ParseIP("10.0.0.1"), Port: &port},
 	}
 
 	ch := make(chan ScanTarget, 0)

--- a/processing.go
+++ b/processing.go
@@ -118,13 +118,16 @@ func (target *ScanTarget) OpenUDP(flags *BaseFlags, udp *UDPFlags) (net.Conn, er
 // scan responses.
 func BuildGrabFromInputResponse(t *ScanTarget, responses map[string]ScanResponse) *Grab {
 	var ipstr string
-
+	var port uint
 	if t.IP != nil {
 		ipstr = t.IP.String()
 	}
+	if t.Port != nil {
+		port = *t.Port
+	}
 	return &Grab{
 		IP:     ipstr,
-		Port:   *t.Port,
+		Port:   port,
 		Domain: t.Domain,
 		Data:   responses,
 	}

--- a/processing.go
+++ b/processing.go
@@ -13,6 +13,7 @@ import (
 // Grab contains all scan responses for a single host
 type Grab struct {
 	IP     string                  `json:"ip,omitempty"`
+	Port   uint                    `json:"port,omitempty"`
 	Domain string                  `json:"domain,omitempty"`
 	Data   map[string]ScanResponse `json:"data,omitempty"`
 }
@@ -123,6 +124,7 @@ func BuildGrabFromInputResponse(t *ScanTarget, responses map[string]ScanResponse
 	}
 	return &Grab{
 		IP:     ipstr,
+		Port:   *t.Port,
 		Domain: t.Domain,
 		Data:   responses,
 	}


### PR DESCRIPTION
This PR allows setting a custom port in the CSV input and it also shows the port in output results.
The port number is added to the last field for backward compatibility reasons. However it's ugly when you need just IP, Port. You have to input IP,,,Port instead. You can take the target port number out in the JSON output of zgrab2 later.

## How to Test

Domain and port:
echo ',google.com,,80' | ./zgrab2 http

IP and port:
echo '1.2.3.4,,,80' |  ./zgrab2 http

## Notes & Caveats

Port number won't be shown in the output if the input was not in CSV format. For example, when using just IP or domain per line and using -p option to supply the port number.

## Issue Tracking
[https://github.com/zmap/zgrab2/issues/344](https://github.com/zmap/zgrab2/issues/344)