### PR TITLE
Add a per-second status similar to ZDNS

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	flags "github.com/zmap/zflags"
+
 	"github.com/zmap/zgrab2"
 )
 
@@ -157,8 +158,9 @@ func ZGrab2Main() {
 		EndTime:           end.Format(time.RFC3339),
 		Duration:          end.Sub(start).String(),
 	}
-	enc := json.NewEncoder(zgrab2.GetMetaFile())
-	if err := enc.Encode(&s); err != nil {
-		log.Fatalf("unable to write summary: %s", err.Error())
+	if metadataFile := zgrab2.GetMetaFile(); metadataFile != nil {
+		if err := json.NewEncoder(zgrab2.GetMetaFile()).Encode(&s); err != nil {
+			log.Fatalf("unable to write metadata summary: %s", err.Error())
+		}
 	}
 }

--- a/config.go
+++ b/config.go
@@ -30,8 +30,8 @@ type Config struct {
 	Prometheus            string          `long:"prometheus" description:"Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled."`
 	CustomDNS             string          `long:"dns" description:"Address of a custom DNS server for lookups. Default port is 53."`
 	Multiple              MultipleCommand `command:"multiple" description:"Multiple module actions"`
-	LocalAddrString    string          `long:"local-addr" description:"Local address(es) to bind to for outgoing connections. Comma-separated list of IP addresses, ranges (inclusive), or CIDR blocks, ex: 1.1.1.1-1.1.1.3, 2.2.2.2, 3.3.3.0/24"`
-	LocalPortString    string          `long:"local-port" description:"Local port(s) to bind to for outgoing connections. Comma-separated list of ports or port ranges (inclusive) ex: 1200-1300,2000"`
+	LocalAddrString       string          `long:"local-addr" description:"Local address(es) to bind to for outgoing connections. Comma-separated list of IP addresses, ranges (inclusive), or CIDR blocks, ex: 1.1.1.1-1.1.1.3, 2.2.2.2, 3.3.3.0/24"`
+	LocalPortString       string          `long:"local-port" description:"Local port(s) to bind to for outgoing connections. Comma-separated list of ports or port ranges (inclusive) ex: 1200-1300,2000"`
 	inputFile             *os.File
 	outputFile            *os.File
 	metaFile              *os.File
@@ -40,8 +40,8 @@ type Config struct {
 	inputTargets          InputTargetsFunc
 	outputResults         OutputResultsFunc
 	localAddr             *net.TCPAddr
-	localAddrs         []net.IP // will be non-empty if user specified local addresses
-	localPorts         []uint16 // will be non-empty if user specified local ports
+	localAddrs            []net.IP // will be non-empty if user specified local addresses
+	localPorts            []uint16 // will be non-empty if user specified local ports
 }
 
 // SetInputFunc sets the target input function to the provided function.

--- a/monitor.go
+++ b/monitor.go
@@ -1,12 +1,20 @@
 package zgrab2
 
-import "sync"
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
 
 // Monitor is a collection of states per scans and a channel to communicate
 // those scans to the monitor
 type Monitor struct {
-	states       map[string]*State
-	statusesChan chan moduleStatus
+	startTime      time.Time // time when the monitor started
+	totalSuccesses uint      // number of successful scans across modules
+	totalFailures  uint      // number of failed scans across modules
+	states         map[string]*State
+	statusesChan   chan moduleStatus
 	// Callback is invoked after each scan.
 	Callback func(string)
 }
@@ -43,30 +51,69 @@ func (m *Monitor) Stop() {
 	close(m.statusesChan)
 }
 
+func (m *Monitor) printStatus(isFinalPrint bool) {
+	msg := ""
+	if isFinalPrint {
+		msg = "Scan Complete; "
+	}
+	timeSinceStart := time.Since(m.startTime)
+	updateLine := fmt.Sprintf("%02dh:%02dm:%02ds; %s%d targets scanned; %.02f targets/sec; %.01f%% success rate",
+		int(timeSinceStart.Hours()),
+		int(timeSinceStart.Minutes())%60,
+		int(timeSinceStart.Seconds())%60,
+		msg,
+		m.totalSuccesses+m.totalFailures,
+		float64(m.totalSuccesses+m.totalFailures)/float64(timeSinceStart.Seconds()),
+		float64(m.totalSuccesses)/float64(m.totalSuccesses+m.totalFailures)*100,
+	)
+	_, err := fmt.Fprintln(config.statusUpdatesFile, updateLine)
+	if err != nil {
+		log.Errorf("unable to write periodic status update: %v", err)
+	}
+}
+
 // MakeMonitor returns a Monitor object that can be used to collect and send
 // the status of a running scan
 func MakeMonitor(statusChanSize int, wg *sync.WaitGroup) *Monitor {
 	m := new(Monitor)
 	m.statusesChan = make(chan moduleStatus, statusChanSize)
 	m.states = make(map[string]*State, 10)
+	m.startTime = time.Now()
 	wg.Add(1)
 	go func() {
+		ticker := time.NewTicker(time.Second)
 		defer wg.Done()
-		for s := range m.statusesChan {
-			if m.states[s.name] == nil {
-				m.states[s.name] = new(State)
+		for {
+			select {
+			case s, ok := <-m.statusesChan:
+				if !ok {
+					// channel closed, exiting
+					ticker.Stop()
+					m.printStatus(true) // print final status
+					return
+				}
+				// process new status
+				if m.states[s.name] == nil {
+					m.states[s.name] = new(State)
+				}
+				if m.Callback != nil {
+					m.Callback(s.name)
+				}
+				switch s.st {
+				case statusSuccess:
+					m.states[s.name].Successes++
+					m.totalSuccesses++
+				case statusFailure:
+					m.states[s.name].Failures++
+					m.totalFailures++
+				default:
+					continue
+				}
+			case <-ticker.C:
+				// print per-second summary
+				m.printStatus(false)
 			}
-			if m.Callback != nil {
-				m.Callback(s.name)
-			}
-			switch s.st {
-			case statusSuccess:
-				m.states[s.name].Successes++
-			case statusFailure:
-				m.states[s.name].Failures++
-			default:
-				continue
-			}
+
 		}
 	}()
 	return m

--- a/monitor.go
+++ b/monitor.go
@@ -52,16 +52,16 @@ func (m *Monitor) Stop() {
 }
 
 func (m *Monitor) printStatus(isFinalPrint bool) {
-	msg := ""
+	scanStatusMsg := ""
 	if isFinalPrint {
-		msg = "Scan Complete; "
+		scanStatusMsg = "Scan Complete; "
 	}
 	timeSinceStart := time.Since(m.startTime)
 	updateLine := fmt.Sprintf("%02dh:%02dm:%02ds; %s%d targets scanned; %.02f targets/sec; %.01f%% success rate",
 		int(timeSinceStart.Hours()),
 		int(timeSinceStart.Minutes())%60,
 		int(timeSinceStart.Seconds())%60,
-		msg,
+		scanStatusMsg,
 		m.totalSuccesses+m.totalFailures,
 		float64(m.totalSuccesses+m.totalFailures)/float64(timeSinceStart.Seconds()),
 		float64(m.totalSuccesses)/float64(m.totalSuccesses+m.totalFailures)*100,
@@ -113,7 +113,6 @@ func MakeMonitor(statusChanSize int, wg *sync.WaitGroup) *Monitor {
 				// print per-second summary
 				m.printStatus(false)
 			}
-
 		}
 	}()
 	return m

--- a/monitor.go
+++ b/monitor.go
@@ -52,6 +52,9 @@ func (m *Monitor) Stop() {
 }
 
 func (m *Monitor) printStatus(isFinalPrint bool) {
+	if config.statusUpdatesFile == nil {
+		return // no file to write to
+	}
 	scanStatusMsg := ""
 	if isFinalPrint {
 		scanStatusMsg = "Scan Complete; "

--- a/monitor.go
+++ b/monitor.go
@@ -57,14 +57,23 @@ func (m *Monitor) printStatus(isFinalPrint bool) {
 		scanStatusMsg = "Scan Complete; "
 	}
 	timeSinceStart := time.Since(m.startTime)
+	scanRate := float64(0)
+	if timeSinceStart.Seconds() > 0 {
+		scanRate = float64(m.totalSuccesses+m.totalFailures) / timeSinceStart.Seconds() // avoid division by zero
+	}
+	scanSuccessRate := float64(0)
+	totalTargetsScanned := m.totalSuccesses + m.totalFailures
+	if totalTargetsScanned > 0 {
+		scanSuccessRate = float64(m.totalSuccesses) / float64(totalTargetsScanned) * 100
+	}
 	updateLine := fmt.Sprintf("%02dh:%02dm:%02ds; %s%d targets scanned; %.02f targets/sec; %.01f%% success rate",
 		int(timeSinceStart.Hours()),
 		int(timeSinceStart.Minutes())%60,
 		int(timeSinceStart.Seconds())%60,
 		scanStatusMsg,
 		m.totalSuccesses+m.totalFailures,
-		float64(m.totalSuccesses+m.totalFailures)/float64(timeSinceStart.Seconds()),
-		float64(m.totalSuccesses)/float64(m.totalSuccesses+m.totalFailures)*100,
+		scanRate,
+		scanSuccessRate,
 	)
 	_, err := fmt.Fprintln(config.statusUpdatesFile, updateLine)
 	if err != nil {

--- a/processing.go
+++ b/processing.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zcrypto/tls"
 	"net"
 	"sync"
-
-	log "github.com/sirupsen/logrus"
 
 	"github.com/zmap/zgrab2/lib/output"
 )


### PR DESCRIPTION
Adds a per-second status update to `stderr` by default.
Adds a new `--status-updates-file` for users to specify if they want these updates going elsewhere.

This is very useful for making performance improvements and knowing at what rate is ZGrab scanning.

## Testing

```
~/zgrab2 on  phillip/add-per-second-status! ⌚ 17:29:49
$ make; cat /tmp/10k.input | ./zgrab2 http --output-file=/dev/null --max-redirects=3  
make: Nothing to be done for 'all'.
INFO[0000] started grab at 2025-04-11T17:29:54-07:00    
00h:00m:01s; 62 targets scanned; 62.00 targets/sec; 77.4% success rate
00h:00m:02s; 95 targets scanned; 47.48 targets/sec; 67.4% success rate
00h:00m:03s; 112 targets scanned; 37.32 targets/sec; 70.5% success rate
00h:00m:04s; 134 targets scanned; 33.50 targets/sec; 74.6% success rate
...
00h:01m:28s; 9998 targets scanned; 113.61 targets/sec; 28.2% success rate
00h:01m:29s; 9999 targets scanned; 112.35 targets/sec; 28.2% success rate
INFO[0089] finished grab at 2025-04-11T17:31:23-07:00   
00h:01m:29s; Scan Complete; 10000 targets scanned; 112.28 targets/sec; 28.2% success rate
{"statuses":{"http":{"successes":2824,"failures":7176}},"start":"2025-04-11T17:29:54-07:00","end":"2025-04-11T17:31:23-07:00","duration":"1m29.060092791s"}
```