### PR TITLE
Fix Parser for ModuleIdentificationRequest of s7 Protocol

### DIFF
--- a/modules/siemens/s7.go
+++ b/modules/siemens/s7.go
@@ -292,7 +292,8 @@ func parseModuleIDDataRecord(data []byte) (*moduleIDData, error) {
 
 // Constructs the version number from a moduleIDData record.
 func getVersionNumber(record *moduleIDData) string {
-	return fmt.Sprintf("V%d.%d", record.Ausbg1&0xFF, record.Ausbg2)
+        lastByteAusbg1 := record.Ausbg1 & 0xFF
+	return fmt.Sprintf("V%d.%d", lastByteAusbg1, record.Ausbg2)
 }
 
 func parseModuleIdentificationRequest(logStruct *S7Log, s7Packet *S7Packet) error {

--- a/modules/siemens/s7.go
+++ b/modules/siemens/s7.go
@@ -323,12 +323,12 @@ func parseModuleIdentificationRequest(logStruct *S7Log, s7Packet *S7Packet) erro
 			return fmt.Errorf("failed parsing data record %d: %v", i, err)
 		}
 
-		switch {
-		case record.Index == S7_MODULE_ID_MODULE_INDEX:
+		switch record.Index {
+		case S7_MODULE_ID_MODULE_INDEX:
 			logStruct.ModuleId = record.MIFB
-		case record.Index == S7_MODULE_ID_HARDWARE_INDEX:
+		case S7_MODULE_ID_HARDWARE_INDEX:
 			logStruct.Hardware = getVersionNumber(record)
-		case record.Index == S7_MODULE_ID_FIRMWARE_INDEX:
+		case S7_MODULE_ID_FIRMWARE_INDEX:
 			logStruct.Firmware = getVersionNumber(record)
 		}
 


### PR DESCRIPTION
Rewrote response parser with information provided in the issue. Resolves #212. 

Tested against some real S7 modules and _appears_ to work, absolutely makes more sense than the original code. However, would be great if we can confirm on a device we control.

Also, `ModuleId` field in `type S7Log struct` formerly reflects "Order number of the module". This behavior is kept in current version for forward compatibility but not sure if we should rename it to sth else.