### PR TITLE
fixed typo in cleanup script

### DIFF
--- a/integration_tests/amqp091/cleanup.sh
+++ b/integration_tests/amqp091/cleanup.sh
@@ -3,11 +3,11 @@
 # Keep cleaning up even if something fails
 set +e
 
-# Stop all MySQL containers.
+# Stop all AMQP containers.
 
 VERSIONS="3.12.14 3.13.2"
 
-for version in $MYSQL_VERSIONS; do
+for version in $VERSIONS; do
     CONTAINER_NAME="zgrab_amqp091-$version"
     echo "amqp091/cleanup: Stopping $CONTAINER_NAME..."
     docker stop $CONTAINER_NAME


### PR DESCRIPTION
Noticed that there was a typo in the `cleanup.sh` script for AMQP that resulted in the containers not being cleaned up.
