### PR TITLE
Fix redirects not getting followed

### DIFF
--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -105,6 +105,7 @@ def test_large_http_body_contents():
         )
     pass
 
+
 # Uses the dockerized zgrab to ensure that scanning real domains returns a 200 OK
 def test_scanning_real_domains():
     domains = [
@@ -116,7 +117,8 @@ def test_scanning_real_domains():
         command = "docker run --rm -i zgrab2_runner http --max-redirects=3"
         grabbed_response = run_command(f"echo {domain} | {command}")
         status_line = (
-            json.loads(grabbed_response).get("data", {})
+            json.loads(grabbed_response)
+            .get("data", {})
             .get("http", {})
             .get("result", {})
             .get("response", {})
@@ -128,7 +130,6 @@ def test_scanning_real_domains():
             raise ValueError(
                 f"zgrab2_runner: {domain} returned an unexpected status line: {status_line}"
             )
-
 
 
 def print_docker_logs():

--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -2,6 +2,7 @@
 
 import difflib
 import os
+import json
 import requests
 import subprocess
 import sys
@@ -103,6 +104,31 @@ def test_large_http_body_contents():
             "http/large-body-test: The HTTP body contents do not match the expected contents.\n"
         )
     pass
+
+# Uses the dockerized zgrab to ensure that scanning real domains returns a 200 OK
+def test_scanning_real_domains():
+    domains = [
+        "cloudflare.com",
+        "github.com",
+        "en.wikipedia.org",
+    ]
+    for domain in domains:
+        command = "docker run --rm -i zgrab2_runner http --max-redirects=3"
+        grabbed_response = run_command(f"echo {domain} | {command}")
+        status_line = (
+            json.loads(grabbed_response).get("data", {})
+            .get("http", {})
+            .get("result", {})
+            .get("response", {})
+            .get("status_line", "Unknown")
+        )
+        print(f"zgrab2_runner: {domain} status => {status_line}")
+        # Check if the response contains a 200 OK status
+        if status_line != "200 OK":
+            raise ValueError(
+                f"zgrab2_runner: {domain} returned an unexpected status line: {status_line}"
+            )
+
 
 
 def print_docker_logs():

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -377,8 +377,10 @@ func (scanner *Scanner) newHTTPScan(ctx context.Context, t *zgrab2.ScanTarget, u
 			MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 			RawHeaderBuffer:     scanner.config.RawHeaders,
 		},
-		client:         http.MakeNewClient(),
-		globalDeadline: time.Now().Add(scanner.config.Timeout),
+		client: http.MakeNewClient(),
+	}
+	if scanner.config.Timeout != 0 {
+		ret.globalDeadline = time.Now().Add(scanner.config.Timeout)
 	}
 	ret.transport.DialTLS = func(network, addr string) (net.Conn, error) {
 		ctx = ret.withDeadlineContext(ctx)

--- a/processing.go
+++ b/processing.go
@@ -147,8 +147,6 @@ func GetDefaultTLSWrapper(tlsFlags *TLSFlags) func(ctx context.Context, t *ScanT
 // GetDefaultUDPDialer returns a UDP dialer suitable for modules with default UDP behavior
 func GetDefaultUDPDialer(flags *BaseFlags, udp *UDPFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
-		// TODO Phillip - remove
-		//address := net.JoinHostPort(t.Host(), fmt.Sprintf("%d", t.Port))
 		var local *net.UDPAddr
 		if udp != nil && (udp.LocalAddress != "" || udp.LocalPort != 0) {
 			local = &net.UDPAddr{}

--- a/processing.go
+++ b/processing.go
@@ -65,7 +65,7 @@ func GetDefaultTCPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarg
 		dialer := NewDialer(nil)
 		dialer.Timeout = flags.Timeout
 		if deadline, ok := ctx.Deadline(); ok {
-			dialer.Deadline = deadline
+			dialer.Dialer.Deadline = deadline
 		}
 
 		// If the scan is for a specific IP, and a domain name is provided, we

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 zschema
 git+https://github.com/zmap/zcrypto@4f0ea0eaccacc4e153ddbb2016afe9d7bb961efd#egg=zcrypto_schemas
 requests
-json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 zschema
 git+https://github.com/zmap/zcrypto@4f0ea0eaccacc4e153ddbb2016afe9d7bb961efd#egg=zcrypto_schemas
 requests
+json


### PR DESCRIPTION
With the module interface refactor, I overlooked that my L4 and TLS dialers were not capable of following re-directs because they used the `ScanTarget` to create the target address. If a redirect was given to some other address, it wouldn't be followed because the dialer would keep trying to dial the `ScanTarget.Host()`.

Changes

- Made the `dialerGroup.L4Dialer` aware of the input address. The two modules that use redirects (IPP and http) use this dialer. IMO, it's better to keep the `TransportAgnosticDialer` simple, it just takes in a `ScanTarget` and creates a `net.Conn` to it.
- Added a small integration test to `http` where we scan `Cloudflare.com`, `GitHub.com` and `wikipedia.org`. This test fails on `master` and these sites currently employ redirects from `http://cloudflare.com` -> `https://cloudflare.com`. This ensures we handle that.

## How to Test
```
echo "cloudflare.com" | ./zgrab2 http --max-redirects=3 | jq ".data.http.status"
```
### `v0.1.8` Last release
```
$ echo "cloudflare.com" | ./zgrab2 http --max-redirects=3 | jq ".data.http.status" 
{"statuses":{"http":{"successes":1,"failures":0}},"start":"2025-04-02T15:33:25-07:00","end":"2025-04-02T15:33:26-07:00","duration":"445.110625ms"}
"success"
```
### `master` (broken) - `2b6064839d82`
```
{"statuses":{"http":{"successes":0,"failures":1}},"start":"2025-04-02T15:34:28-07:00","end":"2025-04-02T15:34:28-07:00","duration":"63.088792ms"}
"unknown-error"
```

### This Branch
```
{"statuses":{"http":{"successes":1,"failures":0}},"start":"2025-04-02T15:35:35-07:00","end":"2025-04-02T15:35:36-07:00","duration":"795.198458ms"}
"success"
```

