### PR TITLE
Fix Multiple Module regression

### DIFF
--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -1,17 +1,9 @@
 // Package #{MODULE_NAME} provides a zgrab2 module that scans for #{MODULE_NAME}.
 // TODO: Describe module, the flags, the probe, the output, etc.
-package
-
-import (
-	"fmt"
-
-	"github.com/zmap/zgrab2"
-)
-#{MODULE_NAME}
+package #{MODULE_NAME}
 
 import (
 	log "github.com/sirupsen/logrus"
-
 	"github.com/zmap/zgrab2"
 )
 

--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -1,6 +1,13 @@
 // Package #{MODULE_NAME} provides a zgrab2 module that scans for #{MODULE_NAME}.
 // TODO: Describe module, the flags, the probe, the output, etc.
-package #{MODULE_NAME}
+package
+
+import (
+	"fmt"
+
+	"github.com/zmap/zgrab2"
+)
+#{MODULE_NAME}
 
 import (
 	log "github.com/sirupsen/logrus"
@@ -61,7 +68,7 @@ func (module *Module) NewScanner() zgrab2.Scanner {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/integration_tests/.template/module/scanner.go
+++ b/integration_tests/.template/module/scanner.go
@@ -4,6 +4,7 @@ package #{MODULE_NAME}
 
 import (
 	log "github.com/sirupsen/logrus"
+
 	"github.com/zmap/zgrab2"
 )
 

--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 
+
 def run_command(command, output_file=None):
     """Run a shell command and optionally redirect output to a file."""
     try:

--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -8,11 +8,6 @@ import subprocess
 import sys
 import time
 
-# Get directories
-module_dir = os.path.dirname(os.path.abspath(__file__))
-test_root = os.path.join(module_dir, "..")
-
-
 def run_command(command, output_file=None):
     """Run a shell command and optionally redirect output to a file."""
     try:

--- a/integration_tests/multiple/docker-run.sh
+++ b/integration_tests/multiple/docker-run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Runs the zgrab2_runner docker image (built with docker-runner/build-runner.sh)
+
+: "${DIR:?}"
+
+set -e
+docker run --rm -i -v $DIR:/multiple zgrab2_runner $@

--- a/integration_tests/multiple/input.csv
+++ b/integration_tests/multiple/input.csv
@@ -1,0 +1,2 @@
+, example.com, http80
+, time-a-g.nist.gov , ntp

--- a/integration_tests/multiple/multiple.ini
+++ b/integration_tests/multiple/multiple.ini
@@ -1,0 +1,5 @@
+[ntp]
+trigger="ntp"
+
+[http]
+trigger="http80"

--- a/integration_tests/multiple/test.py
+++ b/integration_tests/multiple/test.py
@@ -15,11 +15,11 @@ def run_command(command, output_file=None):
     """Run a shell command and optionally redirect output to a file."""
     try:
         with subprocess.Popen(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                shell=True,
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            shell=True,
         ) as process:
             stdout, stderr = process.communicate()
             if output_file:
@@ -38,10 +38,12 @@ zgrab_output = os.path.join(zgrab_root, "zgrab-output")
 output_root = os.path.join(zgrab_output, "multiple")
 multiple_test_root = os.path.join(zgrab_root, "integration_tests", "multiple")
 
+
 def validate_http(output):
     json_data = json.loads(output)
     assert json_data["domain"] == "example.com"
     assert json_data["data"]["http"]["status"] == "success"
+
 
 def validate_ntp(output):
     json_data = json.loads(output)
@@ -57,7 +59,7 @@ def test_multiple():
         cmd,
     )
     # print output
-    lines = out.strip().split('\n')
+    lines = out.strip().split("\n")
 
     # Write each line to a separate JSON file
     for i, line in enumerate(lines):
@@ -71,4 +73,4 @@ def test_multiple():
 
 
 if __name__ == "__main__":
-   test_multiple()
+    test_multiple()

--- a/integration_tests/multiple/test.py
+++ b/integration_tests/multiple/test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import difflib
+import os
+import json
+from unittest.result import failfast
+
+import requests
+import subprocess
+import sys
+import time
+
+
+def run_command(command, output_file=None):
+    """Run a shell command and optionally redirect output to a file."""
+    try:
+        with subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                shell=True,
+        ) as process:
+            stdout, stderr = process.communicate()
+            if output_file:
+                with open(output_file, "w") as f:
+                    f.write(stdout)
+            if stderr:
+                print(stderr, file=sys.stderr)
+            return stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Command failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+zgrab_root = run_command("git rev-parse --show-toplevel")
+zgrab_output = os.path.join(zgrab_root, "zgrab-output")
+output_root = os.path.join(zgrab_output, "multiple")
+multiple_test_root = os.path.join(zgrab_root, "integration_tests", "multiple")
+
+def validate_http(output):
+    json_data = json.loads(output)
+    assert json_data["domain"] == "example.com"
+    assert json_data["data"]["http"]["status"] == "success"
+
+def validate_ntp(output):
+    json_data = json.loads(output)
+    assert json_data["domain"] == "time-a-g.nist.gov"
+    assert json_data["data"]["ntp"]["status"] == "success"
+
+
+def test_multiple():
+    print("multiple/test: Run both NTP and HTTP scans")
+    print(multiple_test_root)
+    cmd = f"DIR={multiple_test_root} {multiple_test_root}/docker-run.sh multiple --input-file=/multiple/input.csv --config-file=/multiple/multiple.ini"
+    out = run_command(
+        cmd,
+    )
+    # print output
+    lines = out.strip().split('\n')
+
+    # Write each line to a separate JSON file
+    for i, line in enumerate(lines):
+        if "http" in line:
+            validate_http(line)
+        elif "ntp" in line:
+            validate_ntp(line)
+        else:
+            print(f"Unknown protocol in line: {line}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+   test_multiple()

--- a/module.go
+++ b/module.go
@@ -223,7 +223,7 @@ type ScanFlags interface {
 	Help() string
 
 	// Validate enforces all command-line flags and positional arguments have valid values.
-	Validate() error
+	Validate([]string) error
 }
 
 // BaseFlags contains the options that every flags type must embed

--- a/modules/amqp091/scanner.go
+++ b/modules/amqp091/scanner.go
@@ -121,7 +121,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	if flags.AuthUser != "" && flags.AuthPass == "" {
 		return fmt.Errorf("must provide --auth-pass if --auth-user is set")
 	}

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -60,7 +60,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -112,7 +112,7 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 }
 
 // Validate validates the flags and returns nil on success.
