### PR TITLE
Give user IP that domain resolves to

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,20 +13,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var defaultIPv4DNSResolvers = []string{
-	"1.1.1.1:53",
-	"1.0.0.1:53",
-	"8.8.8.8:53",
-	"8.8.4.4:53",
-}
-
-var defaultIPv6DNSResolvers = []string{
-	"2606:4700:4700::1111:53",
-	"2606:4700:4700::1001:53",
-	"2001:4860:4860::8888:53",
-	"2001:4860:4860::8844:53",
-}
-
 // Config is the high level framework options that will be parsed
 // from the command line
 type Config struct {
@@ -213,18 +199,6 @@ func validateFrameworkConfiguration() {
 		if config.customDNSNameservers, err = parseCustomDNSString(config.CustomDNS); err != nil {
 			log.Fatalf("invalid DNS server address: %s", err)
 		}
-	} else {
-		// if the user doesn't specify, we'll use defaults
-		if !config.useIPv4 && !config.useIPv6 {
-			log.Fatalf("invalid configuration: could not detect IP capabilites")
-		}
-		config.customDNSNameservers = make([]string, 0, min(len(defaultIPv4DNSResolvers), len(defaultIPv6DNSResolvers))) // preallocate
-		if config.useIPv4 {
-			config.customDNSNameservers = append(config.customDNSNameservers, defaultIPv4DNSResolvers...)
-		}
-		if config.useIPv6 {
-			config.customDNSNameservers = append(config.customDNSNameservers, defaultIPv6DNSResolvers...)
-		}
 	}
 
 	// If localPortString is set, parse it into a list of ports to use for source ports
@@ -235,8 +209,6 @@ func validateFrameworkConfiguration() {
 		}
 		config.localPorts = ports
 	}
-
-	log.Errorf("Using dns servers: %s", strings.Join(config.customDNSNameservers, ","))
 }
 
 // extractIPAddresses takes in a string of comma-separated IP addresses, ranges, or CIDR blocks and returns a de-duped

--- a/config.go
+++ b/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	ConnectionsPerHost    int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	ReadLimitPerHost      int             `long:"read-limit-per-host" default:"96" description:"Maximum total kilobytes to read for a single host (default 96kb)"`
 	Prometheus            string          `long:"prometheus" description:"Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled."`
-	CustomDNS             string          `long:"dns" description:"Address of a custom DNS server(s) for lookups, comma-delimited. Default port is 53. Ex: 1.1.1.1:53,8.8.8.8. Default DNS resolvers are the Google/Cloudflare resolvers."`
+	CustomDNS             string          `long:"dns" description:"Address of a custom DNS server(s) for lookups, comma-delimited. Default port is 53. Ex: 1.1.1.1:53,8.8.8.8. Uses the OS-default resolvers if not set."`
 	Multiple              MultipleCommand `command:"multiple" description:"Multiple module actions"`
 	LocalAddrString       string          `long:"local-addr" description:"Local address(es) to bind to for outgoing connections. Comma-separated list of IP addresses, ranges (inclusive), or CIDR blocks, ex: 1.1.1.1-1.1.1.3, 2.2.2.2, 3.3.3.0/24"`
 	LocalPortString       string          `long:"local-port" description:"Local port(s) to bind to for outgoing connections. Comma-separated list of ports or port ranges (inclusive) ex: 1200-1300,2000"`

--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	ConnectionsPerHost    int             `long:"connections-per-host" default:"1" description:"Number of times to connect to each host (results in more output)"`
 	ReadLimitPerHost      int             `long:"read-limit-per-host" default:"96" description:"Maximum total kilobytes to read for a single host (default 96kb)"`
 	Prometheus            string          `long:"prometheus" description:"Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled."`
-	CustomDNS             string          `long:"dns" description:"Address of a custom DNS server(s) for lookups, comma-delimited. Default port is 53. Ex: 1.1.1.1:53,8.8.8.8"`
+	CustomDNS             string          `long:"dns" description:"Address of a custom DNS server(s) for lookups, comma-delimited. Default port is 53. Ex: 1.1.1.1:53,8.8.8.8. Default DNS resolvers are the Google/Cloudflare resolvers."`
 	Multiple              MultipleCommand `command:"multiple" description:"Multiple module actions"`
 	LocalAddrString       string          `long:"local-addr" description:"Local address(es) to bind to for outgoing connections. Comma-separated list of IP addresses, ranges (inclusive), or CIDR blocks, ex: 1.1.1.1-1.1.1.3, 2.2.2.2, 3.3.3.0/24"`
 	LocalPortString       string          `long:"local-port" description:"Local port(s) to bind to for outgoing connections. Comma-separated list of ports or port ranges (inclusive) ex: 1200-1300,2000"`

