### PR TITLE
Fix issues with running subset of integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN go mod download && go mod verify
 
 # Build the actual app
 COPY . .
+# Ensures that if a dev left the binary ./zgrab2, we'll remove it to force a new build.
+RUN make clean
 RUN make all
 
 ## Runtime image ##

--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,17 @@ integration-test:
 	make integration-test-run
 	# Shut off the services
 	docker compose -p zgrab -f integration_tests/docker-compose.yml down
+
 integration-test-build:
-	# TEST_MODULES will specify the names of the ZGrab modules to run in the integration test
-	# However, the containers are (usually) named module_name_version like smtp_1.0. So we need to do a fuzzy search
-	# to see what containers to run.
-	TEST_SERVICES=$$(docker compose -p zgrab -f integration_tests/docker-compose.yml config --services | grep -E "$$(echo $(TEST_MODULES) | sed 's/ /|/g')"); \
+	@TEST_SERVICES=$$(docker compose -p zgrab -f integration_tests/docker-compose.yml config --services | grep -E "$$(echo $(TEST_MODULES) | sed 's/ /|/g')"); \
 	if [ -n "$(TEST_MODULES)" ] && [ -z "$$TEST_SERVICES" ]; then \
 		echo "Error: TEST_MODULES is set, but no matching services were found."; \
 		exit 1; \
 	fi; \
-	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base # ensure the apt cache is up to date and we've built the runner fresh
+	echo "Filtered services: $$TEST_SERVICES"; \
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base; \
 	docker compose -p zgrab -f integration_tests/docker-compose.yml build $$TEST_SERVICES; \
-	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES;
+	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES
 
 integration-test-run:
 	rm -rf zgrab-output

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,20 @@ zgrab2: $(GO_FILES)
 	ln -s cmd/zgrab2/zgrab2$(EXECUTABLE_EXTENSION) zgrab2
 
 integration-test:
+	# TEST_MODULES will specify the names of the ZGrab modules to run in the integration test
+	# However, the containers are (usually) named module_name_version like smtp_1.0. So we need to do a fuzzy search
+	# to see what containers to run.
 	rm -rf zgrab-output
-	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
-	docker compose -p zgrab -f integration_tests/docker-compose.yml build $(TEST_MODULES)
-	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $(TEST_MODULES)
-	sleep 15 # Wait for services to start
-	TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py
-	# Shut off the services
-	docker compose -p zgrab -f integration_tests/docker-compose.yml down
+	#docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
+	TEST_SERVICES=$$(docker compose -p zgrab -f integration_tests/docker-compose.yml config --services | grep -E "$$(echo $(TEST_MODULES) | sed 's/ /|/g')"); \
+	echo "Filtered services: $$TEST_SERVICES"; \
+ 	echo "Running tests for services: $$TEST_SERVICES"; \
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build $$TEST_SERVICES; \
+	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES;
+	#sleep 15 # Wait for services to start
+	#TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py
+#	# Shut off the services
+#	docker compose -p zgrab -f integration_tests/docker-compose.yml down
 
 integration-test-clean:
 	rm -rf zgrab-output

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ integration-test:
 	# Shut off the services
 	docker compose -p zgrab -f integration_tests/docker-compose.yml down
 integration-test-build:
-	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base # ensure the apt cache is up to date and we've built the runner fresh
 	# TEST_MODULES will specify the names of the ZGrab modules to run in the integration test
 	# However, the containers are (usually) named module_name_version like smtp_1.0. So we need to do a fuzzy search
 	# to see what containers to run.
@@ -42,6 +41,7 @@ integration-test-build:
 		echo "Error: TEST_MODULES is set, but no matching services were found."; \
 		exit 1; \
 	fi; \
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base # ensure the apt cache is up to date and we've built the runner fresh
 	docker compose -p zgrab -f integration_tests/docker-compose.yml build $$TEST_SERVICES; \
 	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES;
 

--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,18 @@ integration-test:
 	# However, the containers are (usually) named module_name_version like smtp_1.0. So we need to do a fuzzy search
 	# to see what containers to run.
 	rm -rf zgrab-output
-	#docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
 	TEST_SERVICES=$$(docker compose -p zgrab -f integration_tests/docker-compose.yml config --services | grep -E "$$(echo $(TEST_MODULES) | sed 's/ /|/g')"); \
