### PR TITLE
Throw an error is all we got was a bunch of empty hashes

### DIFF
--- a/modules/jarm/scanner.go
+++ b/modules/jarm/scanner.go
@@ -3,6 +3,7 @@
 package jarm
 
 import (
+	"errors"
 	_ "fmt"
 	"log"
 	"net"
@@ -136,7 +137,13 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, any, 
 		conn.Close()
 	}
 
+	var fingerprint = jarm.RawHashToFuzzyHash(strings.Join(rawhashes, ","))
+
+	if fingerprint == "00000000000000000000000000000000000000000000000000000000000000" {
+		return zgrab2.SCAN_APPLICATION_ERROR, nil, errors.New("Unable to calculate hashes from server")
+	}
+
 	return zgrab2.SCAN_SUCCESS, &Results{
-		Fingerprint: jarm.RawHashToFuzzyHash(strings.Join(rawhashes, ",")),
+		Fingerprint: fingerprint,
 	}, nil
 }


### PR DESCRIPTION
I noticed that a lot of JARM results are returning a hash of all zeroes. In particular, I noticed that I was getting more successful JARM results than TLS results when scanning port 3306.

This change turns these empty hashes into an error.