### PR TITLE
Remove min() re-declarations

### DIFF
--- a/lib/ssh/channel.go
+++ b/lib/ssh/channel.go
@@ -242,7 +242,7 @@ func (ch *channel) WriteExtended(data []byte, extendedCode uint32) (n int, err e
 	ch.writeMu.Unlock()
 
 	for len(data) > 0 {
-		space := min(ch.maxRemotePayload, len(data))
+		space := min(ch.maxRemotePayload, uint32(len(data)))
 		if space, err = ch.remoteWin.reserve(space); err != nil {
 			return n, err
 		}

--- a/lib/ssh/channel.go
+++ b/lib/ssh/channel.go
@@ -131,13 +131,6 @@ func (r RejectionReason) String() string {
 	return fmt.Sprintf("unknown reason %d", int(r))
 }
 
-func min(a uint32, b int) uint32 {
-	if a < uint32(b) {
-		return a
-	}
-	return uint32(b)
-}
-
 type channelDirection uint8
 
 const (

--- a/modules/mssql/connection.go
+++ b/modules/mssql/connection.go
@@ -747,14 +747,6 @@ type tdsConnection struct {
 	remainder []byte
 }
 
-// return the lesser of a, b
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // Check if the given header is likely to be a valid TDS header (for detection
 // purposes).
 func isValidTDSHeader(header *TDSHeader) bool {

--- a/modules/oracle/types_test.go
+++ b/modules/oracle/types_test.go
@@ -452,13 +452,6 @@ func serialize(val any) []byte {
 	return ret
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func getTNSDriver() *TNSDriver {
 	return &TNSDriver{Mode: TNSModeOld}
 }

--- a/utility.go
+++ b/utility.go
@@ -102,12 +102,6 @@ func (err errTotalTimeout) Temporary() bool {
 // connection's timeout (or, failing that, 1 second).
 // On failure, returns anything it was able to read along with the error.
 func ReadAvailableWithOptions(conn net.Conn, bufferSize int, readTimeout time.Duration, totalTimeout time.Duration, maxReadSize int) ([]byte, error) {
-	min := func(a, b int) int {
-		if a < b {
-			return a
-		}
-		return b
-	}
 	var totalDeadline time.Time
 	if totalTimeout == 0 {
 		// Would be nice if this could be taken from the SetReadDeadline(), but that's not possible in general


### PR DESCRIPTION
Cleanup PR removing `min` functions since we have a built-in `min()` since Go1.21
