### PR TITLE
Use context.Deadline in addition to specified timeouts for connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ all: zgrab2
 # Test currently only runs on the modules folder because some of the 
 # third-party libraries in lib (e.g. http) are failing.
 test:
+	go test -v .
 	cd lib/output/test && go test -v ./...
 	cd modules && go test -v ./...
 

--- a/conn.go
+++ b/conn.go
@@ -228,17 +228,13 @@ func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeo
 
 // DialTimeoutConnectionEx dials the target and returns a net.Conn that uses the configured timeouts for Read/Write operations.
 func DialTimeoutConnectionEx(ctx context.Context, proto string, target string, dialTimeout, sessionTimeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) (net.Conn, error) {
-	var conn net.Conn
-	var err error
-	// Dial timeout will be min(sessionTimeout, dialTimeout, ctx.Deadline)
-	dialer := net.Dialer{Timeout: sessionTimeout}
-	if dialTimeout > 0 {
-		dialer.Timeout = min(dialTimeout, sessionTimeout)
-	}
+	dialer := NewDialer(nil)
+	dialer.SessionTimeout = sessionTimeout
+	dialer.Timeout = dialTimeout
 	if deadline, ok := ctx.Deadline(); ok {
 		dialer.Deadline = deadline
 	}
-	conn, err = dialer.Dial(proto, target)
+	conn, err := dialer.Dial(proto, target)
 	if err != nil {
 		if conn != nil {
 			conn.Close()

--- a/conn.go
+++ b/conn.go
@@ -228,13 +228,17 @@ func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeo
 
 // DialTimeoutConnectionEx dials the target and returns a net.Conn that uses the configured timeouts for Read/Write operations.
 func DialTimeoutConnectionEx(ctx context.Context, proto string, target string, dialTimeout, sessionTimeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) (net.Conn, error) {
-	dialer := NewDialer(nil)
-	dialer.SessionTimeout = sessionTimeout
-	dialer.Timeout = dialTimeout
+	var conn net.Conn
+	var err error
+	// Dial timeout will be min(sessionTimeout, dialTimeout, ctx.Deadline)
+	dialer := net.Dialer{Timeout: sessionTimeout}
+	if dialTimeout > 0 {
+		dialer.Timeout = min(dialTimeout, sessionTimeout)
+	}
 	if deadline, ok := ctx.Deadline(); ok {
 		dialer.Deadline = deadline
 	}
-	conn, err := dialer.Dial(proto, target)
+	conn, err = dialer.Dial(proto, target)
 	if err != nil {
 		if conn != nil {
 			conn.Close()

--- a/conn.go
+++ b/conn.go
@@ -232,7 +232,7 @@ func DialTimeoutConnectionEx(ctx context.Context, proto string, target string, d
 	// Dial timeout will be min(sessionTimeout, dialTimeout, ctx.Deadline)
 	dialer := net.Dialer{Timeout: sessionTimeout}
 	if dialTimeout > 0 {
-		dialer.Timeout = dialTimeout
+		dialer.Timeout = min(dialTimeout, sessionTimeout)
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		dialer.Deadline = deadline

--- a/conn.go
+++ b/conn.go
@@ -248,6 +248,11 @@ func DialTimeoutConnectionEx(ctx context.Context, proto string, target string, d
 	return NewTimeoutConnection(ctx, conn, sessionTimeout, readTimeout, writeTimeout, bytesReadLimit), nil
 }
 
+// DialTimeoutConnection dials the target and returns a net.Conn that uses the configured single timeout for all operations.
+func DialTimeoutConnection(ctx context.Context, proto string, target string, timeout time.Duration, bytesReadLimit int) (net.Conn, error) {
+	return DialTimeoutConnectionEx(ctx, proto, target, timeout, timeout, timeout, timeout, bytesReadLimit)
+}
+
 // Dialer provides Dial and DialContext methods to get connections with the given timeout.
 type Dialer struct {
 	// Timeout is the maximum time to wait for the entire session, after which any operations on the

--- a/conn.go
+++ b/conn.go
@@ -297,9 +297,9 @@ func (d *Dialer) Dial(proto string, target string) (net.Conn, error) {
 
 // GetTimeoutConnectionDialer gets a Dialer that dials connections with the given timeout.
 func GetTimeoutConnectionDialer(timeout time.Duration) *Dialer {
-	dialer := &Dialer{}
+	dialer := NewDialer(nil)
 	dialer.Timeout = timeout
-	return NewDialer(dialer)
+	return dialer
 }
 
 // SetDefaults for the Dialer.

--- a/conn.go
+++ b/conn.go
@@ -248,11 +248,6 @@ func DialTimeoutConnectionEx(ctx context.Context, proto string, target string, d
 	return NewTimeoutConnection(ctx, conn, sessionTimeout, readTimeout, writeTimeout, bytesReadLimit), nil
 }
 
-// DialTimeoutConnection dials the target and returns a net.Conn that uses the configured single timeout for all operations.
-func DialTimeoutConnection(ctx context.Context, proto string, target string, timeout time.Duration, bytesReadLimit int) (net.Conn, error) {
-	return DialTimeoutConnectionEx(ctx, proto, target, timeout, timeout, timeout, timeout, bytesReadLimit)
-}
-
 // Dialer provides Dial and DialContext methods to get connections with the given timeout.
 type Dialer struct {
 	// Timeout is the maximum time to wait for the entire session, after which any operations on the
@@ -310,13 +305,14 @@ func (d *Dialer) SetDefaults() *Dialer {
 	if d.BytesReadLimit == 0 {
 		d.BytesReadLimit = DefaultBytesReadLimit
 	}
+	if d.SessionTimeout == 0 {
+		d.SessionTimeout = DefaultSessionTimeout
+	}
 	if d.Dialer == nil {
 		d.Dialer = &net.Dialer{
-			Timeout:   d.Timeout,
-			KeepAlive: d.Timeout,
-			DualStack: true,
+			Timeout:   d.SessionTimeout,
+			KeepAlive: d.SessionTimeout,
 		}
-
 		// Use custom DNS as default if set
 		if config.CustomDNS != "" {
 			d.Dialer.Resolver = &net.Resolver{
@@ -326,9 +322,6 @@ func (d *Dialer) SetDefaults() *Dialer {
 				},
 			}
 		}
-	}
-	if d.Timeout == 0 {
-		d.Timeout = DefaultSessionTimeout
 	}
 	return d
 }

--- a/conn.go
+++ b/conn.go
@@ -226,33 +226,6 @@ func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeo
 	return ret
 }
 
-// DialTimeoutConnectionEx dials the target and returns a net.Conn that uses the configured timeouts for Read/Write operations.
-func DialTimeoutConnectionEx(ctx context.Context, proto string, target string, dialTimeout, sessionTimeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) (net.Conn, error) {
-	var conn net.Conn
-	var err error
-	// Dial timeout will be min(sessionTimeout, dialTimeout, ctx.Deadline)
-	dialer := net.Dialer{Timeout: sessionTimeout}
-	if dialTimeout > 0 {
-		dialer.Timeout = min(dialTimeout, sessionTimeout)
-	}
-	if deadline, ok := ctx.Deadline(); ok {
-		dialer.Deadline = deadline
-	}
-	conn, err = dialer.Dial(proto, target)
-	if err != nil {
-		if conn != nil {
-			conn.Close()
-		}
-		return nil, err
-	}
-	return NewTimeoutConnection(ctx, conn, sessionTimeout, readTimeout, writeTimeout, bytesReadLimit), nil
-}
-
-// DialTimeoutConnection dials the target and returns a net.Conn that uses the configured single timeout for all operations.
-func DialTimeoutConnection(ctx context.Context, proto string, target string, timeout time.Duration, bytesReadLimit int) (net.Conn, error) {
-	return DialTimeoutConnectionEx(ctx, proto, target, timeout, timeout, timeout, timeout, bytesReadLimit)
-}
-
 // Dialer provides Dial and DialContext methods to get connections with the given timeout.
 type Dialer struct {
 	// Timeout is the maximum time to wait for the entire session, after which any operations on the
@@ -292,7 +265,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 
 // Dial returns a connection with the configured timeout.
 func (d *Dialer) Dial(proto string, target string) (net.Conn, error) {
-	return DialTimeoutConnectionEx(context.Background(), proto, target, d.Timeout, d.SessionTimeout, d.ReadTimeout, d.WriteTimeout, 0)
+	return d.DialContext(context.Background(), proto, target)
 }
 
 // GetTimeoutConnectionDialer gets a Dialer that dials connections with the given timeout.

--- a/conn_bytelimit_test.go
+++ b/conn_bytelimit_test.go
@@ -257,7 +257,15 @@ type directDial struct {
 }
 
 func (d *directDial) connect(ctx context.Context, t *testing.T, port int, idx int) (*TimeoutConnection, error) {
-	conn, err := DialTimeoutConnectionEx(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port), time.Second, time.Second, time.Second, time.Second, d.limit)
+	dialer := NewDialer(&Dialer{
+		SessionTimeout: time.Second,
+		BytesReadLimit: d.limit,
+		ReadTimeout:    time.Second,
+		WriteTimeout:   time.Second,
+	})
+
+	conn, err := dialer.DialContext(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+
 	var ret *TimeoutConnection
 	if conn != nil {
 		ret = conn.(*TimeoutConnection)

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -166,11 +166,11 @@ func (cfg *connTimeoutTestConfig) getEndpoint() string {
 // Dial a connection to the configured endpoint using a Dialer
 func (cfg *connTimeoutTestConfig) dialerDial() (*TimeoutConnection, error) {
 	dialer := NewDialer(&Dialer{
-		Timeout:        cfg.timeout,
-		ConnectTimeout: cfg.connectTimeout,
+		SessionTimeout: cfg.timeout,
 		ReadTimeout:    cfg.readTimeout,
 		WriteTimeout:   cfg.writeTimeout,
 	})
+	dialer.Timeout = cfg.connectTimeout
 	ret, err := dialer.Dial("tcp", cfg.getEndpoint())
 	if err != nil {
 		return nil, err
@@ -180,7 +180,14 @@ func (cfg *connTimeoutTestConfig) dialerDial() (*TimeoutConnection, error) {
 
 // Dial a connection to the configured endpoint using a DialTimeoutConnectionEx
 func (cfg *connTimeoutTestConfig) directDial() (*TimeoutConnection, error) {
-	ret, err := DialTimeoutConnectionEx(context.Background(), "tcp", cfg.getEndpoint(), cfg.connectTimeout, cfg.timeout, cfg.readTimeout, cfg.writeTimeout, 0)
+	dialer := NewDialer(&Dialer{
+		SessionTimeout: cfg.timeout,
+		ReadTimeout:    cfg.readTimeout,
+		WriteTimeout:   cfg.writeTimeout,
+	})
+	dialer.Timeout = cfg.connectTimeout
+
+	ret, err := dialer.Dial("tcp", cfg.getEndpoint())
 	if err != nil {
 		return nil, err
 	}
@@ -190,11 +197,11 @@ func (cfg *connTimeoutTestConfig) directDial() (*TimeoutConnection, error) {
 // Dial a connection to the configured endpoint using Dialer.DialContext
 func (cfg *connTimeoutTestConfig) contextDial() (*TimeoutConnection, error) {
 	dialer := NewDialer(&Dialer{
-		Timeout:        cfg.timeout,
-		ConnectTimeout: cfg.connectTimeout,
+		SessionTimeout: cfg.timeout,
 		ReadTimeout:    cfg.readTimeout,
 		WriteTimeout:   cfg.writeTimeout,
 	})
+	dialer.Timeout = cfg.connectTimeout
 	ret, err := dialer.DialContext(context.Background(), "tcp", cfg.getEndpoint())
 	if err != nil {
 		return nil, err

--- a/processing.go
+++ b/processing.go
@@ -61,13 +61,8 @@ func (target *ScanTarget) Host() string {
 
 // GetDefaultTCPDialer returns a TCP dialer suitable for modules with default TCP behavior
 func GetDefaultTCPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
+	dialer := GetTimeoutConnectionDialer(flags.Timeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
-		dialer := NewDialer(nil)
-		dialer.Timeout = flags.Timeout
-		if deadline, ok := ctx.Deadline(); ok {
-			dialer.Dialer.Deadline = deadline
-		}
-
 		// If the scan is for a specific IP, and a domain name is provided, we
 		// don't want to just let the http library resolve the domain.  Create
 		// a fake resolver that we will use, that always returns the IP we are
@@ -146,8 +141,7 @@ func GetDefaultTLSWrapper(tlsFlags *TLSFlags) func(ctx context.Context, t *ScanT
 
 // GetDefaultUDPDialer returns a UDP dialer suitable for modules with default UDP behavior
 func GetDefaultUDPDialer(flags *BaseFlags, udp *UDPFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
-	dialer := NewDialer(nil)
-	dialer.Timeout = flags.Timeout
+	dialer := GetTimeoutConnectionDialer(flags.Timeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 		var local *net.UDPAddr
 		if udp != nil && (udp.LocalAddress != "" || udp.LocalPort != 0) {


### PR DESCRIPTION
Handles a number of issues/inconsistencies around how we handle timeouts/contexts when dialing connections. My goal here is to have all codepaths use our `zgrab2.Dialer` and handle all connection creation there. This should both minimize the area for bugs to creep in (forgetting to set a `ReadLimit` somewhere) and also make it easier to plug in the source IP/port work.

- Before `DialTimeoutConnectionEx()` was taking in a `context.Context`, but then not using it for anything
- Our `zgrab2.Dialer` wraps a `net.Dialer`. `net.Dialer` includes a `Timeout`, so having `zgrab2.Dialer.ConnectionTimeout` is redundant. This just sets the inner `net.Dialer.Timeout` instead of having a `ConnectionTimeout`
- Small nit - felt weird that since our dialer wraps `net.Dialer`, to have it be a named field. Then you have `zgrab2.Dialer.Dialer`. Changed the `net.Dialer` to be an anonymous structure.
- Removes the deprecated `DualStack: true`, it's now true by [default](https://pkg.go.dev/net#Dialer).