-	echo "Filtered services: $$TEST_SERVICES"; \
- 	echo "Running tests for services: $$TEST_SERVICES"; \
+	if [ -n "$(TEST_MODULES)" ] && [ -z "$$TEST_SERVICES" ]; then \
+		echo "Error: TEST_MODULES is set, but no matching services were found."; \
+		exit 1; \
+	fi; \
 	docker compose -p zgrab -f integration_tests/docker-compose.yml build $$TEST_SERVICES; \
-	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES;
-	#sleep 15 # Wait for services to start
-	#TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py
-#	# Shut off the services
-#	docker compose -p zgrab -f integration_tests/docker-compose.yml down
+	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES; \
+	sleep 15; \ # Wait for services to start
+	TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py; \
+	# Shut off the services
+	docker compose -p zgrab -f integration_tests/docker-compose.yml down;
 
 integration-test-clean:
 	rm -rf zgrab-output

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ integration-test:
 	# Shut off the services
 	docker compose -p zgrab -f integration_tests/docker-compose.yml down
 integration-test-build:
-	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base # ensure the apt cache is up to date and we've built the runner fresh
 	# TEST_MODULES will specify the names of the ZGrab modules to run in the integration test
 	# However, the containers are (usually) named module_name_version like smtp_1.0. So we need to do a fuzzy search
 	# to see what containers to run.
@@ -47,6 +47,7 @@ integration-test-build:
 
 integration-test-run:
 	rm -rf zgrab-output
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build runner
 	TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py
 
 integration-test-clean:

--- a/Makefile
+++ b/Makefile
@@ -27,22 +27,27 @@ zgrab2: $(GO_FILES)
 	ln -s cmd/zgrab2/zgrab2$(EXECUTABLE_EXTENSION) zgrab2
 
 integration-test:
+	make integration-test-build
+	sleep 15  # Wait for services to start
+	make integration-test-run
+	# Shut off the services
+	docker compose -p zgrab -f integration_tests/docker-compose.yml down
+integration-test-build:
+	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
 	# TEST_MODULES will specify the names of the ZGrab modules to run in the integration test
 	# However, the containers are (usually) named module_name_version like smtp_1.0. So we need to do a fuzzy search
 	# to see what containers to run.
-	rm -rf zgrab-output
-	docker compose -p zgrab -f integration_tests/docker-compose.yml build --no-cache service_base runner # ensure the apt cache is up to date and we've built the runner fresh
 	TEST_SERVICES=$$(docker compose -p zgrab -f integration_tests/docker-compose.yml config --services | grep -E "$$(echo $(TEST_MODULES) | sed 's/ /|/g')"); \
 	if [ -n "$(TEST_MODULES)" ] && [ -z "$$TEST_SERVICES" ]; then \
 		echo "Error: TEST_MODULES is set, but no matching services were found."; \
 		exit 1; \
 	fi; \
 	docker compose -p zgrab -f integration_tests/docker-compose.yml build $$TEST_SERVICES; \
-	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES; \
-	sleep 15; \ # Wait for services to start
-	TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py; \
-	# Shut off the services
-	docker compose -p zgrab -f integration_tests/docker-compose.yml down;
+	docker compose -p zgrab -f integration_tests/docker-compose.yml up -d $$TEST_SERVICES;
+
+integration-test-run:
+	rm -rf zgrab-output
+	TEST_MODULES="$(TEST_MODULES)" python3 integration_tests/test.py
 
 integration-test-clean:
 	rm -rf zgrab-output


### PR DESCRIPTION
Before, there was an issue when trying to run a subset of the integration tests.
```
~/zgrab2 on  master! ⌚ 14:11:06
$ TEST_MODULES="amqp091" make integration-test

docker compose -p zgrab -f integration_tests/docker-compose.yml build amqp091
no such service: amqp091
make: *** [Makefile:32: integration-test] Error 1
```

The issue is that the docker containers have module_name and a version, usually.
```
$ docker compose -p zgrab -f integration_tests/docker-compose.yml config --services | grep "amqp"
amqp091-3.12.14
amqp091-3.13.2
```

This PR searches for docker containers that contain the module_name, ensuring desired behavior.