--- a/conn.go
+++ b/conn.go
@@ -301,16 +301,16 @@ func (d *Dialer) SetDefaults() *Dialer {
 			Timeout:   d.SessionTimeout,
 			KeepAlive: d.SessionTimeout,
 		}
-		// Use custom DNS as default if set
-		if len(config.customDNSNameservers) > 0 {
-			// this may be a single IP address or a comma-separated list of IP addresses
-			ns := config.customDNSNameservers[rand.Intn(len(config.customDNSNameservers))]
-			d.Dialer.Resolver = &net.Resolver{
-				PreferGo: true,
-				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-					return net.Dial(network, ns)
-				},
-			}
+	}
+	// Use custom DNS as default if set
+	if len(config.customDNSNameservers) > 0 {
+		// this may be a single IP address or a comma-separated list of IP addresses
+		ns := config.customDNSNameservers[rand.Intn(len(config.customDNSNameservers))]
+		d.Dialer.Resolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				return d.Dialer.DialContext(ctx, network, ns)
+			},
 		}
 	}
 	return d

--- a/conn.go
+++ b/conn.go
@@ -314,6 +314,9 @@ func NewDialer(value *Dialer) *Dialer {
 		value = &Dialer{}
 		value.Dialer = &net.Dialer{}
 	}
+	if value.Dialer == nil {
+		value.Dialer = &net.Dialer{} // initialize defaults to prevent nil pointer dereference
+	}
 	return value.SetDefaults()
 }
 

--- a/conn.go
+++ b/conn.go
@@ -302,11 +302,13 @@ func (d *Dialer) SetDefaults() *Dialer {
 			KeepAlive: d.SessionTimeout,
 		}
 		// Use custom DNS as default if set
-		if config.CustomDNS != "" {
+		if len(config.customDNSNameservers) > 0 {
+			// this may be a single IP address or a comma-separated list of IP addresses
+			ns := config.customDNSNameservers[rand.Intn(len(config.customDNSNameservers))]
 			d.Dialer.Resolver = &net.Resolver{
 				PreferGo: true,
 				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-					return net.Dial(network, config.CustomDNS)
+					return net.Dial(network, ns)
 				},
 			}
 		}

