### PR TITLE
Add test steps to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,7 @@ jobs:
         run: |
           go get -t ./...
           make
+
+      - name: Test
+        run: |
+          make test


### PR DESCRIPTION
Adds test running to the CI step

A number of recent commits have broken tests
It would be nice if this didn't happen and the build told us.