-func (f *Flags) Validate() error {
+func (f *Flags) Validate(_ []string) error {
 	if f.Probe != "\\n" && f.ProbeFile != "" {
 		log.Fatal("Cannot set both --probe and --probe-file")
 		return zgrab2.ErrInvalidArguments

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -58,7 +58,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -62,7 +62,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -103,7 +103,7 @@ func (m *Module) Description() string {
 }
 
 // Validate flags
-func (f *Flags) Validate() (err error) {
+func (f *Flags) Validate(_ []string) (err error) {
 	if f.FTPAuthTLS && f.ImplicitTLS {
 		err = fmt.Errorf("Cannot specify both '--authtls' and '--implicit-tls' together")
 	}

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -141,7 +141,7 @@ func (module *Module) Description() string {
 }
 
 // Validate performs any needed validation on the arguments
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -105,7 +105,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	if flags.StartTLS && flags.IMAPSecure {
 		log.Error("Cannot send both --starttls and --imaps")
 		return zgrab2.ErrInvalidArguments

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -155,7 +155,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/jarm/scanner.go
+++ b/modules/jarm/scanner.go
@@ -91,7 +91,7 @@ func (m *Module) NewScanner() zgrab2.Scanner {
 }
 
 // Validate validates the flags and returns nil on success.
-func (f *Flags) Validate() error {
+func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -78,7 +78,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	if flags.Verbose {
 		// If --verbose is set, do some extra checking but don't fail.
 		if flags.ObjectID >= 0x07 && flags.ObjectID < 0x80 {

--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -231,7 +231,7 @@ func (scanner *Scanner) GetTrigger() string {
 }
 
 // Validate checks that the flags are valid
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/mqtt/scanner.go
+++ b/modules/mqtt/scanner.go
@@ -74,7 +74,7 @@ func (m *Module) Description() string {
 }
 
 // Validate flags
-func (f *Flags) Validate() error {
+func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -81,7 +81,7 @@ func (module *Module) Description() string {
 }
 
 // Validate does nothing in this module.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -176,7 +176,7 @@ func (m *Module) Description() string {
 }
 
 // Validate validates the flags and returns nil on success.
-func (f *Flags) Validate() error {
+func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -839,7 +839,7 @@ func (module *Module) Description() string {
 }
 
 // Validate checks that the flags are valid
-func (cfg *Flags) Validate() error {
+func (cfg *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -133,7 +133,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	u16Strings := map[string]string{
 		"global-service-options":   flags.GlobalServiceOptions,
 		"protocol-characteristics": flags.ProtocolCharacterisics,

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -119,7 +119,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	if flags.StartTLS && flags.POP3Secure {
 		log.Error("Cannot send both --starttls and --pop3s")
 		return zgrab2.ErrInvalidArguments

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -289,7 +289,7 @@ func (m *Module) Description() string {
 }
 
 // Validate checks the arguments; on success, returns nil.
-func (f *Flags) Validate() error {
+func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/pptp/scanner.go
+++ b/modules/pptp/scanner.go
@@ -65,7 +65,7 @@ func (m *Module) Description() string {
 }
 
 // Validate flags
-func (f *Flags) Validate() (err error) {
+func (f *Flags) Validate(_ []string) (err error) {
 	return
 }
 

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -189,7 +189,7 @@ func (module *Module) Description() string {
 }
 
 // Validate checks that the flags are valid
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -57,7 +57,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -60,7 +60,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -137,7 +137,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	if flags.SendSTARTTLSOverride && flags.SMTPSecure {
 		return errors.New("cannot use --smtps and --send-starttls-override at the same time")
 	}

--- a/modules/socks5/scanner.go
+++ b/modules/socks5/scanner.go
@@ -70,7 +70,7 @@ func (m *Module) Description() string {
 }
 
 // Validate flags
-func (f *Flags) Validate() (err error) {
+func (f *Flags) Validate(_ []string) (err error) {
 	return
 }
 

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -57,7 +57,7 @@ func (m *SSHModule) Description() string {
 	return "Fetch an SSH server banner and collect key exchange information"
 }
 
-func (f *SSHFlags) Validate() error {
+func (f *SSHFlags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -65,7 +65,7 @@ func (module *Module) Description() string {
 // Validate checks that the flags are valid.
 // On success, returns nil.
 // On failure, returns an error instance describing the error.
-func (flags *Flags) Validate() error {
+func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -42,7 +42,7 @@ func (m *TLSModule) Description() string {
 	return "Perform a TLS handshake"
 }
 
-func (f *TLSFlags) Validate() error {
+func (f *TLSFlags) Validate(_ []string) error {
 	return nil
 }
 

--- a/multiple.go
+++ b/multiple.go
@@ -10,7 +10,7 @@ type MultipleCommand struct {
 }
 
 // Validate the options sent to MultipleCommand
-func (x *MultipleCommand) Validate() error {
+func (x *MultipleCommand) Validate(_ []string) error {
 	if x.ConfigFileName == config.InputFileName {
 		return errors.New("cannot receive config file and input file from same source")
 	}

--- a/multiple.ini
+++ b/multiple.ini
@@ -1,0 +1,9 @@
+[ntp]
+trigger="ntp"
+name="ntp"
+port=123
+
+[http]
+trigger="http80"
+name="http80"
+port=80


### PR DESCRIPTION
In order for the Multiple module to be able to parse `*.ini` files, the scan modules must implement the [ZCommander interface](https://github.com/ajholland/zflags/blob/master/command.go#L51). When I removed the `[] string` from the `Validate()` function for our ScanFlags in adding the DialerGroups, I broke this. This fixes that.

I also added a Multiple module integration test that performs an NTP grab against [time-a-g.nist.gov](time-a-g.nist.gov) and an HTTP grab for [example.com](example.com). This will catch anything like this breaking the Multiple module in the future.

## Related Issues
Resolves #520 
