### PR TITLE
Permissive TLS parsing

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/zmap/zcrypto/encoding/asn1"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zcrypto/x509"
+	"github.com/zmap/zcrypto/x509/pkix"
 )
 
 // Shared code for TLS scans.
@@ -65,7 +67,8 @@ type TLSFlags struct {
 	// TODO: format?
 	ClientRandom string `long:"client-random" description:"Set an explicit Client Random (base64 encoded)"`
 	// TODO: format?
-	ClientHello string `long:"client-hello" description:"Set an explicit ClientHello (base64 encoded)"`
+	ClientHello       string `long:"client-hello" description:"Set an explicit ClientHello (base64 encoded)"`
+	PermissiveParsing bool   `long:"permissive-parsing" description:"Allow permissive Certificate parsing"`
 }
 
 func getCSV(arg string) []string {
@@ -148,6 +151,11 @@ func (t *TLSFlags) GetTLSConfigForTarget(target *ScanTarget) (*tls.Config, error
 		if !ok {
 			log.Fatalf("Could not read certificates from PEM file. Invalid PEM?")
 		}
+	}
+
+	if t.PermissiveParsing {
+		asn1.AllowPermissiveParsing = true
+		pkix.LegacyNameString = true
 	}
 	if t.NextProtos != "" {
 		// TODO: Different format?

--- a/tls.go
+++ b/tls.go
@@ -68,7 +68,6 @@ type TLSFlags struct {
 	ClientRandom string `long:"client-random" description:"Set an explicit Client Random (base64 encoded)"`
 	// TODO: format?
 	ClientHello       string `long:"client-hello" description:"Set an explicit ClientHello (base64 encoded)"`
-	PermissiveParsing bool   `long:"permissive-parsing" description:"Allow permissive Certificate parsing"`
 }
 
 func getCSV(arg string) []string {
@@ -153,10 +152,9 @@ func (t *TLSFlags) GetTLSConfigForTarget(target *ScanTarget) (*tls.Config, error
 		}
 	}
 
-	if t.PermissiveParsing {
-		asn1.AllowPermissiveParsing = true
-		pkix.LegacyNameString = true
-	}
+  asn1.AllowPermissiveParsing = true
+  pkix.LegacyNameString = true
+
 	if t.NextProtos != "" {
 		// TODO: Different format?
 		ret.NextProtos = getCSV(t.NextProtos)


### PR DESCRIPTION
This is driven by  #378, https://github.com/zmap/zcrypto/issues/364 and https://github.com/zmap/zgrab2/pull/334

This allows a number of scans to actually succeed, rather than fail out when parsing the certificate

Example without permissive parsing:

```
echo FAILING_IP | ./zgrab2 http -p 443 --use-https
INFO[0000] started grab at 2023-09-21T21:25:29-05:00
{"ip":"FAILING_IP","data":{"http":{"status":"unknown-error","protocol":"http","result":{},"timestamp":"2023-09-21T21:25:29-05:00","error":"tls: failed to parse certificate from server: asn1: structure error: explicitly tagged member didn't match"}}}
INFO[0001] finished grab at 2023-09-21T21:25:29-05:00
{"statuses":{"http":{"successes":0,"failures":1}},"start":"2023-09-21T21:25:29-05:00","end":"2023-09-21T21:25:29-05:00","duration":"987.606886ms"}
```

With Permissive parsing:

```
echo FAILING_IP | ./zgrab2 http -p 443 --use-https
INFO[0000] started grab at 2023-09-21T21:25:34-05:00
{"ip":"FAILING_UP","data":{"http":{"status":"application-error","protocol":"http","result":{"response":{"status_line":"302 Found","status_code":302,"protocol":{"name":"HTTP/1.1","major":1,"minor":1},"headers":{"content_length":["0"],
... all the HTTP and TLS handshake log data
```
