### PR TITLE
Group Basic/TLS Flag Groupings in Modules and interface{} -> any

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -114,7 +114,7 @@ func ZGrab2Main() {
 	if m, ok := flag.(*zgrab2.MultipleCommand); ok {
 		iniParser := zgrab2.NewIniParser()
 		var modTypes []string
-		var flagsReturned []interface{}
+		var flagsReturned []any
 		if m.ConfigFileName == "-" {
 			modTypes, flagsReturned, err = iniParser.Parse(os.Stdin)
 		} else {

--- a/conn_bytelimit_test.go
+++ b/conn_bytelimit_test.go
@@ -65,7 +65,7 @@ type readLimitTestConfig struct {
 // Call sendReceive(), and check that the input/output match, and that any expected errors / truncation occurs.
 func checkedSendReceive(t *testing.T, conn *TimeoutConnection, size int) (result error) {
 	// helper to report + return an error
-	tErrorf := func(format string, args ...interface{}) error {
+	tErrorf := func(format string, args ...any) error {
 		result = fmt.Errorf(format, args)
 		t.Error(result)
 		return result

--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -47,7 +47,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -96,7 +96,7 @@ func (scanner *Scanner) Protocol() string {
 }
 
 // Scan TODO: describe what is scanned
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/lib/http/client_test.go
+++ b/lib/http/client_test.go
@@ -769,7 +769,7 @@ func (j *RecordingJar) Cookies(u *url.URL) []*Cookie {
 	return nil
 }
 
-func (j *RecordingJar) logf(format string, args ...interface{}) {
+func (j *RecordingJar) logf(format string, args ...any) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	fmt.Fprintf(&j.log, format, args...)

--- a/lib/http/clientserver_test.go
+++ b/lib/http/clientserver_test.go
@@ -74,7 +74,7 @@ var optQuietLog = func(ts *httptest.Server) {
 	ts.Config.ErrorLog = quietLog
 }
 
-func newClientServerTest(t *testing.T, h2 bool, h Handler, opts ...interface{}) *clientServerTest {
+func newClientServerTest(t *testing.T, h2 bool, h Handler, opts ...any) *clientServerTest {
 	cst := &clientServerTest{
 		t:  t,
 		h2: h2,
@@ -185,7 +185,7 @@ type reqFunc func(c *Client, url string) (*Response, error)
 		ReqFunc            reqFunc                           // optional
 		CheckResponse      func(proto string, res *Response) // optional
 		EarlyCheckResponse func(proto string, res *Response) // optional; pre-normalize
-		Opts               []interface{}
+		Opts               []any
 	}
 
 	func (tt h12Compare) reqFunc() reqFunc {
@@ -438,7 +438,7 @@ func TestH12_AutoGzip(t *testing.T) {
 
 func TestH12_AutoGzip_Disabled(t *testing.T) {
 	h12Compare{
-		Opts: []interface{}{
+		Opts: []any{
 			func(tr *Transport) { tr.DisableCompression = true },
 		},
 		Handler: func(w ResponseWriter, r *Request) {
@@ -1199,7 +1199,7 @@ func TestInterruptWithPanic_ErrAbortHandler_h1(t *testing.T) {
 func TestInterruptWithPanic_ErrAbortHandler_h2(t *testing.T) {
 	testInterruptWithPanic(t, h2Mode, ErrAbortHandler)
 }*/
-func testInterruptWithPanic(t *testing.T, h2 bool, panicValue interface{}) {
+func testInterruptWithPanic(t *testing.T, h2 bool, panicValue any) {
 	setParallel(t)
 	const msg = "hello"
 	defer afterTest(t)

--- a/lib/http/cookie_test.go
+++ b/lib/http/cookie_test.go
@@ -283,7 +283,7 @@ var readSetCookiesTests = []struct {
 	// Header{"Set-Cookie": {"ASP.NET_SessionId=foo; path=/; HttpOnly, .ASPXAUTH=7E3AA; expires=Wed, 07-Mar-2012 14:25:06 GMT; path=/; HttpOnly"}},
 }
 
-func toJSON(v interface{}) string {
+func toJSON(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Sprintf("%#v", v)

--- a/lib/http/fs_test.go
+++ b/lib/http/fs_test.go
@@ -607,7 +607,7 @@ type fakeFileInfo struct {
 }
 
 func (f *fakeFileInfo) Name() string       { return f.basename }
-func (f *fakeFileInfo) Sys() interface{}   { return nil }
+func (f *fakeFileInfo) Sys() any           { return nil }
 func (f *fakeFileInfo) ModTime() time.Time { return f.modtime }
 func (f *fakeFileInfo) IsDir() bool        { return f.dir }
 func (f *fakeFileInfo) Size() int64        { return int64(len(f.contents)) }

--- a/lib/http/h2_bundle.go
+++ b/lib/http/h2_bundle.go
@@ -763,7 +763,7 @@ func (h *http2FrameHeader) invalidate() { h.valid = false }
 // frame header bytes.
 // Used only by ReadFrameHeader.
 var http2fhBytes = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		buf := make([]byte, http2frameHeaderLen)
 		return &buf
 	},
@@ -859,8 +859,8 @@ type http2Framer struct {
 
 	debugFramer       *http2Framer // only use for logging written writes
 	debugFramerBuf    *bytes.Buffer
-	debugReadLoggerf  func(string, ...interface{})
-	debugWriteLoggerf func(string, ...interface{})
+	debugReadLoggerf  func(string, ...any)
+	debugWriteLoggerf func(string, ...any)
 }
 
 func (fr *http2Framer) maxHeaderListSize() uint32 {
@@ -2189,7 +2189,7 @@ func http2configureServer18(h1 *Server, h2 *http2Server) error {
 	return nil
 }
 
-func http2shouldLogPanic(panicValue interface{}) bool {
+func http2shouldLogPanic(panicValue any) bool {
 	return panicValue != nil && panicValue != ErrAbortHandler
 }
 
@@ -2252,7 +2252,7 @@ func http2curGoroutineID() uint64 {
 }
 
 var http2littleBuf = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		buf := make([]byte, 64)
 		return &buf
 	},
@@ -2661,7 +2661,7 @@ func http2newBufferedWriter(w io.Writer) *http2bufferedWriter {
 const http2bufWriterPoolBufferSize = 4 << 10
 
 var http2bufWriterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return bufio.NewWriterSize(nil, http2bufWriterPoolBufferSize)
 	},
 }
@@ -2732,7 +2732,7 @@ type http2connectionStater interface {
 	ConnectionState() tls.ConnectionState
 }
 
-var http2sorterPool = sync.Pool{New: func() interface{} { return new(http2sorter) }}
+var http2sorterPool = sync.Pool{New: func() any { return new(http2sorter) }}
 
 type http2sorter struct {
 	v []string // owned by sorter
@@ -2935,7 +2935,7 @@ var (
 )
 
 var http2responseWriterStatePool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		rws := &http2responseWriterState{}
 		rws.bw = bufio.NewWriterSize(http2chunkWriter{rws}, http2handlerChunkWriteSize)
 		return rws
@@ -2947,7 +2947,7 @@ var (
 	http2testHookOnConn        func()
 	http2testHookGetServerConn func(*http2serverConn)
 	http2testHookOnPanicMu     *sync.Mutex // nil except in tests
-	http2testHookOnPanic       func(sc *http2serverConn, panicVal interface{}) (rePanic bool)
+	http2testHookOnPanic       func(sc *http2serverConn, panicVal any) (rePanic bool)
 )
 
 // Server is an HTTP/2 server.
@@ -3342,13 +3342,13 @@ func (sc *http2serverConn) setConnState(state ConnState) {
 	}
 }
 
-func (sc *http2serverConn) vlogf(format string, args ...interface{}) {
+func (sc *http2serverConn) vlogf(format string, args ...any) {
 	if http2VerboseLogs {
 		sc.logf(format, args...)
 	}
 }
 
-func (sc *http2serverConn) logf(format string, args ...interface{}) {
+func (sc *http2serverConn) logf(format string, args ...any) {
 	if lg := sc.hs.ErrorLog; lg != nil {
 		lg.Printf(format, args...)
 	} else {
@@ -3393,7 +3393,7 @@ func http2isClosedConnError(err error) bool {
 	return false
 }
 
-func (sc *http2serverConn) condlogf(err error, format string, args ...interface{}) {
+func (sc *http2serverConn) condlogf(err error, format string, args ...any) {
 	if err == nil {
 		return
 	}
@@ -3619,11 +3619,11 @@ func (sc *http2serverConn) readPreface() error {
 }
 
 var http2errChanPool = sync.Pool{
-	New: func() interface{} { return make(chan error, 1) },
+	New: func() any { return make(chan error, 1) },
 }
 
 var http2writeDataPool = sync.Pool{
-	New: func() interface{} { return new(http2writeData) },
+	New: func() any { return new(http2writeData) },
 }
 
 // writeDataFromHandler writes DATA response frames from a handler on
@@ -5360,7 +5360,7 @@ func http2h1ServerShutdownChan(hs *Server) <-chan struct{} {
 	if fn := http2testh1ServerShutdownChan; fn != nil {
 		return fn(hs)
 	}
-	var x interface{} = hs
+	var x any = hs
 	type I interface {
 		getDoneChan() <-chan struct{}
 	}
@@ -5377,7 +5377,7 @@ var http2testh1ServerShutdownChan func(hs *Server) <-chan struct{}
 // disabled. See comments on h1ServerShutdownChan above for why
 // the code is written this way.
 func http2h1ServerKeepAlivesDisabled(hs *Server) bool {
-	var x interface{} = hs
+	var x any = hs
 	type I interface {
 		doKeepAlives() bool
 	}
@@ -7233,21 +7233,21 @@ var (
 	http2errPseudoTrailers         = errors.New("http2: invalid pseudo header in trailers")
 )
 
-func (cc *http2ClientConn) logf(format string, args ...interface{}) {
+func (cc *http2ClientConn) logf(format string, args ...any) {
 	cc.t.logf(format, args...)
 }
 
-func (cc *http2ClientConn) vlogf(format string, args ...interface{}) {
+func (cc *http2ClientConn) vlogf(format string, args ...any) {
 	cc.t.vlogf(format, args...)
 }
 
-func (t *http2Transport) vlogf(format string, args ...interface{}) {
+func (t *http2Transport) vlogf(format string, args ...any) {
 	if http2VerboseLogs {
 		t.logf(format, args...)
 	}
 }
 
-func (t *http2Transport) logf(format string, args ...interface{}) {
+func (t *http2Transport) logf(format string, args ...any) {
 	log.Printf(format, args...)
 }
 

--- a/lib/http/header.go
+++ b/lib/http/header.go
@@ -194,7 +194,7 @@ func (s *headerSorter) Swap(i, j int)      { s.kvs[i], s.kvs[j] = s.kvs[j], s.kv
 func (s *headerSorter) Less(i, j int) bool { return s.kvs[i].key < s.kvs[j].key }
 
 var headerSorterPool = sync.Pool{
-	New: func() interface{} { return new(headerSorter) },
+	New: func() any { return new(headerSorter) },
 }
 
 // sortedKeyValues returns h's keys sorted in the returned kvs
@@ -338,7 +338,7 @@ func filterHeaders(h Header) {
 func (h Header) MarshalJSON() ([]byte, error) {
 	filterHeaders(h)
 
-	headerMap := make(map[string]interface{})
+	headerMap := make(map[string]any)
 	for k, v := range h {
 		// Need to special-case unknown header object, since it's not a true header (aka map[string][]string)
 		if k == "Unknown" && len(v) > 0 {

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -24,7 +24,7 @@ var aLongTimeAgo = time.Unix(1, 0)
 // generic http stuff in random places.
 
 // contextKey is a value for use with context.WithValue. It's used as
-// a pointer so it fits in an interface{} without allocation.
+// a pointer so it fits in an any without allocation.
 type contextKey struct {
 	name string
 }

--- a/lib/http/httptrace/trace.go
+++ b/lib/http/httptrace/trace.go
@@ -50,7 +50,7 @@ func WithClientTrace(ctx context.Context, trace *ClientTrace) context.Context {
 			}
 		}
 		if trace.DNSDone != nil {
-			nt.DNSDone = func(netIPs []interface{}, coalesced bool, err error) {
+			nt.DNSDone = func(netIPs []any, coalesced bool, err error) {
 				addrs := make([]net.IPAddr, len(netIPs))
 				for i, ip := range netIPs {
 					addrs[i] = ip.(net.IPAddr)

--- a/lib/http/httputil/dump_test.go
+++ b/lib/http/httputil/dump_test.go
@@ -20,7 +20,7 @@ import (
 
 type dumpTest struct {
 	Req  http.Request
-	Body interface{} // optional []byte or func() io.ReadCloser to populate Req.Body
+	Body any // optional []byte or func() io.ReadCloser to populate Req.Body
 
 	WantDump    string
 	WantDumpOut string

--- a/lib/http/httputil/non.go
+++ b/lib/http/httputil/non.go
@@ -310,7 +310,7 @@ func (p *ReverseProxy) copyBuffer(dst io.Writer, src io.Reader, buf []byte) (int
 	}
 }
 
-func (p *ReverseProxy) logf(format string, args ...interface{}) {
+func (p *ReverseProxy) logf(format string, args ...any) {
 	if p.ErrorLog != nil {
 		p.ErrorLog.Printf(format, args...)
 	} else {

--- a/lib/http/nettrace/nettrace.go
+++ b/lib/http/nettrace/nettrace.go
@@ -23,7 +23,7 @@ type Trace struct {
 	// The coalesced parameter is whether singleflight de-dupped
 	// the call. The addrs are of type net.IPAddr but can't
 	// actually be for circular dependency reasons.
-	DNSDone func(netIPs []interface{}, coalesced bool, err error)
+	DNSDone func(netIPs []any, coalesced bool, err error)
 
 	// ConnectStart is called before a Dial, excluding Dials made
 	// during DNS lookups. In the case of DualStack (Happy Eyeballs)

--- a/lib/http/requestwrite_test.go
+++ b/lib/http/requestwrite_test.go
@@ -20,7 +20,7 @@ import (
 
 type reqWriteTest struct {
 	Req  Request
-	Body interface{} // optional []byte or func() io.ReadCloser to populate Req.Body
+	Body any // optional []byte or func() io.ReadCloser to populate Req.Body
 
 	// Any of these three may be empty to skip that test.
 	WantWrite string // Request.Write

--- a/lib/http/response_test.go
+++ b/lib/http/response_test.go
@@ -636,8 +636,8 @@ var readResponseCloseInMiddleTests = []struct {
 func TestReadResponseCloseInMiddle(t *testing.T) {
 	t.Parallel()
 	for _, test := range readResponseCloseInMiddleTests {
-		fatalf := func(format string, args ...interface{}) {
-			args = append([]interface{}{test.chunked, test.compressed}, args...)
+		fatalf := func(format string, args ...any) {
+			args = append([]any{test.chunked, test.compressed}, args...)
 			t.Fatalf("on test chunked=%v, compressed=%v: "+format, args...)
 		}
 		checkErr := func(err error, msg string) {
@@ -722,7 +722,7 @@ func TestReadResponseCloseInMiddle(t *testing.T) {
 	}
 }
 
-func diff(t *testing.T, prefix string, have, want interface{}) {
+func diff(t *testing.T, prefix string, have, want any) {
 	hv := reflect.ValueOf(have).Elem()
 	wv := reflect.ValueOf(want).Elem()
 	if hv.Type() != wv.Type() {
@@ -842,10 +842,10 @@ func TestReadResponseErrors(t *testing.T) {
 		name    string // optional, defaults to in
 		in      string
 		header  Header
-		wantErr interface{} // nil, err value, or string substring
+		wantErr any // nil, err value, or string substring
 	}
 
-	status := func(s string, wantErr interface{}) testCase {
+	status := func(s string, wantErr any) testCase {
 		if wantErr == true {
 			wantErr = "malformed HTTP status code"
 		}
@@ -856,7 +856,7 @@ func TestReadResponseErrors(t *testing.T) {
 		}
 	}
 
-	version := func(s string, wantErr interface{}) testCase {
+	version := func(s string, wantErr any) testCase {
 		if wantErr == true {
 			wantErr = "malformed HTTP version"
 		}
@@ -867,7 +867,7 @@ func TestReadResponseErrors(t *testing.T) {
 		}
 	}
 
-	contentLength := func(status, body string, wantErr interface{}, header Header) testCase {
+	contentLength := func(status, body string, wantErr any, header Header) testCase {
 		return testCase{
 			name:    fmt.Sprintf("status %q %q", status, body),
 			in:      fmt.Sprintf("HTTP/1.1 %s\r\n%s", status, body),
@@ -937,7 +937,7 @@ func TestReadResponseErrors(t *testing.T) {
 
 // wantErr can be nil, an error value to match exactly, or type string to
 // match a substring.
-func matchErr(err error, wantErr interface{}) error {
+func matchErr(err error, wantErr any) error {
 	if err == nil {
 		if wantErr == nil {
 			return nil

--- a/lib/http/serve_test.go
+++ b/lib/http/serve_test.go
@@ -1776,7 +1776,7 @@ func TestInvalidTrailerClosesConnection(t *testing.T) {
 // Read and Write.
 type slowTestConn struct {
 	// over multiple calls to Read, time.Durations are slept, strings are read.
-	script []interface{}
+	script []any
 	closec chan bool
 
 	mu     sync.Mutex // guards rd/wd
@@ -1868,7 +1868,7 @@ func TestRequestBodyTimeoutClosesConnection(t *testing.T) {
 	defer afterTest(t)
 	for _, handler := range testHandlerBodyConsumers {
 		conn := &slowTestConn{
-			script: []interface{}{
+			script: []any{
 				"POST /public HTTP/1.1\r\n" +
 					"Host: test\r\n" +
 					"Content-Length: 10000\r\n" +
@@ -2283,7 +2283,7 @@ func TestHandlerPanicWithHijack(t *testing.T) {
 	testHandlerPanic(t, true, h1Mode, "intentional death for testing")
 }
 
-func testHandlerPanic(t *testing.T, withHijack, h2 bool, panicValue interface{}) {
+func testHandlerPanic(t *testing.T, withHijack, h2 bool, panicValue any) {
 	defer afterTest(t)
 	// Unlike the other tests that set the log output to ioutil.Discard
 	// to quiet the output, this test uses a pipe. The pipe serves three
@@ -3439,7 +3439,7 @@ func testTransportAndServerSharedBodyRace(t *testing.T, h2 bool) {
 	// this test fails, it hangs. This helps debugging and I've
 	// added this enough times "temporarily".  It now gets added
 	// full time.
-	errorf := func(format string, args ...interface{}) {
+	errorf := func(format string, args ...any) {
 		v := fmt.Sprintf(format, args...)
 		println(v)
 		t.Error(v)
@@ -3448,10 +3448,10 @@ func testTransportAndServerSharedBodyRace(t *testing.T, h2 bool) {
 	unblockBackend := make(chan bool)
 	backend := newClientServerTest(t, h2, HandlerFunc(func(rw ResponseWriter, req *Request) {
 		gone := rw.(CloseNotifier).CloseNotify()
-		didCopy := make(chan interface{})
+		didCopy := make(chan any)
 		go func() {
 			n, err := io.CopyN(rw, req.Body, bodySize)
-			didCopy <- []interface{}{n, err}
+			didCopy <- []any{n, err}
 		}()
 		isGone := false
 	Loop:

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -773,7 +773,7 @@ var (
 )
 
 var copyBufPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		b := make([]byte, 32*1024)
 		return &b
 	},
@@ -1671,10 +1671,10 @@ func (c *conn) setState(nc net.Conn, state ConnState) {
 	}
 }
 
-// connStateInterface is an array of the interface{} versions of
+// connStateInterface is an array of the any versions of
 // ConnState values, so we can use them in atomic.Values later without
-// paying the cost of shoving their integers in an interface{}.
-var connStateInterface = [...]interface{}{
+// paying the cost of shoving their integers in an any.
+var connStateInterface = [...]any{
 	StateNew:      StateNew,
 	StateActive:   StateActive,
 	StateIdle:     StateIdle,
@@ -2747,7 +2747,7 @@ func (srv *Server) SetKeepAlivesEnabled(v bool) {
 	srv.doneChan = nil
 }
 
-func (s *Server) logf(format string, args ...interface{}) {
+func (s *Server) logf(format string, args ...any) {
 	if s.ErrorLog != nil {
 		s.ErrorLog.Printf(format, args...)
 	} else {

--- a/lib/http/transfer.go
+++ b/lib/http/transfer.go
@@ -68,7 +68,7 @@ type transferWriter struct {
 	ByteReadCh   chan readResult // non-nil if probeRequestBody called
 }
 
-func newTransferWriter(r interface{}) (t *transferWriter, err error) {
+func newTransferWriter(r any) (t *transferWriter, err error) {
 	t = &transferWriter{}
 
 	// Extract relevant fields
@@ -402,7 +402,7 @@ func suppressedHeaders(status int) []string {
 }
 
 // msg is *Request or *Response.
-func readTransfer(msg interface{}, r *bufio.Reader) (err error) {
+func readTransfer(msg any, r *bufio.Reader) (err error) {
 	t := &transferReader{RequestMethod: "GET"}
 
 	// Unify input
@@ -726,7 +726,7 @@ func fixTrailer(header Header, te []string) (Header, error) {
 // and then reads the trailer if necessary.
 type body struct {
 	src          io.Reader
-	hdr          interface{}   // non-nil (Response or Request) value means read trailer
+	hdr          any           // non-nil (Response or Request) value means read trailer
 	r            *bufio.Reader // underlying wire-format reader for the trailer
 	closing      bool          // is the connection to be closed after reading body?
 	doEarlyClose bool          // whether Close should stop early

--- a/lib/http/transport_test.go
+++ b/lib/http/transport_test.go
@@ -502,7 +502,7 @@ func TestTransportServerClosingUnexpectedly(t *testing.T) {
 	c.Transport = tr
 
 	fetch := func(n, retries int) string {
-		condFatalf := func(format string, arg ...interface{}) {
+		condFatalf := func(format string, arg ...any) {
 			if retries <= 0 {
 				t.Fatalf(format, arg...)
 			}
@@ -2594,7 +2594,7 @@ func TestRetryIdempotentRequestsOnError(t *testing.T) {
 		mu     sync.Mutex
 		logbuf bytes.Buffer
 	)
-	logf := func(format string, args ...interface{}) {
+	logf := func(format string, args ...any) {
 		mu.Lock()
 		defer mu.Unlock()
 		fmt.Fprintf(&logbuf, format, args...)
@@ -3341,7 +3341,7 @@ func testTransportEventTrace(t *testing.T, h2 bool, noHooks bool) {
 
 	var mu sync.Mutex // guards buf
 	var buf bytes.Buffer
-	logf := func(format string, args ...interface{}) {
+	logf := func(format string, args ...any) {
 		mu.Lock()
 		defer mu.Unlock()
 		fmt.Fprintf(&buf, format, args...)
@@ -3476,7 +3476,7 @@ func TestTransportEventTraceRealDNS(t *testing.T) {
 	c.Transport = tr
 	var mu sync.Mutex // guards buf
 	var buf bytes.Buffer
-	logf := func(format string, args ...interface{}) {
+	logf := func(format string, args ...any) {
 		mu.Lock()
 		defer mu.Unlock()
 		fmt.Fprintf(&buf, format, args...)

--- a/lib/output/process.go
+++ b/lib/output/process.go
@@ -299,7 +299,7 @@ func (processor *Processor) process(v reflect.Value) reflect.Value {
 }
 
 // Process the given value recursively using the options in this processor.
-func (processor *Processor) Process(v interface{}) (ret interface{}, err error) {
+func (processor *Processor) Process(v any) (ret any, err error) {
 	defer func() {
 		if thrown := recover(); thrown != nil {
 			cast, ok := thrown.(error)
@@ -314,6 +314,6 @@ func (processor *Processor) Process(v interface{}) (ret interface{}, err error) 
 }
 
 // Process the given value recursively using the default options.
-func Process(v interface{}) (interface{}, error) {
+func Process(v any) (any, error) {
 	return NewProcessor().Process(v)
 }

--- a/lib/output/test/process_test.go
+++ b/lib/output/test/process_test.go
@@ -36,13 +36,13 @@ type Strippable interface {
 	Stripped() string
 }
 
-// JSON encode the value, then decode it as a map[string]interface{}.
-func toMap(v interface{}) map[string]interface{} {
+// JSON encode the value, then decode it as a map[string]any.
+func toMap(v any) map[string]any {
 	ret, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		logrus.Fatalf("Error marshaling: %v", err)
 	}
-	theMap := new(map[string]interface{})
+	theMap := new(map[string]any)
 	err = json.Unmarshal(ret, theMap)
 	if err != nil {
 		logrus.Fatalf("Error unmarshaling: %v", err)
@@ -52,9 +52,9 @@ func toMap(v interface{}) map[string]interface{} {
 
 // Get v[key0][key1]...[keyN], or return nil, error if any values along the way
 // are nil / not present / not maps.
-func mapPath(theMap interface{}, keys ...string) (interface{}, error) {
+func mapPath(theMap any, keys ...string) (any, error) {
 	for i, key := range keys {
-		cast, ok := theMap.(map[string]interface{})
+		cast, ok := theMap.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("%s in map is not a map", strings.Join(keys[0:i], "."))
 		}
@@ -70,13 +70,13 @@ func mapPath(theMap interface{}, keys ...string) (interface{}, error) {
 
 // Set theMap[key0][key1]...[keyN] = value, or return error if any values along
 // the way are nil / not present / not maps.
-func setMapValue(theMap map[string]interface{}, value interface{}, keys ...string) error {
+func setMapValue(theMap map[string]any, value any, keys ...string) error {
 	lastIndex := len(keys) - 1
 	out, err := mapPath(theMap, keys[0:lastIndex]...)
 	if err != nil {
 		return err
 	}
-	cast, ok := out.(map[string]interface{})
+	cast, ok := out.(map[string]any)
 	if !ok {
 		return fmt.Errorf("%s in map is not a map", strings.Join(keys[0:lastIndex], "."))
 	}
@@ -86,13 +86,13 @@ func setMapValue(theMap map[string]interface{}, value interface{}, keys ...strin
 
 // delete the value at theMap[key0][key1]...[keyN], or return an error if any
 // values along the way are nil / not present / not maps.
-func delOut(theMap map[string]interface{}, keys ...string) error {
+func delOut(theMap map[string]any, keys ...string) error {
 	lastIndex := len(keys) - 1
 	out, err := mapPath(theMap, keys[0:lastIndex]...)
 	if err != nil {
 		return err
 	}
-	cast, ok := out.(map[string]interface{})
+	cast, ok := out.(map[string]any)
 	if !ok {
 		return fmt.Errorf("%s in map is not a map", strings.Join(keys[0:lastIndex], "."))
 	}
@@ -104,7 +104,7 @@ func delOut(theMap map[string]interface{}, keys ...string) error {
 // structs' keys are sorted by order in the definition, which can vary between
 // the original and "stripped" versions, the marshalled text is unmarshaled into
 // a map (whose keys are sorted alphabetically) and then re-marshaled.
-func marshal(v interface{}) string {
+func marshal(v any) string {
 	theMap := toMap(v)
 	realRet, err := json.MarshalIndent(theMap, "", "  ")
 	if err != nil {
@@ -114,7 +114,7 @@ func marshal(v interface{}) string {
 }
 
 // Get the processed copy of v using the given verbosity value.
-func process(verbose bool, v interface{}) interface{} {
+func process(verbose bool, v any) any {
 	proc := output.NewProcessor()
 	proc.Verbose = verbose
 	ret, err := proc.Process(v)
@@ -125,20 +125,20 @@ func process(verbose bool, v interface{}) interface{} {
 }
 
 // Return the marshalled  processed copy of v using the given verbosity value.
-func strip(verbose bool, v interface{}) string {
+func strip(verbose bool, v any) string {
 	theCopy := process(verbose, v)
 	return marshal(theCopy)
 }
 
 // Flat value with a wide variety of types, both debug and non-debug.
 type Flat struct {
-	StringValue    string      `json:"string_value"`
-	TrueValue      bool        `json:"true_value"`
-	FalseValue     bool        `json:"false_value"`
-	IntValue       int         `json:"int_value"`
-	BytesValue     []byte      `json:"bytes_value"`
-	ArrayValue     [5]string   `json:"array_value"`
-	InterfaceValue interface{} `json:"interface_value"`
+	StringValue    string    `json:"string_value"`
+	TrueValue      bool      `json:"true_value"`
+	FalseValue     bool      `json:"false_value"`
+	IntValue       int       `json:"int_value"`
+	BytesValue     []byte    `json:"bytes_value"`
+	ArrayValue     [5]string `json:"array_value"`
+	InterfaceValue any       `json:"interface_value"`
 
 	PtrStringValue *string    `json:"ptr_string_value"`
 	PtrTrueValue   *bool      `json:"ptr_true_value"`
@@ -147,13 +147,13 @@ type Flat struct {
 	PtrBytesValue  *[]byte    `json:"ptr_bytes_value"`
 	PtrArrayValue  *[5]string `json:"ptr_array_value"`
 
-	DebugStringValue    string      `json:"debug_string_value,omitempty" zgrab:"debug"`
-	DebugTrueValue      bool        `json:"debug_true_value,omitempty" zgrab:"debug"`
-	DebugFalseValue     bool        `json:"debug_false_value,omitempty" zgrab:"debug"`
-	DebugIntValue       int         `json:"debug_int_value,omitempty" zgrab:"debug"`
-	DebugBytesValue     []byte      `json:"debug_bytes_value,omitempty" zgrab:"debug"`
-	DebugArrayValue     [5]string   `json:"debug_array_value,omitempty" zgrab:"debug"`
-	DebugInterfaceValue interface{} `json:"debug_interface_value,omitempty" zgrab:"debug"`
+	DebugStringValue    string    `json:"debug_string_value,omitempty" zgrab:"debug"`
+	DebugTrueValue      bool      `json:"debug_true_value,omitempty" zgrab:"debug"`
+	DebugFalseValue     bool      `json:"debug_false_value,omitempty" zgrab:"debug"`
+	DebugIntValue       int       `json:"debug_int_value,omitempty" zgrab:"debug"`
+	DebugBytesValue     []byte    `json:"debug_bytes_value,omitempty" zgrab:"debug"`
+	DebugArrayValue     [5]string `json:"debug_array_value,omitempty" zgrab:"debug"`
+	DebugInterfaceValue any       `json:"debug_interface_value,omitempty" zgrab:"debug"`
 
 	DebugPtrStringValue *string    `json:"debug_ptr_string_value,omitempty" zgrab:"debug"`
 	DebugPtrTrueValue   *bool      `json:"debug_ptr_true_value,omitempty" zgrab:"debug"`
@@ -165,13 +165,13 @@ type Flat struct {
 
 type StrippedFlat struct {
 	*Flat
-	OmitDebugStringValue    string      `json:"debug_string_value,omitempty" zgrab:"debug"`
-	OmitDebugTrueValue      bool        `json:"debug_true_value,omitempty" zgrab:"debug"`
-	OmitDebugFalseValue     bool        `json:"debug_false_value,omitempty" zgrab:"debug"`
-	OmitDebugIntValue       int         `json:"debug_int_value,omitempty" zgrab:"debug"`
-	OmitDebugBytesValue     []byte      `json:"debug_bytes_value,omitempty" zgrab:"debug"`
-	OmitDebugArrayValue     [5]string   `json:"debug_array_value,omitempty" zgrab:"debug"`
-	OmitDebugInterfaceValue interface{} `json:"debug_interface_value,omitempty" zgrab:"debug"`
+	OmitDebugStringValue    string    `json:"debug_string_value,omitempty" zgrab:"debug"`
+	OmitDebugTrueValue      bool      `json:"debug_true_value,omitempty" zgrab:"debug"`
+	OmitDebugFalseValue     bool      `json:"debug_false_value,omitempty" zgrab:"debug"`
+	OmitDebugIntValue       int       `json:"debug_int_value,omitempty" zgrab:"debug"`
+	OmitDebugBytesValue     []byte    `json:"debug_bytes_value,omitempty" zgrab:"debug"`
+	OmitDebugArrayValue     [5]string `json:"debug_array_value,omitempty" zgrab:"debug"`
+	OmitDebugInterfaceValue any       `json:"debug_interface_value,omitempty" zgrab:"debug"`
 
 	OmitDebugPtrStringValue *string    `json:"debug_ptr_string_value,omitempty" zgrab:"debug"`
 	OmitDebugPtrTrueValue   *bool      `json:"debug_ptr_true_value,omitempty" zgrab:"debug"`
@@ -310,12 +310,12 @@ func getDeep(id string, depth int) *Deep {
 	return ret
 }
 
-// An arbitrarily deep struct, with its children stored as interface{} fields.
+// An arbitrarily deep struct, with its children stored as any fields.
 type DeepIface struct {
-	ID         string      `json:"id"`
-	DebugID    string      `json:"debug_id,omitempty" zgrab:"debug"`
-	Child      interface{} `json:"child"`
-	DebugChild interface{} `json:"debug_child,omitempty" zgrab:"debug"`
+	ID         string `json:"id"`
+	DebugID    string `json:"debug_id,omitempty" zgrab:"debug"`
+	Child      any    `json:"child"`
+	DebugChild any    `json:"debug_child,omitempty" zgrab:"debug"`
 
 	Flat    Flat  `json:"flat,omitempty"`
 	PtrFlat *Flat `json:"ptr_flat,omitempty"`
@@ -326,9 +326,9 @@ type DeepIface struct {
 
 type StrippedDeepIface struct {
 	*DeepIface
-	OmitDebugID    string      `json:"debug_id,omitempty" zgrab:"debug"`
-	OverrideChild  interface{} `json:"child"`
-	OmitDebugChild interface{} `json:"debug_child,omitempty" zgrab:"debug"`
+	OmitDebugID    string `json:"debug_id,omitempty" zgrab:"debug"`
+	OverrideChild  any    `json:"child"`
+	OmitDebugChild any    `json:"debug_child,omitempty" zgrab:"debug"`
 
 	OverrideFlat    StrippedFlat  `json:"flat,omitempty"`
 	OverridePtrFlat *StrippedFlat `json:"ptr_flat,omitempty"`
@@ -500,13 +500,13 @@ func getDeepArray(id string, depth int) *DeepArray {
 	return ret
 }
 
-// An arbitrarily deep struct, with its children stored in a slice of interface{}s.
+// An arbitrarily deep struct, with its children stored in a slice of anys.
 type DeepIfaceSlice struct {
 	ID      string `json:"id"`
 	DebugID string `json:"debug_id,omitempty" zgrab:"debug"`
 
-	Children      []interface{} `json:"children"`
-	DebugChildren []interface{} `json:"debug_children,omitempty" zgrab:"debug"`
+	Children      []any `json:"children"`
+	DebugChildren []any `json:"debug_children,omitempty" zgrab:"debug"`
 
 	Flat    Flat  `json:"flat,omitempty"`
 	PtrFlat *Flat `json:"ptr_flat,omitempty"`
@@ -519,8 +519,8 @@ type StrippedDeepIfaceSlice struct {
 	*DeepIfaceSlice
 	OmitDebugID string `json:"debug_id,omitempty" zgrab:"debug"`
 
-	OverrideChildren  []interface{} `json:"children"`
-	OmitDebugChildren []interface{} `json:"debug_children,omitempty" zgrab:"debug"`
+	OverrideChildren  []any `json:"children"`
+	OmitDebugChildren []any `json:"debug_children,omitempty" zgrab:"debug"`
 
 	OverrideFlat    StrippedFlat  `json:"flat,omitempty"`
 	OverridePtrFlat *StrippedFlat `json:"ptr_flat,omitempty"`
@@ -535,7 +535,7 @@ func (deep *DeepIfaceSlice) GetStripped() *StrippedDeepIfaceSlice {
 	if len(deep.Children) > 0 {
 		child0 := deep.Children[0].(DeepIfaceSlice)
 		child1 := deep.Children[1].(Flat)
-		temp.OverrideChildren = []interface{}{
+		temp.OverrideChildren = []any{
 			*(&child0).GetStripped(),
 			*(&child1).GetStripped(),
 		}
@@ -562,11 +562,11 @@ func getDeepIfaceSlice(id string, depth int) *DeepIfaceSlice {
 		DebugPtrFlat: getFlat(id + ".debug_ptr_flat"),
 	}
 	if depth > 0 {
-		ret.Children = []interface{}{
+		ret.Children = []any{
 			*getDeepIfaceSlice(ret.ID+".children[0]", depth-1),
 			*getFlat(id + ".children[1]"),
 		}
-		ret.DebugChildren = []interface{}{
+		ret.DebugChildren = []any{
 			*getDeepIfaceSlice(ret.ID+".debug_children[0]", depth-1),
 			*getFlat(ret.ID + ".debug_children[1]"),
 		}
@@ -574,13 +574,13 @@ func getDeepIfaceSlice(id string, depth int) *DeepIfaceSlice {
 	return ret
 }
 
-// An arbitrarily deep struct, with its children stored in an array of interface{}s
+// An arbitrarily deep struct, with its children stored in an array of anys
 type DeepIfaceArray struct {
 	ID      string `json:"id"`
 	DebugID string `json:"debug_id,omitempty" zgrab:"debug"`
 
-	Children      [2]interface{} `json:"children"`
-	DebugChildren [2]interface{} `json:"debug_children,omitempty" zgrab:"debug"`
+	Children      [2]any `json:"children"`
+	DebugChildren [2]any `json:"debug_children,omitempty" zgrab:"debug"`
 
 	Flat    Flat  `json:"flat,omitempty"`
 	PtrFlat *Flat `json:"ptr_flat,omitempty"`
@@ -593,8 +593,8 @@ type StrippedDeepIfaceArray struct {
 	*DeepIfaceArray
 	OmitDebugID string `json:"debug_id,omitempty" zgrab:"debug"`
 
-	OverrideChildren  [2]interface{} `json:"children"`
-	OmitDebugChildren [2]interface{} `json:"debug_children,omitempty" zgrab:"debug"`
+	OverrideChildren  [2]any `json:"children"`
+	OmitDebugChildren [2]any `json:"debug_children,omitempty" zgrab:"debug"`
 
 	OverrideFlat    StrippedFlat  `json:"flat,omitempty"`
 	OverridePtrFlat *StrippedFlat `json:"ptr_flat,omitempty"`

--- a/lib/smb/gss/gss.go
+++ b/lib/smb/gss/gss.go
@@ -37,7 +37,7 @@ type NegTokenResp struct {
 // gsswrapped used to force ASN1 encoding to include explicit sequence tags
 // Type does not fulfill the BinaryMarshallable interfce and is used only as a
 // helper to marshal a NegTokenResp
-type gsswrapped struct{ G interface{} }
+type gsswrapped struct{ G any }
 
 func NewNegTokenInit() (NegTokenInit, error) {
 	oid, err := ObjectIDStrToInt(SpnegoOid)

--- a/lib/smb/smb/encoder/encoder.go
+++ b/lib/smb/smb/encoder/encoder.go
@@ -19,14 +19,14 @@ type Metadata struct {
 	Tags       *TagMap
 	Lens       map[string]uint64
 	Offsets    map[string]uint64
-	Parent     interface{}
+	Parent     any
 	ParentBuf  []byte
 	CurrOffset uint64
 	CurrField  string
 }
 
 type TagMap struct {
-	m   map[string]interface{}
+	m   map[string]any
 	has map[string]bool
 }
 
@@ -34,12 +34,12 @@ func (t TagMap) Has(key string) bool {
 	return t.has[key]
 }
 
-func (t TagMap) Set(key string, val interface{}) {
+func (t TagMap) Set(key string, val any) {
 	t.m[key] = val
 	t.has[key] = true
 }
 
-func (t TagMap) Get(key string) interface{} {
+func (t TagMap) Get(key string) any {
 	return t.m[key]
 }
 
@@ -59,7 +59,7 @@ func (t TagMap) GetString(key string) (string, error) {
 
 func parseTags(sf reflect.StructField) (*TagMap, error) {
 	ret := &TagMap{
-		m:   make(map[string]interface{}),
+		m:   make(map[string]any),
 		has: make(map[string]bool),
 	}
 	tag := sf.Tag.Get("smb")
@@ -187,11 +187,11 @@ func getFieldLengthByName(fieldName string, meta *Metadata) (uint64, error) {
 	return ret, nil
 }
 
-func Marshal(v interface{}) ([]byte, error) {
+func Marshal(v any) ([]byte, error) {
 	return marshal(v, nil)
 }
 
-func marshal(v interface{}, meta *Metadata) ([]byte, error) {
+func marshal(v any, meta *Metadata) ([]byte, error) {
 	var ret []byte
 	tf := reflect.TypeOf(v)
 	vf := reflect.ValueOf(v)
@@ -313,7 +313,7 @@ func marshal(v interface{}, meta *Metadata) ([]byte, error) {
 	return w.Bytes(), nil
 }
 
-func unmarshal(buf []byte, v interface{}, meta *Metadata) (interface{}, error) {
+func unmarshal(buf []byte, v any, meta *Metadata) (any, error) {
 	tf := reflect.TypeOf(v)
 	vf := reflect.ValueOf(v)
 
@@ -360,7 +360,7 @@ func unmarshal(buf []byte, v interface{}, meta *Metadata) (interface{}, error) {
 				return nil, err
 			}
 			m.Tags = tags
-			var data interface{}
+			var data any
 			switch tf.Field(i).Type.Kind() {
 			case reflect.Struct:
 				data, err = unmarshal(buf[m.CurrOffset:], vf.Field(i).Addr().Interface(), m)
@@ -464,7 +464,7 @@ func unmarshal(buf []byte, v interface{}, meta *Metadata) (interface{}, error) {
 
 }
 
-func Unmarshal(buf []byte, v interface{}) error {
+func Unmarshal(buf []byte, v any) error {
 	_, err := unmarshal(buf, v, nil)
 	return err
 }

--- a/lib/smb/smb/session.go
+++ b/lib/smb/smb/session.go
@@ -338,7 +338,7 @@ func (s *Session) Close() {
 	s.Debug("Session close completed", nil)
 }
 
-func (s *Session) send(req interface{}) (res []byte, err error) {
+func (s *Session) send(req any) (res []byte, err error) {
 	buf, err := encoder.Marshal(req)
 	if err != nil {
 		s.Debug("", err)

--- a/lib/ssh/agent/client.go
+++ b/lib/ssh/agent/client.go
@@ -62,7 +62,7 @@ type Agent interface {
 type AddedKey struct {
 	// PrivateKey must be a *rsa.PrivateKey, *dsa.PrivateKey or
 	// *ecdsa.PrivateKey, which will be inserted into the agent.
-	PrivateKey interface{}
+	PrivateKey any
 	// Certificate, if not nil, is communicated to the agent and will be
 	// stored with the key.
 	Certificate *ssh.Certificate
@@ -244,7 +244,7 @@ func NewClient(rw io.ReadWriter) Agent {
 // call sends an RPC to the agent. On success, the reply is
 // unmarshaled into reply and replyType is set to the first byte of
 // the reply, which contains the type of the message.
-func (c *client) call(req []byte) (reply interface{}, err error) {
+func (c *client) call(req []byte) (reply any, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -372,11 +372,11 @@ func (c *client) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
 
 // unmarshal parses an agent message in packet, returning the parsed
 // form and the message type of packet.
-func unmarshal(packet []byte) (interface{}, error) {
+func unmarshal(packet []byte) (any, error) {
 	if len(packet) < 1 {
 		return nil, errors.New("agent: empty packet")
 	}
-	var msg interface{}
+	var msg any
 	switch packet[0] {
 	case agentFailure:
 		return new(failureAgentMsg), nil
@@ -438,7 +438,7 @@ type ed25519KeyMsg struct {
 }
 
 // Insert adds a private key to the agent.
-func (c *client) insertKey(s interface{}, comment string, constraints []byte) error {
+func (c *client) insertKey(s any, comment string, constraints []byte) error {
 	var req []byte
 	switch k := s.(type) {
 	case *rsa.PrivateKey:
@@ -565,7 +565,7 @@ func (c *client) Add(key AddedKey) error {
 	}
 }
 
-func (c *client) insertCert(s interface{}, cert *ssh.Certificate, comment string, constraints []byte) error {
+func (c *client) insertCert(s any, cert *ssh.Certificate, comment string, constraints []byte) error {
 	var req []byte
 	switch k := s.(type) {
 	case *rsa.PrivateKey:

--- a/lib/ssh/agent/client_test.go
+++ b/lib/ssh/agent/client_test.go
@@ -79,19 +79,19 @@ func startAgent(t *testing.T) (client Agent, socket string, cleanup func()) {
 	}
 }
 
-func testAgent(t *testing.T, key interface{}, cert *ssh.Certificate, lifetimeSecs uint32) {
+func testAgent(t *testing.T, key any, cert *ssh.Certificate, lifetimeSecs uint32) {
 	agent, _, cleanup := startAgent(t)
 	defer cleanup()
 
 	testAgentInterface(t, agent, key, cert, lifetimeSecs)
 }
 
-func testKeyring(t *testing.T, key interface{}, cert *ssh.Certificate, lifetimeSecs uint32) {
+func testKeyring(t *testing.T, key any, cert *ssh.Certificate, lifetimeSecs uint32) {
 	a := NewKeyring()
 	testAgentInterface(t, a, key, cert, lifetimeSecs)
 }
 
-func testAgentInterface(t *testing.T, agent Agent, key interface{}, cert *ssh.Certificate, lifetimeSecs uint32) {
+func testAgentInterface(t *testing.T, agent Agent, key any, cert *ssh.Certificate, lifetimeSecs uint32) {
 	signer, err := ssh.NewSignerFromKey(key)
 	if err != nil {
 		t.Fatalf("NewSignerFromKey(%T): %v", key, err)

--- a/lib/ssh/agent/server.go
+++ b/lib/ssh/agent/server.go
@@ -73,7 +73,7 @@ type agentUnlockMsg struct {
 	Passphrase []byte `sshtype:"23"`
 }
 
-func (s *server) processRequest(data []byte) (interface{}, error) {
+func (s *server) processRequest(data []byte) (any, error) {
 	switch data[0] {
 	case agentRequestV1Identities:
 		return &agentV1IdentityMsg{0}, nil

--- a/lib/ssh/agent/testdata_test.go
+++ b/lib/ssh/agent/testdata_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	testPrivateKeys map[string]interface{}
+	testPrivateKeys map[string]any
 	testSigners     map[string]ssh.Signer
 	testPublicKeys  map[string]ssh.PublicKey
 )
@@ -26,7 +26,7 @@ func init() {
 	var err error
 
 	n := len(testdata.PEMBytes)
-	testPrivateKeys = make(map[string]interface{}, n)
+	testPrivateKeys = make(map[string]any, n)
 	testSigners = make(map[string]ssh.Signer, n)
 	testPublicKeys = make(map[string]ssh.PublicKey, n)
 	for t, k := range testdata.PEMBytes {

--- a/lib/ssh/channel.go
+++ b/lib/ssh/channel.go
@@ -171,7 +171,7 @@ type channel struct {
 	direction channelDirection
 
 	// Pending internal channel messages.
-	msg chan interface{}
+	msg chan any
 
 	// Since requests have no ID, there can be only one request
 	// with WantReply=true outstanding.  This lock is held by a
@@ -217,7 +217,7 @@ func (c *channel) writePacket(packet []byte) error {
 	return err
 }
 
-func (c *channel) sendMessage(msg interface{}) error {
+func (c *channel) sendMessage(msg any) error {
 	if debugMux {
 		log.Printf("send(%d): %#v", c.mux.chanList.offset, msg)
 	}
@@ -462,7 +462,7 @@ func (m *mux) newChannel(chanType string, direction channelDirection, extraData 
 		extPending:       newBuffer(),
 		direction:        direction,
 		incomingRequests: make(chan *Request, 16),
-		msg:              make(chan interface{}, 16),
+		msg:              make(chan any, 16),
 		chanType:         chanType,
 		extraData:        extraData,
 		mux:              m,
@@ -611,7 +611,7 @@ func (ch *channel) ackRequest(ok bool) error {
 		return errUndecided
 	}
 
-	var msg interface{}
+	var msg any
 	if !ok {
 		msg = channelRequestFailureMsg{
 			PeersId: ch.remoteId,

--- a/lib/ssh/keys.go
+++ b/lib/ssh/keys.go
@@ -512,7 +512,7 @@ func (key ed25519PublicKey) Type() string {
 }
 
 func (key ed25519PublicKey) MarshalJSON() ([]byte, error) {
-	temp := make(map[string]interface{})
+	temp := make(map[string]any)
 	baseKey := (ed25519.PublicKey)(key)
 	temp["public_bytes"] = ([]byte)(baseKey)
 	return json.Marshal(temp)
@@ -663,7 +663,7 @@ func (k *ecdsaPublicKey) CryptoPublicKey() crypto.PublicKey {
 // NewSignerFromKey takes an *rsa.PrivateKey, *dsa.PrivateKey,
 // *ecdsa.PrivateKey or any other crypto.Signer and returns a corresponding
 // Signer instance. ECDSA keys must use P-256, P-384 or P-521.
-func NewSignerFromKey(key interface{}) (Signer, error) {
+func NewSignerFromKey(key any) (Signer, error) {
 	switch key := key.(type) {
 	case crypto.Signer:
 		return NewSignerFromSigner(key)
@@ -758,7 +758,7 @@ func (s *wrappedSigner) Sign(rand io.Reader, data []byte) (*Signature, error) {
 // NewPublicKey takes an *rsa.PublicKey, *dsa.PublicKey, *ecdsa.PublicKey,
 // or ed25519.PublicKey returns a corresponding PublicKey instance.
 // ECDSA keys must use P-256, P-384 or P-521.
-func NewPublicKey(key interface{}) (PublicKey, error) {
+func NewPublicKey(key any) (PublicKey, error) {
 	switch key := key.(type) {
 	case *rsa.PublicKey:
 		return (*rsaPublicKey)(key), nil
@@ -797,7 +797,7 @@ func encryptedBlock(block *pem.Block) bool {
 
 // ParseRawPrivateKey returns a private key from a PEM encoded private key. It
 // supports RSA (PKCS#1), DSA (OpenSSL), and ECDSA private keys.
-func ParseRawPrivateKey(pemBytes []byte) (interface{}, error) {
+func ParseRawPrivateKey(pemBytes []byte) (any, error) {
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
 		return nil, errors.New("ssh: no key found")

--- a/lib/ssh/keys_test.go
+++ b/lib/ssh/keys_test.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/crypto/ed25519"
 )
 
-func rawKey(pub PublicKey) interface{} {
+func rawKey(pub PublicKey) any {
 	switch k := pub.(type) {
 	case *rsaPublicKey:
 		return (*rsa.PublicKey)(k)

--- a/lib/ssh/messages.go
+++ b/lib/ssh/messages.go
@@ -357,7 +357,7 @@ var errShortRead = errors.New("ssh: short read")
 // in decimal, the packet must start with one of those numbers. In
 // case of error, Unmarshal returns a ParseError or
 // UnexpectedMessageError.
-func Unmarshal(data []byte, out interface{}) error {
+func Unmarshal(data []byte, out any) error {
 	v := reflect.ValueOf(out).Elem()
 	structType := v.Type()
 	expectedTypes := typeTags(structType)
@@ -480,12 +480,12 @@ func Unmarshal(data []byte, out interface{}) error {
 // member has the "sshtype" tag set to a number in decimal, that
 // number is prepended to the result. If the last of member has the
 // "ssh" tag set to "rest", its contents are appended to the output.
-func Marshal(msg interface{}) []byte {
+func Marshal(msg any) []byte {
 	out := make([]byte, 0, 64)
 	return marshalStruct(out, msg)
 }
 
-func marshalStruct(out []byte, msg interface{}) []byte {
+func marshalStruct(out []byte, msg any) []byte {
 	v := reflect.Indirect(reflect.ValueOf(msg))
 	msgTypes := typeTags(v.Type())
 	if len(msgTypes) > 0 {
@@ -759,8 +759,8 @@ func marshalString(to []byte, s []byte) []byte {
 var bigIntType = reflect.TypeOf((*big.Int)(nil))
 
 // Decode a packet into its corresponding message.
-func decode(packet []byte) (interface{}, error) {
-	var msg interface{}
+func decode(packet []byte) (any, error) {
+	var msg any
 	switch packet[0] {
 	case msgDisconnect:
 		msg = new(disconnectMsg)

--- a/lib/ssh/mux.go
+++ b/lib/ssh/mux.go
@@ -92,7 +92,7 @@ type mux struct {
 	incomingChannels chan NewChannel
 
 	globalSentMu     sync.Mutex
-	globalResponses  chan interface{}
+	globalResponses  chan any
 	incomingRequests chan *Request
 
 	errCond *sync.Cond
@@ -117,7 +117,7 @@ func newMux(p packetConn) *mux {
 	m := &mux{
 		conn:             p,
 		incomingChannels: make(chan NewChannel, 16),
-		globalResponses:  make(chan interface{}, 1),
+		globalResponses:  make(chan any, 1),
 		incomingRequests: make(chan *Request, 16),
 		errCond:          newCond(),
 	}
@@ -129,7 +129,7 @@ func newMux(p packetConn) *mux {
 	return m
 }
 
-func (m *mux) sendMessage(msg interface{}) error {
+func (m *mux) sendMessage(msg any) error {
 	p := Marshal(msg)
 	if debugMux {
 		log.Printf("send global(%d): %#v", m.chanList.offset, msg)

--- a/lib/ssh/server.go
+++ b/lib/ssh/server.go
@@ -65,7 +65,7 @@ func (jOptions *JsonCriticalOptions) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	temp := make(map[string]interface{})
+	temp := make(map[string]any)
 	if len(knownOpt) > 0 {
 		temp["known"] = knownOpt
 	}
@@ -101,7 +101,7 @@ func (ext *JsonExtensions) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	temp := make(map[string]interface{})
+	temp := make(map[string]any)
 	if len(knownExt) > 0 {
 		temp["known"] = knownExt
 	}

--- a/lib/ssh/test/testdata_test.go
+++ b/lib/ssh/test/testdata_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	testPrivateKeys map[string]interface{}
+	testPrivateKeys map[string]any
 	testSigners     map[string]ssh.Signer
 	testPublicKeys  map[string]ssh.PublicKey
 )
@@ -26,7 +26,7 @@ func init() {
 	var err error
 
 	n := len(testdata.PEMBytes)
-	testPrivateKeys = make(map[string]interface{}, n)
+	testPrivateKeys = make(map[string]any, n)
 	testSigners = make(map[string]ssh.Signer, n)
 	testPublicKeys = make(map[string]ssh.PublicKey, n)
 	for t, k := range testdata.PEMBytes {

--- a/lib/ssh/testdata_test.go
+++ b/lib/ssh/testdata_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	testPrivateKeys map[string]interface{}
+	testPrivateKeys map[string]any
 	testSigners     map[string]Signer
 	testPublicKeys  map[string]PublicKey
 )
@@ -25,7 +25,7 @@ func init() {
 	var err error
 
 	n := len(testdata.PEMBytes)
-	testPrivateKeys = make(map[string]interface{}, n)
+	testPrivateKeys = make(map[string]any, n)
 	testSigners = make(map[string]Signer, n)
 	testPublicKeys = make(map[string]PublicKey, n)
 	for t, k := range testdata.PEMBytes {

--- a/module.go
+++ b/module.go
@@ -21,7 +21,7 @@ type Scanner interface {
 	Protocol() string
 
 	// Scan connects to a host. The result should be JSON-serializable
-	Scan(t ScanTarget) (ScanStatus, interface{}, error)
+	Scan(t ScanTarget) (ScanStatus, any, error)
 }
 
 // ScanResponse is the result of a scan on a single host
@@ -33,32 +33,29 @@ type ScanResponse struct {
 	// the scan name.
 	Protocol string `json:"protocol"`
 
-	Result    interface{} `json:"result,omitempty"`
-	Timestamp string      `json:"timestamp,omitempty"`
-	Error     *string     `json:"error,omitempty"`
+	Result    any     `json:"result,omitempty"`
+	Timestamp string  `json:"timestamp,omitempty"`
+	Error     *string `json:"error,omitempty"`
 }
 
-// ScanModule is an interface which represents a module that the framework can
-// manipulate
+// ScanModule is an interface which represents a module that the framework can manipulate
 type ScanModule interface {
 	// NewFlags is called by the framework to pass to the argument parser. The parsed flags will be passed
 	// to the scanner created by NewScanner().
-	NewFlags() interface{}
+	NewFlags() any
 
 	// NewScanner is called by the framework for each time an individual scan is specified in the config or on
 	// the command-line. The framework will then call scanner.Init(name, flags).
 	NewScanner() Scanner
 
-	// Description returns a string suitable for use as an overview of this
-	// module within usage text.
+	// Description returns a string suitable for use as an overview of this module within usage text.
 	Description() string
 }
 
 // ScanFlags is an interface which must be implemented by all types sent to
 // the flag parser
 type ScanFlags interface {
-	// Help optionally returns any additional help text, e.g. specifying what empty defaults
-	// are interpreted as.
+	// Help optionally returns any additional help text, e.g. specifying what empty defaults are interpreted as.
 	Help() string
 
 	// Validate enforces all command-line flags and positional arguments have valid values.
@@ -68,10 +65,10 @@ type ScanFlags interface {
 // BaseFlags contains the options that every flags type must embed
 type BaseFlags struct {
 	Port           uint          `short:"p" long:"port" description:"Specify port to grab on"`
+	BytesReadLimit int           `short:"m" long:"maxbytes" description:"Maximum byte read limit per scan (0 = defaults)"`
 	Name           string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
 	Timeout        time.Duration `short:"t" long:"timeout" description:"Set connection timeout (0 = no timeout)" default:"10s"`
 	Trigger        string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
-	BytesReadLimit int           `short:"m" long:"maxbytes" description:"Maximum byte read limit per scan (0 = defaults)"`
 }
 
 // UDPFlags contains the common options used for all UDP scans

--- a/modules/amqp091/scanner.go
+++ b/modules/amqp091/scanner.go
@@ -102,7 +102,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -165,7 +165,7 @@ func (scanner *Scanner) Protocol() string {
 	return "amqp091"
 }
 
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/amqp091/scanner.go
+++ b/modules/amqp091/scanner.go
@@ -7,20 +7,20 @@ import (
 
 	amqpLib "github.com/rabbitmq/amqp091-go"
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 )
 
 // Flags holds the command-line configuration for the smb scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	Vhost            string `long:"vhost" description:"The vhost to connect to" default:"/"`
+	AuthUser         string `long:"auth-user" description:"Username to use for authentication. Must be used with --auth-pass. No auth is attempted if not provided."`
+	AuthPass         string `long:"auth-pass" description:"Password to use for authentication. Must be used with --auth-user. No auth is attempted if not provided."`
 
-	Vhost    string `long:"vhost" description:"The vhost to connect to" default:"/"`
-	AuthUser string `long:"auth-user" description:"Username to use for authentication. Must be used with --auth-pass. No auth is attempted if not provided."`
-	AuthPass string `long:"auth-pass" description:"Password to use for authentication. Must be used with --auth-user. No auth is attempted if not provided."`
-
-	UseTLS bool `long:"use-tls" description:"Use TLS to connect to the server. Note that AMQPS uses a different default port (5671) than AMQP (5672) and you will need to specify that port manually with -p."`
-	zgrab2.TLSFlags
+	UseTLS          bool `long:"use-tls" description:"Use TLS to connect to the server. Note that AMQPS uses a different default port (5671) than AMQP (5672) and you will need to specify that port manually with -p."`
+	zgrab2.TLSFlags `group:"TLS Options"`
 }
 
 // Module implements the zgrab2.Module interface.

--- a/modules/bacnet/messages.go
+++ b/modules/bacnet/messages.go
@@ -26,10 +26,10 @@ type APDU struct {
 }
 
 type Frame struct {
-	VLC     *VLC        `json:"vlc,omitempty"`
-	NPDU    *NPDU       `json:"npdu,omitempty"`
-	APDU    *APDU       `json:"apdu,omitempty"`
-	Payload interface{} `json:"payload,omitempty"`
+	VLC     *VLC  `json:"vlc,omitempty"`
+	NPDU    *NPDU `json:"npdu,omitempty"`
+	APDU    *APDU `json:"apdu,omitempty"`
+	Payload any   `json:"payload,omitempty"`
 }
 
 const vlcLength = 4

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -6,6 +6,7 @@ package bacnet
 
 import (
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 )
 
@@ -14,8 +15,8 @@ import (
 // Flags holds the command-line configuration for the bacnet scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.UDPFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.UDPFlags  `group:"UDP Options"`
 
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -39,7 +39,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -107,7 +107,7 @@ func (scanner *Scanner) Protocol() string {
 // 8. Description
 // 9. Location
 // The result is a bacnet.Log, and contains any of the above.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.OpenUDP(&scanner.config.BaseFlags, &scanner.config.UDPFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -70,7 +70,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a new default flags object.
-func (m *Module) NewFlags() interface{} {
+func (m *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -142,7 +142,7 @@ func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	return nil
 }
 
-func (s *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (s *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	var (
 		conn    net.Conn
 		tlsConn *zgrab2.TLSConnection

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -23,7 +23,9 @@ import (
 
 // Flags give the command-line flags for the banner module.
 type Flags struct {
-	zgrab2.BaseFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
+
 	Probe     string `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file."`
 	ProbeFile string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe."`
 	Pattern   string `long:"pattern" description:"Pattern to match, must be valid regexp."`
@@ -34,7 +36,6 @@ type Flags struct {
 	MD5       bool   `long:"md5" description:"Calculate MD5 hash of banner value."`
 	SHA1      bool   `long:"sha1" description:"Calculate SHA1 hash of banner value."`
 	SHA256    bool   `long:"sha256" description:"Calculate SHA256 hash of banner value."`
-	zgrab2.TLSFlags
 }
 
 // Module is the implementation of the zgrab2.Module interface.

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -37,7 +37,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -92,7 +92,7 @@ func (scanner *Scanner) Protocol() string {
 
 // Scan probes for a DNP3 service.
 // Connects to the configured TCP port (default 20000) and reads the banner.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	// TODO: Allow UDP?
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -13,9 +13,8 @@ import (
 // Flags holds the command-line configuration for the dnp3 scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	// TODO: Support UDP?
-	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"` // TODO: Support UDP?
+	Verbose          bool                    `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module implements the zgrab2.Module interface.

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -15,11 +15,10 @@ import (
 // Flags holds the command-line configuration for the fox scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-
-	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
-	UseTLS  bool `long:"use-tls" description:"Sends probe with a TLS connection. Loads TLS module command options."`
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	Verbose          bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	UseTLS           bool `long:"use-tls" description:"Sends probe with a TLS connection. Loads TLS module command options."`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 }
 
 // Module implements the zgrab2.Module interface.

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -41,7 +41,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -100,7 +100,7 @@ func (scanner *Scanner) Protocol() string {
 // 3. Attempt to read the response (up to 8k + 4 bytes -- larger responses trigger an error)
 // 4. If the response has the Fox response prefix, mark the scan as having detected the service.
 // 5. Attempt to read any / all of the data fields from the Log struct
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 
 	var (
 		conn    net.Conn

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -85,7 +85,7 @@ func RegisterModule() {
 
 // NewFlags returns the default flags object to be filled in with the
 // command-line arguments.
-func (m *Module) NewFlags() interface{} {
+func (m *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -246,7 +246,7 @@ func (ftp *Connection) GetFTPSCertificates() error {
 //   - Perform ths TLS handshake / any configured TLS scans, populating
 //     results.TLSLog.
 //   - Return SCAN_SUCCESS, &results, nil
-func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result interface{}, thrown error) {
+func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result any, thrown error) {
 	var err error
 	conn, err := t.Open(&s.config.BaseFlags)
 	if err != nil {

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -46,8 +46,8 @@ type ScanResults struct {
 // Flags are the FTP-specific command-line flags. Taken from the original zgrab.
 // (TODO: should FTPAuthTLS be on by default?).
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 
 	Verbose     bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 	FTPAuthTLS  bool `long:"authtls" description:"Collect FTPS certificates in addition to FTP banners"`

--- a/modules/http/http_readlimit_test.go
+++ b/modules/http/http_readlimit_test.go
@@ -372,7 +372,7 @@ var readLimitTestConfigs = map[string]*readLimitTestConfig{
 }
 
 // Try to get the HTTP body from a result; otherwise return the empty string.
-func getResponse(result interface{}) *http.Response {
+func getResponse(result any) *http.Response {
 	if result == nil {
 		return nil
 	}

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -24,9 +24,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zcrypto/tls"
+	"golang.org/x/net/html/charset"
+
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/http"
-	"golang.org/x/net/html/charset"
 )
 
 var (
@@ -123,7 +124,7 @@ type scan struct {
 }
 
 // NewFlags returns an empty Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -618,7 +619,7 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 // Scan implements the zgrab2.Scanner interface and performs the full scan of
 // the target. If the scanner is configured to follow redirects, this may entail
 // multiple TCP connections to hosts other than target.
-func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	scan := scanner.newHTTPScan(&t, scanner.config.UseHTTPS)
 	defer scan.Cleanup()
 	err := scan.Grab()

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -45,15 +45,15 @@ var (
 //
 // TODO: Custom headers?
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
-	Method          string `long:"method" default:"GET" description:"Set HTTP request method type"`
-	Endpoint        string `long:"endpoint" default:"/" description:"Send an HTTP request to an endpoint"`
-	FailHTTPToHTTPS bool   `long:"fail-http-to-https" description:"Trigger retry-https logic on known HTTP/400 protocol mismatch responses"`
-	UserAgent       string `long:"user-agent" default:"Mozilla/5.0 zgrab/0.x" description:"Set a custom user agent"`
-	RetryHTTPS      bool   `long:"retry-https" description:"If the initial request fails, reconnect and try with HTTPS."`
-	MaxSize         int    `long:"max-size" default:"256" description:"Max kilobytes to read in response to an HTTP request"`
-	MaxRedirects    int    `long:"max-redirects" default:"0" description:"Max number of redirects to follow"`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
+	Method           string `long:"method" default:"GET" description:"Set HTTP request method type"`
+	Endpoint         string `long:"endpoint" default:"/" description:"Send an HTTP request to an endpoint"`
+	FailHTTPToHTTPS  bool   `long:"fail-http-to-https" description:"Trigger retry-https logic on known HTTP/400 protocol mismatch responses"`
+	UserAgent        string `long:"user-agent" default:"Mozilla/5.0 zgrab/0.x" description:"Set a custom user agent"`
+	RetryHTTPS       bool   `long:"retry-https" description:"If the initial request fails, reconnect and try with HTTPS."`
+	MaxSize          int    `long:"max-size" default:"256" description:"Max kilobytes to read in response to an HTTP request"`
+	MaxRedirects     int    `long:"max-redirects" default:"0" description:"Max number of redirects to follow"`
 
 	// FollowLocalhostRedirects overrides the default behavior to return
 	// ErrRedirLocalhost whenever a redirect points to localhost.

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -50,8 +50,8 @@ type ScanResults struct {
 // Flags holds the command-line configuration for the IMAP scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 
 	// SendCLOSE indicates that the CLOSE command should be sent.
 	SendCLOSE bool `long:"send-close" description:"Send the CLOSE command before closing."`

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -85,7 +85,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -181,7 +181,7 @@ func VerifyIMAPContents(banner string) zgrab2.ScanStatus {
 //     TLS connection using the command-line flags.
 //  7. If --send-close is sent, send a001 CLOSE and read the result.
 //  8. Close the connection.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	c, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -92,9 +92,9 @@ type ScanResults struct {
 // Flags holds the command-line configuration for the ipp scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
-	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
+	Verbose          bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 
 	//FIXME: Borrowed from http module, determine whether this is all needed
 	MaxSize      int    `long:"max-size" default:"256" description:"Max kilobytes to read in response to an IPP request"`

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/http"
 )
@@ -135,7 +136,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -742,7 +743,7 @@ func (scan *scan) shouldReportResult(scanner *Scanner) bool {
 // Scan TODO: describe how scan operates in appropriate detail
 // 1. Send a request (currently get-printer-attributes)
 // 2. Take in that response & read out version numbers
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	// Try all known IPP versions from newest to oldest until we reach a supported version
 	scan, err := scanner.tryGrabForVersions(&target, Versions, scanner.config.TLSRetry || scanner.config.IPPSecure)
 	if err != nil {

--- a/modules/jarm/scanner.go
+++ b/modules/jarm/scanner.go
@@ -43,7 +43,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a new default flags object.
-func (m *Module) NewFlags() interface{} {
+func (m *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -99,7 +99,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	return nil
 }
 
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	// Stores raw hashes returned from parsing each protocols Hello message
 	rawhashes := []string{}
 

--- a/modules/jarm/scanner.go
+++ b/modules/jarm/scanner.go
@@ -10,13 +10,14 @@ import (
 	"time"
 
 	jarm "github.com/hdm/jarm-go"
+
 	"github.com/zmap/zgrab2"
 )
 
 // Flags give the command-line flags for the banner module.
 type Flags struct {
-	zgrab2.BaseFlags
-	MaxTries int `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	MaxTries         int `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up."`
 }
 
 // Module is the implementation of the zgrab2.Module interface.

--- a/modules/modbus/modbus.go
+++ b/modules/modbus/modbus.go
@@ -114,7 +114,7 @@ func (m *MEIObjectID) Name() string {
 
 // MarshalJSON encodes the identifier as its friendly name.
 func (m *MEIObject) MarshalJSON() ([]byte, error) {
-	enc := make(map[string]interface{}, 1)
+	enc := make(map[string]any, 1)
 	name := m.OID.Name()
 	enc[name] = m.Value
 	return json.Marshal(enc)

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -31,13 +31,12 @@ import (
 // Flags holds the command-line configuration for the modbus scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	// Protocols that support TLS should include zgrab2.TLSFlags
-	UnitID    uint8  `long:"unit-id" description:"The UnitID / Station ID to probe"`
-	ObjectID  uint8  `long:"object-id" description:"The ObjectID of the object to be read." default:"0x00"`
-	Strict    bool   `long:"strict" description:"If set, perform stricter checks on the response data to get fewer false positives"`
-	RequestID uint16 `long:"request-id" description:"Override the default request ID." default:"0x5A47"`
-	Verbose   bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"` // Protocols that support TLS should include zgrab2.TLSFlags
+	UnitID           uint8                   `long:"unit-id" description:"The UnitID / Station ID to probe"`
+	ObjectID         uint8                   `long:"object-id" description:"The ObjectID of the object to be read." default:"0x00"`
+	Strict           bool                    `long:"strict" description:"If set, perform stricter checks on the response data to get fewer false positives"`
+	RequestID        uint16                  `long:"request-id" description:"Override the default request ID." default:"0x5A47"`
+	Verbose          bool                    `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module implements the zgrab2.Module interface.

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -59,7 +59,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -140,7 +140,7 @@ func (c *Conn) getUnderlyingConn() net.Conn {
 //
 // If the response is not a valid modbus response to this packet, then fail with a SCAN_PROTOCOL_ERROR.
 // Otherwise, return the parsed response and status (SCAN_SUCCESS or SCAN_APPLICATION_ERROR)
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -230,7 +230,7 @@ func (flags *Flags) Help() string {
 }
 
 // NewFlags provides an empty instance of the flags that will be filled in by the framework
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -313,7 +313,7 @@ func listDatabases(conn *Connection) (*ListDatabases_t, error) {
 
 // Scan connects to a host and performs a scan.
 // https://github.com/mongodb/specifications/blob/master/source/message/OP_MSG.rst
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	scan, err := scanner.StartScan(&target)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -16,7 +16,7 @@ type Module struct {
 
 // Flags contains mongodb-specific command-line flags.
 type Flags struct {
-	zgrab2.BaseFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
 }
 
 // Scanner implements the zgrab2.Scanner interface

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -60,7 +60,7 @@ type Scanner struct {
 
 // NewFlags returns a default Flags instance to be populated by the command
 // line flags.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -121,7 +121,7 @@ func (scanner *Scanner) GetTrigger() string {
 // 4. If the server encrypt mode is EncryptModeNotSupported, break.
 // 5. Perform a TLS handshake, with the packets wrapped in TDS headers.
 // 6. Decode the Version and InstanceName from the PRELOGIN response
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -43,10 +43,10 @@ type ScanResults struct {
 
 // Flags defines the command-line configuration options for the module.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
-	EncryptMode string `long:"encrypt-mode" description:"The type of encryption to request in the pre-login step. One of ENCRYPT_ON, ENCRYPT_OFF, ENCRYPT_NOT_SUP." default:"ENCRYPT_ON"`
-	Verbose     bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
+	EncryptMode      string `long:"encrypt-mode" description:"The type of encryption to request in the pre-login step. One of ENCRYPT_ON, ENCRYPT_OFF, ENCRYPT_NOT_SUP." default:"ENCRYPT_ON"`
+	Verbose          bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module is the implementation of zgrab2.Module for the MSSQL protocol.

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -132,9 +132,9 @@ func readResultsFromConnectionLog(connectionLog *mysql.ConnectionLog) *ScanResul
 
 // Flags give the command-line flags for the MySQL module.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
-	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
+	Verbose          bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module is the implementation of the zgrab2.Module interface.

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -156,7 +156,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a new default flags object.
-func (m *Module) NewFlags() interface{} {
+func (m *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -215,7 +215,7 @@ func (scanner *Scanner) GetTrigger() string {
 //  2. If the server supports SSL, send an SSLRequest packet, then
 //     perform the standard TLS actions.
 //  3. Process and return the results.
-func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result interface{}, thrown error) {
+func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result any, thrown error) {
 	var tlsConn *zgrab2.TLSConnection
 	sql := mysql.NewConnection(&mysql.Config{})
 	defer func() {

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -822,7 +822,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a flags instant to be populated with the command line args
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -1007,7 +1007,7 @@ func (scanner *Scanner) GetTime(sock net.Conn) (*NTPHeader, error) {
 // a valid NTP packet, then the result will be nil.
 // The presence of a DDoS-amplifying target can be inferred by
 // result.MonListReponse being present.
-func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	sock, err := t.OpenUDP(&scanner.config.BaseFlags, &scanner.config.UDPFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 )
 
@@ -793,7 +794,7 @@ type Results struct {
 
 // Flags holds the command-line flags for the scanner.
 type Flags struct {
-	zgrab2.BaseFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
 	zgrab2.UDPFlags
 	Verbose       bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 	Version       uint8  `long:"version" description:"The version number to pass to the Server." default:"3"`

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -41,8 +41,8 @@ type ScanResults struct {
 // Flags holds the command-line configuration for the HTTP scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 
 	// Version is the client version number sent to the server in the Connect
 	// packet. TODO: Find version number mappings.

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -113,7 +113,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -217,7 +217,7 @@ func (scanner *Scanner) getTNSDriver() *TNSDriver {
 //     into the results, then send a Native Security Negotiation Data packet.
 //  8. If the response is not a Data packet, exit with SCAN_APPLICATION_ERROR.
 //  9. Pull the versions out of the response and exit with SCAN_SUCCESS.
-func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	var results *ScanResults
 
 	sock, err := t.Open(&scanner.config.BaseFlags)

--- a/modules/oracle/types.go
+++ b/modules/oracle/types.go
@@ -580,7 +580,7 @@ func startReading(reader io.Reader) *chainedReader {
 
 // read the value from the stream, unless there was a previous error on the
 // reader. Uses binary.Read() to decode the data. dest must be a pointer.
-func (reader *chainedReader) read(dest interface{}) *chainedReader {
+func (reader *chainedReader) read(dest any) *chainedReader {
 	if reader.err != nil {
 		return reader
 	}
@@ -1253,7 +1253,7 @@ func (value *NSNValue) String() string {
 func (value *NSNValue) MarshalJSON() ([]byte, error) {
 	type Aux struct {
 		Type  NSNValueType `json:"type"`
-		Value interface{}  `json:"value"`
+		Value any          `json:"value"`
 	}
 	ret := Aux{
 		Type: value.Type,

--- a/modules/oracle/types_test.go
+++ b/modules/oracle/types_test.go
@@ -442,7 +442,7 @@ var validTNSAccept = map[string]TestCase{
 	},
 }
 
-func serialize(val interface{}) []byte {
+func serialize(val any) []byte {
 	// According to the comments in json.Marshal, JSON object keys are sorted,
 	// so this is suitable for comparison.
 	ret, err := json.Marshal(val)

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -57,8 +57,8 @@ type ScanResults struct {
 // Flags holds the command-line configuration for the POP3 scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 
 	// SendHELP indicates that the client should send the HELP command.
 	SendHELP bool `long:"send-help" description:"Send the HELP command"`

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -98,7 +98,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -195,7 +195,7 @@ func VerifyPOP3Contents(banner string) zgrab2.ScanStatus {
 //     TLS connection using the command-line flags.
 //  7. If --send-quit is sent, send QUIT and read the result.
 //  8. Close the connection.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	c, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -116,14 +116,14 @@ type AuthenticationMode struct {
 // Flags sets the module-specific flags that can be passed in from the
 // command line.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
-	SkipSSL         bool   `long:"skip-ssl" description:"If set, do not attempt to negotiate an SSL connection"`
-	Verbose         bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
-	ProtocolVersion string `long:"protocol-version" description:"The protocol to use in the StartupPacket" default:"3.0"`
-	User            string `long:"user" description:"Username to pass to StartupMessage. If omitted, no user will be sent." default:""`
-	Database        string `long:"database" description:"Database to pass to StartupMessage. If omitted, none will be sent." default:""`
-	ApplicationName string `long:"application-name" description:"application_name value to pass in StartupMessage. If omitted, none will be sent." default:""`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
+	SkipSSL          bool   `long:"skip-ssl" description:"If set, do not attempt to negotiate an SSL connection"`
+	Verbose          bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	ProtocolVersion  string `long:"protocol-version" description:"The protocol to use in the StartupPacket" default:"3.0"`
+	User             string `long:"user" description:"Username to pass to StartupMessage. If omitted, no user will be sent." default:""`
+	Database         string `long:"database" description:"Database to pass to StartupMessage. If omitted, none will be sent." default:""`
+	ApplicationName  string `long:"application-name" description:"application_name value to pass in StartupMessage. If omitted, none will be sent." default:""`
 }
 
 // Scanner is the zgrab2 scanner type for the postgres protocol

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -271,7 +271,7 @@ func (results *Results) decodeServerResponse(packets []*ServerPacket) {
 }
 
 // NewFlags returns a default Flags instance.
-func (m *Module) NewFlags() interface{} {
+func (m *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -396,7 +396,7 @@ func (s *Scanner) getDefaultKVPs() map[string]string {
 //
 //     - NOTE: TLS is only used for the first connection, and then only if
 //     both client and server support it.
-func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result interface{}, thrown error) {
+func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result any, thrown error) {
 	var results Results
 
 	mgr := newConnectionManager()

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -24,13 +24,14 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/zmap/zgrab2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/zmap/zgrab2"
 )
 
 // Flags contains redis-specific command-line flags.
 type Flags struct {
-	zgrab2.BaseFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
 
 	CustomCommands   string `long:"custom-commands" description:"Pathname for JSON/YAML file that contains extra commands to execute. WARNING: This is sent in the clear."`
 	Mappings         string `long:"mappings" description:"Pathname for JSON/YAML file that contains mappings for command names."`
@@ -39,7 +40,7 @@ type Flags struct {
 	DoInline         bool   `long:"inline" description:"Send commands using the inline syntax"`
 	Verbose          bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 	UseTLS           bool   `long:"use-tls" description:"Sends probe with a TLS connection. Loads TLS module command options."`
-	zgrab2.TLSFlags
+	zgrab2.TLSFlags  `group:"TLS Options"`
 }
 
 // Module implements the zgrab2.Module interface
@@ -172,7 +173,7 @@ func RegisterModule() {
 }
 
 // NewFlags provides an empty instance of the flags that will be filled in by the framework
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -227,8 +228,8 @@ func (scan *scan) Close() {
 	defer scan.close()
 }
 
-func getUnmarshaler(file string) (func([]byte, interface{}) error, error) {
-	var unmarshaler func([]byte, interface{}) error
+func getUnmarshaler(file string) (func([]byte, any) error, error) {
+	var unmarshaler func([]byte, any) error
 	switch ext := filepath.Ext(file); ext {
 	case ".json":
 		unmarshaler = json.Unmarshal
@@ -241,7 +242,7 @@ func getUnmarshaler(file string) (func([]byte, interface{}) error, error) {
 	return unmarshaler, nil
 }
 
-func (scanner *Scanner) getFileContents(file string, output interface{}) error {
+func (scanner *Scanner) getFileContents(file string, output any) error {
 	unmarshaler, err := getUnmarshaler(file)
 	if err != nil {
 		return err
@@ -405,7 +406,7 @@ func convToUint32(s string) uint32 {
 // 6. QUIT
 // The responses for each of these is logged, and if INFO succeeds, the version
 // is scraped from it.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	// ping, info, quit
 	scan, err := scanner.StartScan(&target)
 	if err != nil {

--- a/modules/redis/types_test.go
+++ b/modules/redis/types_test.go
@@ -163,7 +163,7 @@ func getConnection() (*Connection, *fakeIO) {
 }
 
 // strip s down to 32 chars
-func strip(s interface{}) string {
+func strip(s any) string {
 	var stringVal string
 	switch v := s.(type) {
 	case SimpleString:

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -13,9 +13,8 @@ import (
 // Flags holds the command-line configuration for the siemens scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	// TODO: configurable TSAP source / destination, etc
-	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"` // TODO: configurable TSAP source / destination, etc
+	Verbose          bool                    `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module implements the zgrab2.Module interface.

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -37,7 +37,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -98,7 +98,7 @@ func (scanner *Scanner) Protocol() string {
 // 5. Request to read the module identification (and store it in the output)
 // 6. Request to read the component identification (and store it in the output)
 // 7. Return the output
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -39,7 +39,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -104,7 +104,7 @@ func (scanner *Scanner) Protocol() string {
 //  5. Send a setup session packet to the server with appropriate values
 //  6. Read the response from the server; on failure, exit with the log so far.
 //  7. Return the log.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -11,8 +11,7 @@ import (
 // Flags holds the command-line configuration for the smb scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-
+	zgrab2.BaseFlags `group:"Basic Options"`
 	// SetupSession tells the client to continue the handshake up to the point where credentials would be needed.
 	SetupSession bool `long:"setup-session" description:"After getting the response from the negotiation request, send a setup session packet."`
 

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -69,8 +69,8 @@ type ScanResults struct {
 // Flags holds the command-line configuration for the HTTP scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 
 	// SendEHLO indicates that the EHLO command should be set.
 	SendEHLO bool `long:"send-ehlo" description:"Send the EHLO command; use --ehlo-domain to set a domain."`

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -119,7 +119,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -237,7 +237,7 @@ func VerifySMTPContents(banner string) (zgrab2.ScanStatus, int) {
 //     TLS connection.
 //  7. If --send-quit is sent, send QUIT and read the result.
 //  8. Close the connection.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	c, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -43,7 +43,7 @@ func init() {
 	cmd.FindOptionByLongName("ciphers").Default = []string{strings.Join(s.Ciphers, ",")}
 }
 
-func (m *SSHModule) NewFlags() interface{} {
+func (m *SSHModule) NewFlags() any {
 	return new(SSHFlags)
 }
 
@@ -82,7 +82,7 @@ func (s *SSHScanner) GetTrigger() string {
 	return s.config.Trigger
 }
 
-func (s *SSHScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (s *SSHScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	data := new(ssh.HandshakeLog)
 
 	var port uint

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/ssh"
 )
 
 type SSHFlags struct {
-	zgrab2.BaseFlags
+	zgrab2.BaseFlags  `group:"Basic Options"`
 	ClientID          string `long:"client" description:"Specify the client ID string to use" default:"SSH-2.0-Go"`
 	KexAlgorithms     string `long:"kex-algorithms" description:"Set SSH Key Exchange Algorithms"`
 	HostKeyAlgorithms string `long:"host-key-algorithms" description:"Set SSH Host Key Algorithms"`

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -13,16 +13,17 @@ package telnet
 
 import (
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 )
 
 // Flags holds the command-line configuration for the Telnet scan module.
 // Populated by the framework.
 type Flags struct {
-	zgrab2.BaseFlags
-	MaxReadSize int  `long:"max-read-size" description:"Set the maximum number of bytes to read when grabbing the banner" default:"65536"`
-	Banner      bool `long:"force-banner" description:"Always return banner if it has non-zero bytes"`
-	Verbose     bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	zgrab2.BaseFlags `group:"Basic Options"`
+	MaxReadSize      int  `long:"max-read-size" description:"Set the maximum number of bytes to read when grabbing the banner" default:"65536"`
+	Banner           bool `long:"force-banner" description:"Always return banner if it has non-zero bytes"`
+	Verbose          bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
 }
 
 // Module implements the zgrab2.Module interface.

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -44,7 +44,7 @@ func RegisterModule() {
 }
 
 // NewFlags returns a default Flags object.
-func (module *Module) NewFlags() interface{} {
+func (module *Module) NewFlags() any {
 	return new(Flags)
 }
 
@@ -98,7 +98,7 @@ func (scanner *Scanner) Protocol() string {
 }
 
 // Scan connects to the target (default port TCP 23) and attempts to grab the Telnet banner.
-func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := target.Open(&scanner.config.BaseFlags)
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, err

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -6,8 +6,8 @@ import (
 )
 
 type TLSFlags struct {
-	zgrab2.BaseFlags
-	zgrab2.TLSFlags
+	zgrab2.BaseFlags `group:"Basic Options"`
+	zgrab2.TLSFlags  `group:"TLS Options"`
 }
 
 type TLSModule struct {

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -25,7 +25,7 @@ func init() {
 	}
 }
 
-func (m *TLSModule) NewFlags() interface{} {
+func (m *TLSModule) NewFlags() any {
 	return new(TLSFlags)
 }
 
@@ -71,7 +71,7 @@ func (s *TLSScanner) InitPerSender(senderID int) error {
 // a TLS handshake. If the handshake gets past the ServerHello stage, the
 // handshake log is returned (along with any other TLS-related logs, such as
 // heartbleed, if enabled).
-func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, error) {
+func (s *TLSScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := t.OpenTLS(&s.config.BaseFlags, &s.config.TLSFlags)
 	if conn != nil {
 		defer conn.Close()

--- a/processing.go
+++ b/processing.go
@@ -135,7 +135,7 @@ func BuildGrabFromInputResponse(t *ScanTarget, responses map[string]ScanResponse
 
 // EncodeGrab serializes a Grab to JSON, handling the debug fields if necessary.
 func EncodeGrab(raw *Grab, includeDebug bool) ([]byte, error) {
-	var outputData interface{}
+	var outputData any
 	if includeDebug {
 		outputData = raw
 	} else {

--- a/status.go
+++ b/status.go
@@ -40,7 +40,7 @@ func (err *ScanError) Error() string {
 	return err.Err.Error()
 }
 
-func (err *ScanError) Unpack(results interface{}) (ScanStatus, interface{}, error) {
+func (err *ScanError) Unpack(results any) (ScanStatus, any, error) {
 	return err.Status, results, err.Err
 }
 

--- a/utility.go
+++ b/utility.go
@@ -32,7 +32,7 @@ func NewIniParser() *flags.IniParser {
 
 // AddGroup exposes the parser's AddGroup function, allowing extension
 // of the global arguments.
-func AddGroup(shortDescription string, longDescription string, data interface{}) {
+func AddGroup(shortDescription string, longDescription string, data any) {
 	parser.AddGroup(shortDescription, longDescription, data)
 }
 
@@ -220,7 +220,7 @@ func IsTimeoutError(err error) bool {
 // Example:
 //
 //	defer zgrab2.LogPanic("Error decoding body '%x'", body)
-func LogPanic(format string, args ...interface{}) {
+func LogPanic(format string, args ...any) {
 	err := recover()
 	if err == nil {
 		return


### PR DESCRIPTION
- Replace all instances of `interface{}` with the new (as of Go 1.18, not too new) `any` for readability
- Add Flag `group` tags to group Basic/TLS Flags together. Makes it easier for CLI users to find the commands they're looking for

Example of new `--help`
```zsh
$ make; ./zgrab2 redis --help             
...
Usage:
  zgrab2 [OPTIONS] redis [redis-OPTIONS]

Probe for Redis

Application Options:
  -o, --output-file=                   Output filename, use - for stdout (default: -)
  -f, --input-file=                    Input filename, use - for stdin (default: -)
  -m, --metadata-file=                 Metadata filename, use - for stderr (default: -)
  -l, --log-file=                      Log filename, use - for stderr (default: -)
  -s, --senders=                       Number of send goroutines to use (default: 1000)
      --debug                          Include debug fields in the output.
      --flush                          Flush after each line of output.
      --gomaxprocs=                    Set GOMAXPROCS (default: 0)
      --connections-per-host=          Number of times to connect to each host (results in more output) (default: 1)
      --read-limit-per-host=           Maximum total kilobytes to read for a single host (default 96kb) (default: 96)
      --prometheus=                    Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled.
      --dns=                           Address of a custom DNS server for lookups. Default port is 53.

Help Options:
  -h, --help                           Show this help message

[redis command options]
          --custom-commands=           Pathname for JSON/YAML file that contains extra commands to execute. WARNING: This is sent in the clear.
          --mappings=                  Pathname for JSON/YAML file that contains mappings for command names.
          --max-input-file-size=       Maximum size for either input file. (default: 102400)
          --password=                  Set a password to use to authenticate to the server. WARNING: This is sent in the clear.
          --inline                     Send commands using the inline syntax
          --verbose                    More verbose logging, include debug fields in the scan results
          --use-tls                    Sends probe with a TLS connection. Loads TLS module command options.

    Basic Options:
      -p, --port=                      Specify port to grab on (default: 6379)
      -m, --maxbytes=                  Maximum byte read limit per scan (0 = defaults)
      -n, --name=                      Specify name for output json, only necessary if scanning multiple modules (default: redis)
      -t, --timeout=                   Set connection timeout (0 = no timeout) (default: 10s)
      -g, --trigger=                   Invoke only on targets with specified tag

    TLS Options:
          --heartbleed                 Check if server is vulnerable to Heartbleed
          --session-ticket             Send support for TLS Session Tickets and output ticket if presented
          --extended-master-secret     Offer RFC 7627 Extended Master Secret extension
          --extended-random            Send TLS Extended Random Extension
          --no-sni                     Do not send domain name in TLS Handshake regardless of whether known
          --sct                        Request Signed Certificate Timestamps during TLS Handshake
          --keep-client-logs           Include the client-side logs in the TLS handshake
          --time=                      Explicit request time to use, instead of clock. YYYYMMDDhhmmss format.
          --certificates=              Set of certificates to present to the server
          --certificate-map=           A file mapping server names to certificates
          --root-cas=                  Set of certificates to use when verifying server certificates
          --next-protos=               A list of supported application-level protocols
          --server-name=               Server name used for certificate verification and (optionally) SNI
          --verify-server-certificate  If set, the scan will fail if the server certificate does not match the server-name, or does not chain to a trusted root.
          --cipher-suite=              A comma-delimited list of hex cipher suites to advertise.
          --min-version=               The minimum SSL/TLS version that is acceptable. 0 means that SSLv3 is the minimum.
          --max-version=               The maximum SSL/TLS version that is acceptable. 0 means use the highest supported value.
          --curve-preferences=         A list of elliptic curves used in an ECDHE handshake, in order of preference.
          --no-ecdhe                   Do not allow ECDHE handshakes
          --signature-algorithms=      Signature and hash algorithms that are acceptable
          --heartbeat-enabled          If set, include the heartbeat extension
          --dsa-enabled                Accept server DSA keys
          --client-random=             Set an explicit Client Random (base64 encoded)
          --client-hello=              Set an explicit ClientHello (base64 encoded)

```