--- a/conn.go
+++ b/conn.go
@@ -335,6 +335,9 @@ func (d *Dialer) SetRandomLocalAddr(network string, localIPs []net.IP, localPort
 	if len(localPorts) != 0 {
 		localPort = int(localPorts[rand.Intn(len(localPorts))])
 	}
+	if localIP == nil && localPort == 0 {
+		return nil // nothing to set
+	}
 	switch network {
 	case "tcp", "tcp4", "tcp6":
 		d.LocalAddr = &net.TCPAddr{

--- a/conn.go
+++ b/conn.go
@@ -312,6 +312,7 @@ func (d *Dialer) SetDefaults() *Dialer {
 func NewDialer(value *Dialer) *Dialer {
 	if value == nil {
 		value = &Dialer{}
+		value.Dialer = &net.Dialer{}
 	}
 	return value.SetDefaults()
 }

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -92,8 +92,13 @@ type Results struct {
 
 	// RedirectResponseChain is non-empty is the scanner follows a redirect.
 	// It contains all redirect response prior to the final response.
-	RedirectResponseChain []*http.Response  `json:"redirect_response_chain,omitempty"`
-	NamesToIPs            map[string]string `json:"redirects_to_resolved_ips,omitempty"`
+	RedirectResponseChain []*http.Response `json:"redirect_response_chain,omitempty"`
+	NamesToIPs            []RedirectToIP   `json:"redirects_to_resolved_ips,omitempty"`
+}
+
+type RedirectToIP struct {
+	RedirectName string `json:"redirect_name"`
+	IP           string `json:"ip"`
 }
 
 // Module is an implementation of the zgrab2.Module interface.
@@ -591,7 +596,13 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	}
 	// Copy over the resolved names to IPs
 	if len(scan.redirectsToResolvedIPs) > 0 {
-		scan.results.NamesToIPs = scan.redirectsToResolvedIPs
+		scan.results.NamesToIPs = make([]RedirectToIP, 0, len(scan.redirectsToResolvedIPs))
+		for k, v := range scan.redirectsToResolvedIPs {
+			scan.results.NamesToIPs = append(scan.results.NamesToIPs, RedirectToIP{
+				RedirectName: k,
+				IP:           v,
+			})
+		}
 	}
 	return zgrab2.SCAN_SUCCESS, &scan.results, nil
 }

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -254,7 +254,7 @@ func (s *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zg
 	var err error
 	var tlsConn *zgrab2.TLSConnection
 
-	conn, err := l4Dialer(t)(ctx, "tcp", net.JoinHostPort(t.String(), fmt.Sprintf("%d", t.Port)))
+	conn, err := l4Dialer(t)(ctx, "tcp", net.JoinHostPort(t.Host(), fmt.Sprintf("%d", t.Port)))
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error dialing target %s: %v", t.String(), err)
 	}

--- a/processing.go
+++ b/processing.go
@@ -61,8 +61,8 @@ func (target *ScanTarget) Host() string {
 // GetDefaultTCPDialer returns a TCP dialer suitable for modules with default TCP behavior
 func GetDefaultTCPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	// create dialer once and reuse it
-	dialer := GetTimeoutConnectionDialer(flags.Timeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
+		dialer := GetTimeoutConnectionDialer(flags.Timeout)
 		// If the scan is for a specific IP, and a domain name is provided, we
 		// don't want to just let the http library resolve the domain.  Create
 		// a fake resolver that we will use, that always returns the IP we are
@@ -146,8 +146,8 @@ func GetDefaultTLSWrapper(tlsFlags *TLSFlags) func(ctx context.Context, t *ScanT
 // GetDefaultUDPDialer returns a UDP dialer suitable for modules with default UDP behavior
 func GetDefaultUDPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	// create dialer once and reuse it
-	dialer := GetTimeoutConnectionDialer(flags.Timeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
+		dialer := GetTimeoutConnectionDialer(flags.Timeout)
 		err := dialer.SetRandomLocalAddr("udp", config.localAddrs, config.localPorts)
 		if err != nil {
 			return nil, fmt.Errorf("could not set random local address: %w", err)

--- a/processing.go
+++ b/processing.go
@@ -239,7 +239,7 @@ func grabTarget(ctx context.Context, input ScanTarget, m *Monitor) *Grab {
 				panic(e)
 			}
 		}(scannerName)
-		name, res := RunScanner(*scanner, m, input)
+		name, res := RunScanner(ctx, *scanner, m, input)
 		moduleResult[name] = res
 		if res.Error != nil && !config.Multiple.ContinueOnError {
 			break

--- a/scanner.go
+++ b/scanner.go
@@ -43,7 +43,7 @@ func PrintScanners() {
 }
 
 // RunScanner runs a single scan on a target and returns the resulting data
-func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanResponse) {
+func RunScanner(ctx context.Context, s Scanner, mon *Monitor, target ScanTarget) (string, ScanResponse) {
 	t := time.Now()
 	dialerGroupConfig, ok := defaultDialerGroupConfigToScanners[s.GetName()]
 	if !ok {
@@ -57,7 +57,6 @@ func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanRespons
 	if target.Port == 0 {
 		target.Port = dialerGroupConfig.BaseFlags.Port
 	}
-	ctx := context.Background()
 	if dialerGroupConfig.BaseFlags.TargetTimeout > 0 {
 		// timeout is set, use it on the context
 		var cancel context.CancelFunc

--- a/utility.go
+++ b/utility.go
@@ -264,6 +264,26 @@ func addDefaultPortToDNSServerName(inAddr string) (string, error) {
 	return net.JoinHostPort(ip.String(), port), nil
 }
 
+func parseCustomDNSString(customDNS string) ([]string, error) {
+	nameservers := make([]string, 0)
+	customDNS = strings.TrimSpace(customDNS)
+	if customDNS == "" {
+		return nil, nil
+	}
+	for _, ns := range strings.Split(customDNS, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns == "" {
+			continue
+		}
+		nsWithPort, err := addDefaultPortToDNSServerName(ns)
+		if err != nil {
+			return nil, fmt.Errorf("invalid DNS server address: %s", ns)
+		}
+		nameservers = append(nameservers, nsWithPort)
+	}
+	return nameservers, nil
+}
+
 // CloseConnAndHandleError closes the connection and logs an error if it fails. Convenience function for code-reuse.
 func CloseConnAndHandleError(conn net.Conn) {
 	err := conn.Close()

--- a/utility_test.go
+++ b/utility_test.go
@@ -1,0 +1,63 @@
+package zgrab2
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseIPList(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    []string
+		errExpected bool
+	}{
+		{
+			name:     "Single IPv4 without port",
+			input:    "8.8.8.8",
+			expected: []string{"8.8.8.8:53"},
+		},
+		{
+			name:     "Single IPv4 with custom port",
+			input:    "8.8.8.8:5353",
+			expected: []string{"8.8.8.8:5353"},
+		},
+		{
+			name:     "Single IPv6 without port",
+			input:    "2001:4860:4860::8888",
+			expected: []string{"[2001:4860:4860::8888]:53"},
+		},
+		{
+			name:     "Single IPv6 with custom port",
+			input:    "[2001:4860:4860::8888]:5353",
+			expected: []string{"[2001:4860:4860::8888]:5353"},
+		},
+		{
+			name:     "Multiple IPv4s mixed ports",
+			input:    "1.1.1.1:5300,8.8.8.8",
+			expected: []string{"1.1.1.1:5300", "8.8.8.8:53"},
+		},
+		{
+			name:  "Mixed IPv4 and IPv6, some with ports",
+			input: "1.1.1.1:5300,[2001:4860:4860::8888]:5353,8.8.8.8,2001:4860:4860::8844",
+			expected: []string{
+				"1.1.1.1:5300",
+				"[2001:4860:4860::8888]:5353",
+				"8.8.8.8:53",
+				"[2001:4860:4860::8844]:53",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseCustomDNSString(tt.input)
+			if (err != nil) != tt.errExpected {
+				t.Errorf("parseCustomDNSString() error = %v, expected %v", err, tt.errExpected)
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("ParseIPList(%q) = %v; want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/zgrab2_schemas/zgrab2/http.py
+++ b/zgrab2_schemas/zgrab2/http.py
@@ -168,6 +168,11 @@ http_response_full = SubRecord(
     }
 )
 
+redirects_to_resolved_ip = SubRecord({
+    "redirect_name": String(),
+    "ip": String(),
+})
+
 # modules/http.go: HTTPResults
 http_scan_response = SubRecord(
     {
@@ -177,6 +182,7 @@ http_scan_response = SubRecord(
                 "connect_response": http_response,
                 "response": http_response_full,
                 "redirect_response_chain": ListOf(http_response_full),
+                "redirects_to_resolved_ips": ListOf(redirects_to_resolved_ip)
             }
         )
     },

--- a/zgrab2_schemas/zgrab2/http.py
+++ b/zgrab2_schemas/zgrab2/http.py
@@ -168,10 +168,12 @@ http_response_full = SubRecord(
     }
 )
 
-redirects_to_resolved_ip = SubRecord({
-    "redirect_name": String(),
-    "ip": String(),
-})
+redirects_to_resolved_ip = SubRecord(
+    {
+        "redirect_name": String(),
+        "ip": String(),
+    }
+)
 
 # modules/http.go: HTTPResults
 http_scan_response = SubRecord(
@@ -182,7 +184,7 @@ http_scan_response = SubRecord(
                 "connect_response": http_response,
                 "response": http_response_full,
                 "redirect_response_chain": ListOf(http_response_full),
-                "redirects_to_resolved_ips": ListOf(redirects_to_resolved_ip)
+                "redirects_to_resolved_ips": ListOf(redirects_to_resolved_ip),
             }
         )
     },


### PR DESCRIPTION
This PR does a couple things:

- ~~Changes the default DNS resolvers to a combination of Cloudflare/Google~~ Uses OS defaults
- If a user gives `--local-addr`, use that to detect IPv4/IPv6 support
    - If they don't, attempt to connect to both IPv4 and v6 resolvers to self-detect. From then on, use this info to decide to use A or AAAA records during resolution
- If the user only provides the domain, we'll fill out the IP we resolve the domain to. Additionally, we'll do this outside of the modules, so if the `MULTIPLE` module is used, the target is only resolved once.
- With `http`, we have a wrinkle of complications with re-directs. I've modified the `net.Dialer` to use a custom resolver respecting our nameservers. Additionally, I've included a mapping of `resolved_names_to_ips` in the `http` response:
```
..."redirects_to_resolved_ips":[{"redirect_name":"facebook.com","ip":"157.240.22.35:443"},{"redirect_name":"www.facebook.com","ip":"157.240.22.35:443"}]},"...
```

## How to Test

To test, I spot-checked the output on sample domains and on 10k, spot checking a few throughout the output.

## Notes & Caveats

~~It's important to note that this PR _ignores the OS-specified (ie: `/etc/resolv.conf`) file and uses Google/Cloudflare_. The user can ofc override this. Anecdotally, I saw better results using these and I think it's a reasonable choice for most people.~~ Uses OS defaults now

## Issue Tracking

Resolves #104 
