### PR TITLE
Fix non-compilation in /lib/ssh/messages_test.go

### DIFF
--- a/lib/ssh/messages_test.go
+++ b/lib/ssh/messages_test.go
@@ -206,25 +206,26 @@ func TestMarshalMultiTag(t *testing.T) {
 	}
 }
 
-funcTestHaSSH(t *testing.T) {
+func TestHaSSH(t *testing.T) {
 	ki := &KexInitMsg{}
-	randomBytes(ki.Cookie[:]"," rand)
-	ki.KexAlgos = []string {"curve25519-sha256@libssh.org","diffie-hellman-group-exchange-sha256","ecdh-sha2-nistp521","ecdh-sha2-nistp384","ecdh-sha2-nistp256","diffie-hellman-group-exchange-sha1","diffie-hellman-group1-sha1","diffie-hellman-group14-sha1","diffie-hellman-group14-sha256","diffie-hellman-group15-sha512","diffie-hellman-group16-sha512","diffie-hellman-group17-sha512","diffie-hellman-group18-sha512","diffie-hellman-group14-sha256@ssh.com","diffie-hellman-group15-sha256","diffie-hellman-group15-sha256@ssh.com","diffie-hellman-group15-sha384@ssh.com","diffie-hellman-group16-sha256","diffie-hellman-group16-sha384@ssh.com","diffie-hellman-group16-sha512@ssh.com","diffie-hellman-group18-sha512@ssh.com")
-	ki.ServerHostKeyAlgos = randomNameList(rand)
-	ki.CiphersClientServer = randomNameList(rand)
-	ki.CiphersServerClient = []string {"aes128-cbc","aes128-ctr","aes192-cbc","aes192-ctr","aes256-cbc","aes256-ctr","blowfish-cbc","blowfish-ctr","cast128-cbc","cast128-ctr","idea-cbc","idea-ctr","serpent128-cbc","serpent128-ctr","serpent192-cbc","serpent192-ctr","serpent256-cbc","serpent256-ctr","3des-cbc","3des-ctr","twofish128-cbc","twofish128-ctr","twofish192-cbc","twofish192-ctr","twofish256-cbc","twofish256-ctr","twofish-cbc","arcfour","arcfour128","arcfour256"}
-	ki.MACsClientServer = randomNameList(rand)
-	ki.MACsServerClient = []string {"hmac-sha1","hmac-sha1-96","hmac-md5","hmac-md5-96","hmac-sha2-256","hmac-sha2-512"}
-	ki.CompressionClientServer = randomNameList(rand)
-	ki.CompressionServerClient = []string {"zlib@openssh.com","zlib","none"}
-	ki.LanguagesClientServer = randomNameList(rand)
-	ki.LanguagesServerClient = randomNameList(rand)
+	randSource := rand.New(rand.NewSource(0))
+	randomBytes(ki.Cookie[:], randSource)
+	ki.KexAlgos = []string{"curve25519-sha256@libssh.org", "diffie-hellman-group-exchange-sha256", "ecdh-sha2-nistp521", "ecdh-sha2-nistp384", "ecdh-sha2-nistp256", "diffie-hellman-group-exchange-sha1", "diffie-hellman-group1-sha1", "diffie-hellman-group14-sha1", "diffie-hellman-group14-sha256", "diffie-hellman-group15-sha512", "diffie-hellman-group16-sha512", "diffie-hellman-group17-sha512", "diffie-hellman-group18-sha512", "diffie-hellman-group14-sha256@ssh.com", "diffie-hellman-group15-sha256", "diffie-hellman-group15-sha256@ssh.com", "diffie-hellman-group15-sha384@ssh.com", "diffie-hellman-group16-sha256", "diffie-hellman-group16-sha384@ssh.com", "diffie-hellman-group16-sha512@ssh.com", "diffie-hellman-group18-sha512@ssh.com"}
+	ki.ServerHostKeyAlgos = randomNameList(randSource)
+	ki.CiphersClientServer = randomNameList(randSource)
+	ki.CiphersServerClient = []string{"aes128-cbc", "aes128-ctr", "aes192-cbc", "aes192-ctr", "aes256-cbc", "aes256-ctr", "blowfish-cbc", "blowfish-ctr", "cast128-cbc", "cast128-ctr", "idea-cbc", "idea-ctr", "serpent128-cbc", "serpent128-ctr", "serpent192-cbc", "serpent192-ctr", "serpent256-cbc", "serpent256-ctr", "3des-cbc", "3des-ctr", "twofish128-cbc", "twofish128-ctr", "twofish192-cbc", "twofish192-ctr", "twofish256-cbc", "twofish256-ctr", "twofish-cbc", "arcfour", "arcfour128", "arcfour256"}
+	ki.MACsClientServer = randomNameList(randSource)
+	ki.MACsServerClient = []string{"hmac-sha1", "hmac-sha1-96", "hmac-md5", "hmac-md5-96", "hmac-sha2-256", "hmac-sha2-512"}
+	ki.CompressionClientServer = randomNameList(randSource)
+	ki.CompressionServerClient = []string{"zlib@openssh.com", "zlib", "none"}
+	ki.LanguagesClientServer = randomNameList(randSource)
+	ki.LanguagesServerClient = randomNameList(randSource)
 	ki.FirstKexFollows = true
 
-	hassh := ki.GenerateHaSSH()
+	hassh := ki.GenerateServerHaSSH()
 	expected := "8a8ae540028bf433cd68356c1b9e8d5b"
 	if hassh != expected {
-	  t.Errorf("Unexpected hash. Wanted %s, got %s", expected, hassh)
+		t.Errorf("Unexpected hash. Wanted %s, got %s", expected, hassh)
 	}
 }
 


### PR DESCRIPTION
While investigating another PR, noticed that non-compiling code was in `messages_test.go` This fixes the formatting.

## Testing - post fix
```
/opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/phillip/Library/Caches/JetBrains/GoLand2024.1/tmp/GoLand/___TestHaSSH_in_github_com_zmap_zgrab2_lib_ssh.test -test.v -test.paniconexit0 -test.run ^\QTestHaSSH\E$
=== RUN   TestHaSSH
--- PASS: TestHaSSH (0.00s)
PASS

Process finished with the exit code 0
```
