### PR TITLE
Improve ZGrab Docs/`--help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ domain.com
 10.0.0.1, , , 5678
 , domain.com, tag
 192.168.0.0/24, , tag
+```
 
+And an example of calling zgrab2 with input:
+
+```shell
+echo "en.wikipedia.org" | ./zgrab2 http --max-redirects=1 --endpoint="/wiki/New_York_City"
 ```
 
 ## Multiple Module Usage

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -133,7 +133,11 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 
 // Description returns an overview of this module.
 func (module *Module) Description() string {
-	return "Send an HTTP request and read the response, optionally following redirects."
+	desc := []string{
+		"Send an HTTP request and read the response, optionally following redirects",
+		"Ex: echo \"en.wikipedia.org\" | ./zgrab2 http --max-redirects=1 --endpoint=\"/wiki/New_York_City\"",
+	}
+	return strings.Join(desc, "\n")
 }
 
 // Validate performs any needed validation on the arguments

--- a/utility.go
+++ b/utility.go
@@ -22,6 +22,23 @@ const defaultDNSPort = "53"
 
 func init() {
 	parser = flags.NewParser(&config, flags.Default)
+	desc := []string{
+		// Using a long single line so the terminal can handle wrapping, except for Input/Examples which should be on
+		// separate lines
+		"zgrab2 is fast, modular L7 application-layer scanner. It is commonly used with tools like ZMap which identify " +
+			"\"potential services\", or services we know are active on a given IP + port, and these are fed into ZGrab2 " +
+			"to confirm and provide details of the service. It has support for a number of protocols listed below as " +
+			"'Available commands' including SSH and HTTP. By default, zgrab2 will accept input from stdin and output " +
+			"results to stdout, with updates and logs to stderr. Please see 'zgrab2 <command> --help' for more details " +
+			"on a specific command.",
+		"Input is taken from stdin or --input-file, if specified. Input is CSV-formatted with 'IP, Domain, Tag, Port' " +
+			"or simply 'IP' or 'Domain'. See README.md for more details.",
+		"",
+		"Example usages:",
+		"echo '1.1.1.1' | zgrab2 tls          # Scan 1.1.1.1 with TLS",
+		"echo example.com | ./zgrab2 http     # Scan example.com with HTTP",
+	}
+	parser.LongDescription = strings.Join(desc, "\n")
 }
 
 // NewIniParser creates and returns a ini parser initialized

--- a/utility.go
+++ b/utility.go
@@ -36,7 +36,7 @@ func init() {
 		"",
 		"Example usages:",
 		"echo '1.1.1.1' | zgrab2 tls          # Scan 1.1.1.1 with TLS",
-		"echo example.com | ./zgrab2 http     # Scan example.com with HTTP",
+		"echo example.com | zgrab2 http     # Scan example.com with HTTP",
 	}
 	parser.LongDescription = strings.Join(desc, "\n")
 }


### PR DESCRIPTION
Thanks to new contributor @ashleydai2003 for these suggestions!

## Description
- Adds example of using `stdin` with `echo` to `README.md`
- Adds description to `zgrab2 --help` to explain tool and give guidance on input/output + usage.
- Adds description to `http` module to give example usage

New `--help` text:
```shell
Usage:
  zgrab2 [OPTIONS] <command>

zgrab2 is fast, modular L7 application-layer scanner. It is commonly used with tools like ZMap which identify "potential services", or services we know are active on a given IP + port, and these are fed into ZGrab2 to confirm and provide details of the service. It has support for a number of protocols listed below as 'Available commands' including SSH and HTTP. By default, zgrab2 will accept input from stdin
and output results to stdout, with updates and logs to stderr. Please see 'zgrab2 <command> --help' for more details on a specific command.
Input is taken from stdin or --input-file, if specified. Input is CSV-formatted with 'IP, Domain, Tag, Port' or simply 'IP' or 'Domain'. See README.md for more details.

Example usages:
echo '1.1.1.1' | zgrab2 tls          # Scan 1.1.1.1 with TLS
echo example.com | zgrab2 http     # Scan example.com with HTTP
```
