### PR TITLE
Fix SHA256 typo

### DIFF
--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -60,7 +60,7 @@ type Results struct {
 	TLSLog *zgrab2.TLSLog `json:"tls,omitempty"`
 	MD5    string         `json:"md5,omitempty"`
 	SHA1   string         `json:"sha1,omitempty"`
-	SHA256 string         `json:"sha25,omitempty"`
+	SHA256 string         `json:"sha256,omitempty"`
 }
 
 var NoMatchError = errors.New("pattern did not match")


### PR DESCRIPTION
Fixed a simple SHA256 typo in the banner module, just added a missing "6"

## Notes & Caveats

Motivation was a need for correctly normalised data

