### PR TITLE
Update config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -102,7 +102,7 @@ func validateFrameworkConfiguration() {
 	//validate/start prometheus
 	if config.Prometheus != "" {
 		go func() {
-			http.Handle("metrics", promhttp.Handler())
+			http.Handle("/metrics", promhttp.Handler())
 			if err := http.ListenAndServe(config.Prometheus, nil); err != nil {
 				log.Fatalf("could not run prometheus server: %s", err.Error())
 			}


### PR DESCRIPTION
fix /metrics 404 error

prometheus metrics return 404 Not Found

## How to Test

go version go1.22.2 linux/amd64
Linux 5.4.0-174-generic #193-Ubuntu SMP Thu Mar 7 14:29:28 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux

before
curl localhost:10000/metrics
404 page not found

after
curl localhost:10000/metrics
```
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.2542e-05
go_gc_duration_seconds{quantile="0.25"} 6.0905e-05
go_gc_duration_seconds{quantile="0.5"} 8.1575e-05
go_gc_duration_seconds{quantile="0.75"} 0.000107555
go_gc_duration_seconds{quantile="1"} 0.000347025
go_gc_duration_seconds_sum 0.011626545
go_gc_duration_seconds_count 131
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 4...
```
