### PR TITLE
smb: add support for v3.0 and v3.0.2

### DIFF
--- a/lib/smb/smb/smb.go
+++ b/lib/smb/smb/smb.go
@@ -346,6 +346,8 @@ func (s *Session) NewNegotiateReq() NegotiateReq {
 
 	dialects := []uint16{
 		uint16(DialectSmb_2_1),
+		uint16(DialectSmb_3_0),
+		uint16(DialectSmb_3_0_2),
 	}
 	return NegotiateReq{
 		Header:          header,


### PR DESCRIPTION
Adds support for SMB v3.0 and v3.0.2

## How to Test

```
$ echo "217.160.74.34"  | ./zgrab2 smb -p 445 | jq
{
  "ip": "217.160.74.34",
  "data": {
    "smb": {
      "status": "success",
      "protocol": "smb",
      "result": {
        "smbv1_support": false,
        "smb_version": {
          "major": 3,
          "minor": 0,
          "revision": 2,
          "version_string": "SMB 3.0.2"
        },
```
## Notes & Caveats

Note: Currently excluding v3.1.1, there seems to be a bug that causes servers to reject the negotiation, rather than selecting a working version. 