### PR TITLE
Move setting global TLS parameters to init() so it's run once and -race won't complain

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/csv"
 	"fmt"
+	"github.com/zmap/zcrypto/encoding/asn1"
+	"github.com/zmap/zcrypto/x509/pkix"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -11,11 +13,14 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/zmap/zcrypto/encoding/asn1"
 	"github.com/zmap/zcrypto/tls"
 	"github.com/zmap/zcrypto/x509"
-	"github.com/zmap/zcrypto/x509/pkix"
 )
+
+func init() {
+	asn1.AllowPermissiveParsing = true
+	pkix.LegacyNameString = true
+}
 
 // Shared code for TLS scans.
 // Example usage:
@@ -148,9 +153,6 @@ func (t *TLSFlags) GetTLSConfigForTarget(target *ScanTarget) (*tls.Config, error
 			log.Fatalf("Could not read certificates from PEM file. Invalid PEM?")
 		}
 	}
-
-	asn1.AllowPermissiveParsing = true
-	pkix.LegacyNameString = true
 
 	if t.NextProtos != "" {
 		// TODO: Different format?


### PR DESCRIPTION
Without this, when I'd test things with the `go run -race` race detector, these lines would flag. They are only set here, so setting in `init` should be fine and ensures it's only run once. `go run -race` had no faults after this.