### PR TITLE
Fix tests and boundary condition

### DIFF
--- a/lib/http/transport.go
+++ b/lib/http/transport.go
@@ -1553,7 +1553,7 @@ func (pc *persistConn) readLoop() {
 			closeErr = err
 		}
 
-		if err != nil && (!pc.sawEOF || resp == nil) {
+		if err != nil && (!pc.sawEOF || resp == nil || resp.Status == "") {
 			if pc.readLimit <= 0 {
 				err = fmt.Errorf("net/http: server response headers exceeded %d bytes; aborted", pc.maxHeaderResponseSize())
 			}


### PR DESCRIPTION
https://github.com/zmap/zgrab2/pull/375/files caused two tests to fail:
truncate_read_header
tls_truncate_read_header

Because now we skip a block if we have EOF errors
I added a bunch of additional tests to try to confirm we'd break for a bunch of other weird cases
This turns up a potential issue where we hit an EOF and because of golang defaults, we actually return a success.

I'm not entirely sure if these are expected behavior, but minimally this highlights some perhaps unexpected side effects from the mentioned PR.