### PR TITLE
Update zgrab's python2 dependency to python3

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -64,8 +64,8 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           # Install Python dependencies
-          pip3 install --user zschema
-          pip3 install --user -r requirements.txt
+          pip3 install zschema
+          pip3 install -r requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,12 +62,11 @@ jobs:
           sudo chmod +x /usr/local/bin/jp
           # Install Python 2.7
           sudo apt update
-          sudo apt install -y python2
-          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-          sudo python2 get-pip.py
+          sudo apt install -y python3
+          python -m ensurepip --upgrade
           # Install Python dependencies
-          pip2 install --user zschema
-          pip2 install --user -r requirements.txt
+          pip install --user zschema
+          pip install --user -r requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -69,4 +69,5 @@ jobs:
 
       - name: Run tests
         run: |
+          source venv/bin/activate
           make integration-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -61,6 +61,8 @@ jobs:
           sudo apt update
           # Install latest Python
           sudo apt install -y python3 jp python3-pip
+          python3 -m venv venv
+          source venv/bin/activate
           # Install Python dependencies
           pip3 install --user zschema
           pip3 install --user -r requirements.txt

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -60,11 +60,10 @@ jobs:
           set -e
           sudo apt update
           # Install latest Python
-          sudo apt install -y python3 jp
-          python -m ensurepip --upgrade
+          sudo apt install -y python3 jp python3-pip
           # Install Python dependencies
-          pip install --user zschema
-          pip install --user -r requirements.txt
+          pip3 install --user zschema
+          pip3 install --user -r requirements.txt
 
       - name: Run tests
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,7 +37,7 @@ jobs:
 
   integration-test:
     name: Integration Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out source
         uses: actions/checkout@v4
@@ -58,11 +58,9 @@ jobs:
       - name: Install dependencies
         run: |
           set -e
-          sudo wget https://github.com/jmespath/jp/releases/download/0.2.1/jp-linux-amd64 -O /usr/local/bin/jp
-          sudo chmod +x /usr/local/bin/jp
-          # Install Python 2.7
           sudo apt update
-          sudo apt install -y python3
+          # Install latest Python
+          sudo apt install -y python3 jp
           python -m ensurepip --upgrade
           # Install Python dependencies
           pip install --user zschema

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -64,8 +64,8 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           # Install Python dependencies
-          pip3 install zschema
-          pip3 install -r requirements.txt
+          pip install zschema
+          pip install -r requirements.txt
 
       - name: Run tests
         run: |

--- a/integration_tests/mssql/cleanup.sh
+++ b/integration_tests/mssql/cleanup.sh
@@ -2,7 +2,7 @@
 
 set +e
 
-CONTAINER_NAME="zgrab_mssql-2017-linux"
+CONTAINER_NAME="zgrab_mssql-2022-linux"
 
 echo "mssql/cleanup: Tests cleanup for mssql"
 

--- a/integration_tests/mssql/setup.sh
+++ b/integration_tests/mssql/setup.sh
@@ -3,8 +3,8 @@
 echo "mssql/setup: Tests setup for mssql"
 
 CONTAINER_IMAGE="mcr.microsoft.com/mssql/server"
-CONTAINER_VERSION="2017-latest"
-CONTAINER_NAME="zgrab_mssql-2017-linux"
+CONTAINER_VERSION="2022-latest"
+CONTAINER_NAME="zgrab_mssql-2022-linux"
 
 # Supported MSSQL_PRODUCT_ID values are Developer, Express, Standard, Enterprise, EnterpriseCore
 MSSQL_PRODUCT_ID="Enterprise"
@@ -14,7 +14,7 @@ if docker ps --filter "name=$CONTAINER_NAME" | grep $CONTAINER_NAME; then
     exit 0
 fi
 
-docker run -td --rm -e "MSSQL_PID=$MSSQL_PRODUCT_ID" -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(openssl rand -base64 12)" --name $CONTAINER_NAME $CONTAINER_IMAGE:$CONTAINER_VERSION
+docker run -td --rm -e "MSSQL_PID=$MSSQL_PRODUCT_ID" -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(openssl rand -base64 12)" --platform "linux/amd64" --name $CONTAINER_NAME $CONTAINER_IMAGE:$CONTAINER_VERSION
 
 echo -n "mssql/setup: Waiting on $CONTAINER_NAME..."
 

--- a/integration_tests/mssql/test.sh
+++ b/integration_tests/mssql/test.sh
@@ -6,11 +6,11 @@ TEST_ROOT=$MODULE_DIR/..
 ZGRAB_ROOT=$(git rev-parse --show-toplevel)
 ZGRAB_OUTPUT=$ZGRAB_ROOT/zgrab-output
 
-CONTAINER_NAME="zgrab_mssql-2017-linux"
+CONTAINER_NAME="zgrab_mssql-2022-linux"
 
 mkdir -p $ZGRAB_OUTPUT/mssql
 
-OUTPUT_FILE="$ZGRAB_OUTPUT/mssql/2017-linux.json"
+OUTPUT_FILE="$ZGRAB_OUTPUT/mssql/2022-linux.json"
 
 echo "mssql/test: Tests runner for mssql"
 CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh mssql > $OUTPUT_FILE

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -71,7 +71,6 @@ fi
 status=0
 failures=""
 echo "Doing schema validation..."
-source venv/bin/activate
 
 for protocol in $(ls $ZGRAB_OUTPUT); do
     for outfile in $(ls $ZGRAB_OUTPUT/$protocol); do

--- a/integration_tests/test.sh
+++ b/integration_tests/test.sh
@@ -71,6 +71,7 @@ fi
 status=0
 failures=""
 echo "Doing schema validation..."
+source venv/bin/activate
 
 for protocol in $(ls $ZGRAB_OUTPUT); do
     for outfile in $(ls $ZGRAB_OUTPUT/$protocol); do
@@ -78,7 +79,7 @@ for protocol in $(ls $ZGRAB_OUTPUT); do
         echo "Validating $target [{("
         cat $target
         echo ")}]:"
-        if ! python2 -m zschema validate zgrab2 $target --path . --module zgrab2_schemas.zgrab2 ; then
+        if ! python3 -m zschema validate zgrab2 $target --path . --module zgrab2_schemas.zgrab2 ; then
             echo "Schema validation failed for $protocol/$outfile"
             err="schema failure@$protocol/$outfile"
             if [[ $status -eq 0 ]]; then

--- a/zgrab2_schemas/README.md
+++ b/zgrab2_schemas/README.md
@@ -15,7 +15,7 @@ you can follow these steps:
    4. Pass in the zgrab2 JSON file to validate
      * ```
        echo 127.0.0.1 | ./cmd/zgrab2/zgrab2 mysql > output.json
-       PYTHONPATH=/path/to/zschema python2 -m zschema validate zgrab2 output.json --path . --module zgrab2_schemas.zgrab2
+       PYTHONPATH=/path/to/zschema python3 -m zschema validate zgrab2 output.json --path . --module zgrab2_schemas.zgrab2
        ```
 
 ## Adding new module schemas


### PR DESCRIPTION
I updated zschema to run with the latest python3.12 so we can update zgrab to not require the deprecated Python2

