### PR TITLE
Stabilize conn timeout unit tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,10 +32,6 @@ jobs:
           go get -t ./...
           make
 
-      - name: Sleep to let the server start
-        run: |
-          sleep 10
-
       - name: Test
         run: |
           make test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,43 +32,47 @@ jobs:
           go get -t ./...
           make
 
+      - name: Sleep to let the server start
+        run: |
+          sleep 5
+
       - name: Test
         run: |
           make test
 
-  integration-test:
-    name: Integration Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out source
-        uses: actions/checkout@v4
-
-      - name: Read go version
-        id: go_version
-        run: |
-          # Read the variable from the file
-          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-          # Set the variable as an output
-          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ steps.go_version.outputs.GO_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          set -e
-          sudo apt update
-          # Install latest Python
-          sudo apt install -y python3 jp python3-pip
-          python3 -m venv venv
-          source venv/bin/activate
-          # Install Python dependencies
-          pip install zschema
-          pip install -r requirements.txt
-
-      - name: Run tests
-        run: |
-          source venv/bin/activate
-          make integration-test
+#  integration-test:
+#    name: Integration Test
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Check out source
+#        uses: actions/checkout@v4
+#
+#      - name: Read go version
+#        id: go_version
+#        run: |
+#          # Read the variable from the file
+#          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+#          # Set the variable as an output
+#          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_OUTPUT
+#
+#      - name: Set up Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: ${{ steps.go_version.outputs.GO_VERSION }}
+#
+#      - name: Install dependencies
+#        run: |
+#          set -e
+#          sudo apt update
+#          # Install latest Python
+#          sudo apt install -y python3 jp python3-pip
+#          python3 -m venv venv
+#          source venv/bin/activate
+#          # Install Python dependencies
+#          pip install zschema
+#          pip install -r requirements.txt
+#
+#      - name: Run tests
+#        run: |
+#          source venv/bin/activate
+#          make integration-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,39 +36,39 @@ jobs:
         run: |
           make test
 
-#  integration-test:
-#    name: Integration Test
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Check out source
-#        uses: actions/checkout@v4
-#
-#      - name: Read go version
-#        id: go_version
-#        run: |
-#          # Read the variable from the file
-#          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-#          # Set the variable as an output
-#          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_OUTPUT
-#
-#      - name: Set up Go
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version: ${{ steps.go_version.outputs.GO_VERSION }}
-#
-#      - name: Install dependencies
-#        run: |
-#          set -e
-#          sudo apt update
-#          # Install latest Python
-#          sudo apt install -y python3 jp python3-pip
-#          python3 -m venv venv
-#          source venv/bin/activate
-#          # Install Python dependencies
-#          pip install zschema
-#          pip install -r requirements.txt
-#
-#      - name: Run tests
-#        run: |
-#          source venv/bin/activate
-#          make integration-test
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Read go version
+        id: go_version
+        run: |
+          # Read the variable from the file
+          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          # Set the variable as an output
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go_version.outputs.GO_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          set -e
+          sudo apt update
+          # Install latest Python
+          sudo apt install -y python3 jp python3-pip
+          python3 -m venv venv
+          source venv/bin/activate
+          # Install Python dependencies
+          pip install zschema
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          make integration-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Sleep to let the server start
         run: |
-          sleep 5
+          sleep 10
 
       - name: Test
         run: |

--- a/conn.go
+++ b/conn.go
@@ -75,10 +75,6 @@ func (c *TimeoutConnection) SaturateTimeoutsToReadAndWriteTimeouts() {
 	if c.SessionTimeout > 0 {
 		minDeadline = min(minDeadline, int64(c.SessionTimeout))
 	}
-	if minDeadline == int64(math.MaxInt64) {
-		// no deadline set, we'll use the default
-		minDeadline = int64(DefaultSessionTimeout)
-	}
 	c.SessionTimeout = time.Duration(minDeadline)
 
 	// Now we'll check read and write timeouts.
@@ -214,21 +210,10 @@ func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeo
 	ret := &TimeoutConnection{
 		ctx:            ctx,
 		Conn:           conn,
-		ReadTimeout:    DefaultSessionTimeout,
-		WriteTimeout:   DefaultSessionTimeout,
-		BytesReadLimit: DefaultBytesReadLimit,
-	}
-	if readTimeout != 0 {
-		ret.ReadTimeout = readTimeout
-	}
-	if writeTimeout != 0 {
-		ret.WriteTimeout = writeTimeout
-	}
-	if bytesReadLimit != 0 {
-		ret.BytesReadLimit = bytesReadLimit
-	}
-	if timeout == 0 {
-		timeout = DefaultSessionTimeout
+		SessionTimeout: timeout,
+		ReadTimeout:    readTimeout,
+		WriteTimeout:   writeTimeout,
+		BytesReadLimit: bytesReadLimit,
 	}
 	ret.ctx, ret.Cancel = context.WithTimeout(ctx, timeout)
 	ret.SaturateTimeoutsToReadAndWriteTimeouts()

--- a/conn.go
+++ b/conn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"net"
 	"time"
@@ -51,16 +52,41 @@ var ErrReadLimitExceeded = errors.New("read limit exceeded")
 type TimeoutConnection struct {
 	net.Conn
 	ctx                     context.Context
-	ReadTimeout             time.Duration
-	WriteTimeout            time.Duration
+	Timeout                 time.Duration // used to set the connection deadline, set once
+	ReadTimeout             time.Duration // used to set the read deadline, set fresh for each read
+	WriteTimeout            time.Duration // used to set the write deadline, set fresh for each write
 	BytesRead               int
 	BytesWritten            int
 	BytesReadLimit          int
 	ReadLimitExceededAction ReadLimitExceededAction
 	Cancel                  context.CancelFunc
-	explicitReadDeadline    bool
-	explicitWriteDeadline   bool
-	explicitDeadline        bool
+}
+
+// ManageTimeouts uses the timeouts set on a TimeoutConnection to set the underlying deadlines on the base connection.
+// The underlying conn only supports read and write deadlines. So we'll use the minimum of the set ctx, timeouts, etc.
+func (c *TimeoutConnection) ManageTimeouts() {
+	// Get the minimum of the context deadline and the timeout
+	minDeadline := int64(math.MaxInt64)
+	if ctxDeadline, ok := c.ctx.Deadline(); ok {
+		minDeadline = int64(ctxDeadline.Sub(time.Now()))
+	}
+	if c.Timeout > 0 {
+		minDeadline = min(minDeadline, int64(c.Timeout))
+	}
+	if minDeadline == int64(math.MaxInt64) {
+		// no deadline set, we'll use the default
+		minDeadline = int64(DefaultSessionTimeout)
+	}
+	c.Timeout = time.Duration(minDeadline)
+
+	// Now we'll check read and write timeouts.
+	if c.ReadTimeout > 0 {
+		c.ReadTimeout = time.Duration(min(minDeadline, int64(c.ReadTimeout)))
+	}
+
+	if c.WriteTimeout > 0 {
+		c.WriteTimeout = time.Duration(min(minDeadline, int64(c.WriteTimeout)))
+	}
 }
 
 // TimeoutConnection.Read calls Read() on the underlying connection, using any configured deadlines
@@ -72,16 +98,11 @@ func (c *TimeoutConnection) Read(b []byte) (n int, err error) {
 	if c.BytesRead+len(b) >= c.BytesReadLimit {
 		b = b[0 : c.BytesReadLimit-c.BytesRead]
 	}
-	if c.explicitReadDeadline || c.explicitDeadline {
-		c.explicitReadDeadline = false
-		c.explicitDeadline = false
-	} else if readTimeout := c.getTimeout(c.ReadTimeout); readTimeout > 0 {
-		if err = c.Conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
-			return 0, err
-		}
+	if err = c.Conn.SetReadDeadline(time.Now().Add(c.ReadTimeout)); err != nil {
+		return 0, err
 	}
 	//c.SetDeadline(time.Now())
-	//timeUntilDeadline := time.Now().Add(c.Timeout)
+	//timeUntilDeadline := time.Now().Add()
 	////c.SetDeadline(time.Now().Add(c.Timeout))
 	//fmt.Printf("time until deadline: %v\n", timeUntilDeadline)
 	n, err = c.Conn.Read(b)
@@ -108,13 +129,8 @@ func (c *TimeoutConnection) Write(b []byte) (n int, err error) {
 	if err := c.checkContext(); err != nil {
 		return 0, err
 	}
-	if c.explicitWriteDeadline || c.explicitDeadline {
-		c.explicitWriteDeadline = false
-		c.explicitDeadline = false
-	} else if writeTimeout := c.getTimeout(c.WriteTimeout); writeTimeout > 0 {
-		if err = c.Conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
-			return 0, err
-		}
+	if err = c.Conn.SetWriteDeadline(time.Now().Add(c.WriteTimeout)); err != nil {
+		return 0, err
 	}
 	n, err = c.Conn.Write(b)
 	c.BytesWritten += n
@@ -122,7 +138,7 @@ func (c *TimeoutConnection) Write(b []byte) (n int, err error) {
 }
 
 // SetReadDeadline sets an explicit ReadDeadline that will override the timeout
-// for one read. Use deadline = 0 to clear the deadline.
+// for one read.
 func (c *TimeoutConnection) SetReadDeadline(deadline time.Time) error {
 	if err := c.checkContext(); err != nil {
 		return err
@@ -133,12 +149,11 @@ func (c *TimeoutConnection) SetReadDeadline(deadline time.Time) error {
 			return err
 		}
 	}
-	c.explicitReadDeadline = !deadline.IsZero()
 	return nil
 }
 
 // SetWriteDeadline sets an explicit WriteDeadline that will override the
-// WriteDeadline for one write. Use deadline = 0 to clear the deadline.
+// WriteDeadline for one write.
 func (c *TimeoutConnection) SetWriteDeadline(deadline time.Time) error {
 	if err := c.checkContext(); err != nil {
 		return err
@@ -149,37 +164,30 @@ func (c *TimeoutConnection) SetWriteDeadline(deadline time.Time) error {
 			return err
 		}
 	}
-	c.explicitWriteDeadline = deadline.IsZero()
 	return nil
 }
 
 // SetDeadline sets a read / write deadline that will override the deadline for
-// a single read/write. Use deadline = 0 to clear the deadline.
+// a single read/write.
 func (c *TimeoutConnection) SetDeadline(deadline time.Time) error {
 	if err := c.checkContext(); err != nil {
 		return err
 	}
 	if !deadline.IsZero() {
+		// print time until deadline
+		timeUntilDeadline := deadline.Sub(time.Now())
+		fmt.Printf("time until deadline: %v\n", timeUntilDeadline)
 		err := c.Conn.SetDeadline(deadline)
 		if err != nil {
 			return err
 		}
 	}
-	c.explicitDeadline = deadline.IsZero()
 	return nil
 }
 
 // Close the underlying connection.
 func (c *TimeoutConnection) Close() error {
 	return c.Conn.Close()
-}
-
-// Get the timeout for the given field, falling back to the global timeout.
-func (c *TimeoutConnection) getTimeout(field time.Duration) time.Duration {
-	if field == 0 {
-		return DefaultSessionTimeout
-	}
-	return field
 }
 
 // Check if the context has been cancelled, and if so, return an error (either the context error, or
@@ -200,30 +208,39 @@ func (c *TimeoutConnection) checkContext() error {
 	}
 }
 
-// SetDefaults on the connection.
-func (c *TimeoutConnection) SetDefaults() *TimeoutConnection {
-	if c.BytesReadLimit == 0 {
-		c.BytesReadLimit = DefaultBytesReadLimit
-	}
-	if c.ReadLimitExceededAction == ReadLimitExceededActionNotSet {
-		c.ReadLimitExceededAction = DefaultReadLimitExceededAction
-	}
-	if !c.explicitDeadline {
-		if err := c.SetDeadline(time.Now().Add(DefaultSessionTimeout)); err != nil {
-			logrus.Fatalf("failed to set default deadline: %v", err)
-		}
-	}
-	return c
-}
+//// SetDefaults on the connection.
+//func (c *TimeoutConnection) SetDefaults() *TimeoutConnection {
+//	if c.BytesReadLimit == 0 {
+//		c.BytesReadLimit = DefaultBytesReadLimit
+//	}
+//	if c.ReadLimitExceededAction == ReadLimitExceededActionNotSet {
+//		c.ReadLimitExceededAction = DefaultReadLimitExceededAction
+//	}
+//	if !c.explicitDeadline {
+//		if err := c.SetDeadline(time.Now().Add(DefaultSessionTimeout)); err != nil {
+//			logrus.Fatalf("failed to set default deadline: %v", err)
+//		}
+//	}
+//	return c
+//}
 
 // NewTimeoutConnection returns a new TimeoutConnection with the appropriate defaults.
 func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) *TimeoutConnection {
 	ret := (&TimeoutConnection{
 		Conn:           conn,
-		ReadTimeout:    readTimeout,
-		WriteTimeout:   writeTimeout,
-		BytesReadLimit: bytesReadLimit,
-	}).SetDefaults()
+		ReadTimeout:    DefaultSessionTimeout,
+		WriteTimeout:   DefaultSessionTimeout,
+		BytesReadLimit: DefaultBytesReadLimit,
+	})
+	if readTimeout != 0 {
+		ret.ReadTimeout = readTimeout
+	}
+	if writeTimeout != 0 {
+		ret.WriteTimeout = writeTimeout
+	}
+	if bytesReadLimit != 0 {
+		ret.BytesReadLimit = bytesReadLimit
+	}
 	connDeadline := time.Now().Add(timeout)
 	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(connDeadline) {
 		// get the minimum of the two deadlines
@@ -237,6 +254,7 @@ func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeo
 	}
 
 	ret.ctx, ret.Cancel = context.WithTimeout(ctx, timeout)
+	ret.ManageTimeouts()
 	return ret
 }
 

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -55,9 +55,9 @@ type connTimeoutTestConfig struct {
 	failError string
 }
 
-// Standardized time units, separated by factors of 10.
+// Standardized time units, separated by factors of 100.
 const (
-	short  = 100 * time.Millisecond
+	short  = 10 * time.Millisecond
 	medium = 1000 * time.Millisecond
 	long   = 10000 * time.Millisecond
 )

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -57,9 +57,9 @@ type connTimeoutTestConfig struct {
 
 // Standardized time units, separated by factors of 100.
 const (
-	short  = 10 * time.Millisecond
-	medium = 1000 * time.Millisecond
-	long   = 100000 * time.Millisecond
+	short  = 100 * time.Millisecond
+	medium = 10000 * time.Millisecond
+	long   = 1000000 * time.Millisecond
 )
 
 // enum type for the various locations where the test can fail

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -57,9 +57,9 @@ type connTimeoutTestConfig struct {
 
 // Standardized time units, separated by factors of 100.
 const (
-	short  = 100 * time.Millisecond
-	medium = 10000 * time.Millisecond
-	long   = 1000000 * time.Millisecond
+	short  = 10 * time.Millisecond
+	medium = 1000 * time.Millisecond
+	long   = 100000 * time.Millisecond
 )
 
 // enum type for the various locations where the test can fail
@@ -280,82 +280,82 @@ func (cfg *connTimeoutTestConfig) run(t *testing.T) {
 
 var connTestConfigs = []connTimeoutTestConfig{
 	// Long timeouts, short delays -- should succeed
-	{
-		name:           "happy",
-		port:           0x5613,
-		timeout:        long,
-		connectTimeout: medium,
-		readTimeout:    medium,
-		writeTimeout:   medium,
-
-		acceptDelay: short,
-		writeDelay:  short,
-		readDelay:   short,
-
-		serverToClientPayload: []byte("abc"),
-		clientToServerPayload: []byte("defghi"),
-
-		failStep: testStepDone,
-	},
-	// long session timeout, short connectTimeout. Use a non-local, nonexistent endpoint (localhost
-	// would return "connection refused" immediately)
-	{
-		name:           "connect_timeout",
-		endpoint:       "10.0.254.254:41591",
-		timeout:        long,
-		connectTimeout: short,
-		readTimeout:    medium,
-		writeTimeout:   medium,
-
-		acceptDelay: short,
-		writeDelay:  short,
-		readDelay:   short,
-
-		serverToClientPayload: []byte("abc"),
-		clientToServerPayload: []byte("defghi"),
-
-		failStep:  testStepConnect,
-		failError: "i/o timeout",
-	},
-	// short session timeout, medium connect timeout, with connect to nonexistent endpoint.
-	{
-		name:           "session_connect_timeout",
-		endpoint:       "10.0.254.254:41591",
-		timeout:        short,
-		connectTimeout: medium,
-		readTimeout:    medium,
-		writeTimeout:   medium,
-
-		acceptDelay: short,
-		writeDelay:  short,
-		readDelay:   short,
-
-		serverToClientPayload: []byte("abc"),
-		clientToServerPayload: []byte("defghi"),
-
-		failStep:  testStepConnect,
-		failError: "i/o timeout",
-	},
-	// Get an IO timeout on the read.
-	// sessionTimeout > acceptDelay + writeDelay > writeDelay > readTimeout
-	{
-		name:           "read_timeout",
-		port:           0x5614,
-		timeout:        long,
-		connectTimeout: short,
-		readTimeout:    short,
-		writeTimeout:   short,
-
-		acceptDelay: short,
-		writeDelay:  medium,
-		readDelay:   short,
-
-		serverToClientPayload: []byte("abc"),
-		clientToServerPayload: []byte("defghi"),
-
-		failStep:  testStepRead,
-		failError: "i/o timeout",
-	},
+	//{
+	//	name:           "happy",
+	//	port:           0x5613,
+	//	timeout:        long,
+	//	connectTimeout: medium,
+	//	readTimeout:    medium,
+	//	writeTimeout:   medium,
+	//
+	//	acceptDelay: short,
+	//	writeDelay:  short,
+	//	readDelay:   short,
+	//
+	//	serverToClientPayload: []byte("abc"),
+	//	clientToServerPayload: []byte("defghi"),
+	//
+	//	failStep: testStepDone,
+	//},
+	//// long session timeout, short connectTimeout. Use a non-local, nonexistent endpoint (localhost
+	//// would return "connection refused" immediately)
+	//{
+	//	name:           "connect_timeout",
+	//	endpoint:       "10.0.254.254:41591",
+	//	timeout:        long,
+	//	connectTimeout: short,
+	//	readTimeout:    medium,
+	//	writeTimeout:   medium,
+	//
+	//	acceptDelay: short,
+	//	writeDelay:  short,
+	//	readDelay:   short,
+	//
+	//	serverToClientPayload: []byte("abc"),
+	//	clientToServerPayload: []byte("defghi"),
+	//
+	//	failStep:  testStepConnect,
+	//	failError: "i/o timeout",
+	//},
+	//// short session timeout, medium connect timeout, with connect to nonexistent endpoint.
+	//{
+	//	name:           "session_connect_timeout",
+	//	endpoint:       "10.0.254.254:41591",
+	//	timeout:        short,
+	//	connectTimeout: medium,
+	//	readTimeout:    medium,
+	//	writeTimeout:   medium,
+	//
+	//	acceptDelay: short,
+	//	writeDelay:  short,
+	//	readDelay:   short,
+	//
+	//	serverToClientPayload: []byte("abc"),
+	//	clientToServerPayload: []byte("defghi"),
+	//
+	//	failStep:  testStepConnect,
+	//	failError: "i/o timeout",
+	//},
+	//// Get an IO timeout on the read.
+	//// sessionTimeout > acceptDelay + writeDelay > writeDelay > readTimeout
+	//{
+	//	name:           "read_timeout",
+	//	port:           0x5614,
+	//	timeout:        long,
+	//	connectTimeout: short,
+	//	readTimeout:    short,
+	//	writeTimeout:   short,
+	//
+	//	acceptDelay: short,
+	//	writeDelay:  medium,
+	//	readDelay:   short,
+	//
+	//	serverToClientPayload: []byte("abc"),
+	//	clientToServerPayload: []byte("defghi"),
+	//
+	//	failStep:  testStepRead,
+	//	failError: "i/o timeout",
+	//},
 	// Get a context timeout on a read.
 	// readTimeout > writeDelay > timeout > acceptDelay
 	{
@@ -378,24 +378,24 @@ var connTestConfigs = []connTimeoutTestConfig{
 	},
 	// Use a session timeout that is longer than any individual action's timeout.
 	// acceptDelay+writeDelay+readDelay > timeout > acceptDelay >= writeDelay >= readDelay
-	{
-		name:           "session_timeout",
-		port:           0x5616,
-		timeout:        medium,
-		connectTimeout: long,
-		readTimeout:    long,
-		writeTimeout:   long,
-
-		acceptDelay: time.Nanosecond * time.Duration(medium.Nanoseconds()/2+short.Nanoseconds()),
-		writeDelay:  time.Nanosecond * time.Duration(medium.Nanoseconds()/2+short.Nanoseconds()),
-		readDelay:   time.Nanosecond * time.Duration(medium.Nanoseconds()/2+short.Nanoseconds()),
-
-		serverToClientPayload: []byte("abc"),
-		clientToServerPayload: []byte("defghi"),
-
-		failStep:  testStepWrite,
-		failError: "context deadline exceeded",
-	},
+	//{
+	//	name:           "session_timeout",
+	//	port:           0x5616,
+	//	timeout:        medium,
+	//	connectTimeout: long,
+	//	readTimeout:    long,
+	//	writeTimeout:   long,
+	//
+	//	acceptDelay: time.Nanosecond * time.Duration(medium.Nanoseconds()/2+short.Nanoseconds()),
+	//	writeDelay:  time.Nanosecond * time.Duration(medium.Nanoseconds()/2+short.Nanoseconds()),
+	//	readDelay:   time.Nanosecond * time.Duration(medium.Nanoseconds()/2+short.Nanoseconds()),
+	//
+	//	serverToClientPayload: []byte("abc"),
+	//	clientToServerPayload: []byte("defghi"),
+	//
+	//	failStep:  testStepWrite,
+	//	failError: "context deadline exceeded",
+	//},
 	// TODO: How to test write timeout?
 }
 

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -57,8 +57,8 @@ type connTimeoutTestConfig struct {
 
 // Standardized time units, separated by factors of 100.
 const (
-	short  = 10 * time.Millisecond
-	medium = 1000 * time.Millisecond
+	short  = 1 * time.Millisecond
+	medium = 100 * time.Millisecond
 	long   = 10000 * time.Millisecond
 )
 

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -143,10 +143,10 @@ func (cfg *connTimeoutTestConfig) runServer(t *testing.T) chan *timeoutTestError
 			errorChan <- serverError(testStepRead, err)
 			return
 		}
-		//if err == io.EOF && n < len(buf) {
-		//	errorChan <- serverError(testStepRead, err)
-		//	return
-		//}
+		if err == io.EOF && n < len(buf) {
+			errorChan <- serverError(testStepRead, err)
+			return
+		}
 		if !bytes.Equal(buf, cfg.clientToServerPayload) {
 			t.Errorf("%s: clientToServerPayload mismatch", cfg.name)
 		}

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -143,10 +143,10 @@ func (cfg *connTimeoutTestConfig) runServer(t *testing.T) chan *timeoutTestError
 			errorChan <- serverError(testStepRead, err)
 			return
 		}
-		if err == io.EOF && n < len(buf) {
-			errorChan <- serverError(testStepRead, err)
-			return
-		}
+		//if err == io.EOF && n < len(buf) {
+		//	errorChan <- serverError(testStepRead, err)
+		//	return
+		//}
 		if !bytes.Equal(buf, cfg.clientToServerPayload) {
 			t.Errorf("%s: clientToServerPayload mismatch", cfg.name)
 		}

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -57,9 +57,9 @@ type connTimeoutTestConfig struct {
 
 // Standardized time units, separated by factors of 100.
 const (
-	short  = 1 * time.Millisecond
-	medium = 100 * time.Millisecond
-	long   = 10000 * time.Millisecond
+	short  = 10 * time.Millisecond
+	medium = 1000 * time.Millisecond
+	long   = 100000 * time.Millisecond
 )
 
 // enum type for the various locations where the test can fail

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -402,6 +403,7 @@ var connTestConfigs = []connTimeoutTestConfig{
 // TestTimeoutConnectionTimeouts tests that the TimeoutConnection behaves as expected with respect
 // to timeouts.
 func TestTimeoutConnectionTimeouts(t *testing.T) {
+	fmt.Printf("GOMAXPROCS = %d\n", runtime.GOMAXPROCS(0))
 	temp := make([]connTimeoutTestConfig, 0, len(connTestConfigs)*3)
 	// Make three copies of connTestConfigs, one with each dial method.
 	for _, cfg := range connTestConfigs {

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -376,8 +376,8 @@ var connTestConfigs = []connTimeoutTestConfig{
 		clientFailStep: clientTestStepRead,
 		failError:      "i/o timeout",
 	},
-	//Use a session timeout that is longer than any individual action's timeout.
-	//serverAcceptDelay+serverWriteDelay+serverReadDelay > timeout > serverAcceptDelay >= serverWriteDelay >= serverReadDelay
+	// Use a session timeout that is longer than any individual action's timeout.
+	// serverAcceptDelay+serverWriteDelay+serverReadDelay > timeout > serverAcceptDelay >= serverWriteDelay >= serverReadDelay
 	{
 		name:           "session_timeout",
 		port:           0x5616,

--- a/conn_timeout_test.go
+++ b/conn_timeout_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -403,7 +402,6 @@ var connTestConfigs = []connTimeoutTestConfig{
 // TestTimeoutConnectionTimeouts tests that the TimeoutConnection behaves as expected with respect
 // to timeouts.
 func TestTimeoutConnectionTimeouts(t *testing.T) {
-	fmt.Printf("GOMAXPROCS = %d\n", runtime.GOMAXPROCS(0))
 	temp := make([]connTimeoutTestConfig, 0, len(connTestConfigs)*3)
 	// Make three copies of connTestConfigs, one with each dial method.
 	for _, cfg := range connTestConfigs {

--- a/utility.go
+++ b/utility.go
@@ -124,10 +124,10 @@ func ReadAvailableWithOptions(conn net.Conn, bufferSize int, readTimeout time.Du
 		// Would be nice if this could be taken from the SetReadDeadline(), but that's not possible in general
 		const defaultTotalTimeout = 1 * time.Second
 		totalTimeout = defaultTotalTimeout
-		timeoutConn, isTimeoutConn := conn.(*TimeoutConnection)
-		if isTimeoutConn {
-			totalTimeout = timeoutConn.Timeout
-		}
+		//timeoutConn, isTimeoutConn := conn.(*TimeoutConnection)
+		//if isTimeoutConn {
+		//	totalTimeout = timeoutConn.Conn.Dea
+		//}
 	}
 	if totalTimeout > 0 {
 		totalDeadline = time.Now().Add(totalTimeout)

--- a/utility.go
+++ b/utility.go
@@ -94,7 +94,7 @@ func ReadAvailable(conn net.Conn) ([]byte, error) {
 	return ReadAvailableWithOptions(conn, defaultBufferSize, defaultReadTimeout, 0, defaultMaxReadSize)
 }
 
-// Make this implement the net.Error interface so that err.(net.Error).Timeout() works.
+// Make this implement the net.Error interface so that err.(net.Error).SessionTimeout() works.
 type errTotalTimeout string
 
 const (
@@ -126,7 +126,7 @@ func ReadAvailableWithOptions(conn net.Conn, bufferSize int, readTimeout time.Du
 		totalTimeout = defaultTotalTimeout
 		timeoutConn, isTimeoutConn := conn.(*TimeoutConnection)
 		if isTimeoutConn {
-			totalTimeout = timeoutConn.Timeout
+			totalTimeout = timeoutConn.SessionTimeout
 		}
 	}
 	if totalTimeout > 0 {

--- a/utility.go
+++ b/utility.go
@@ -124,10 +124,10 @@ func ReadAvailableWithOptions(conn net.Conn, bufferSize int, readTimeout time.Du
 		// Would be nice if this could be taken from the SetReadDeadline(), but that's not possible in general
 		const defaultTotalTimeout = 1 * time.Second
 		totalTimeout = defaultTotalTimeout
-		//timeoutConn, isTimeoutConn := conn.(*TimeoutConnection)
-		//if isTimeoutConn {
-		//	totalTimeout = timeoutConn.Conn.Dea
-		//}
+		timeoutConn, isTimeoutConn := conn.(*TimeoutConnection)
+		if isTimeoutConn {
+			totalTimeout = timeoutConn.Timeout
+		}
 	}
 	if totalTimeout > 0 {
 		totalDeadline = time.Now().Add(totalTimeout)


### PR DESCRIPTION
This [unit test](https://github.com/zmap/zgrab2/blob/master/conn_timeout_test.go#L404) for testing our connection timeouts in different situations has been incredibly flaky on GH runners, yet very stable on my Mac. I took a deeper look at it and noticed we were doing some weird things with timeouts.

As a background, we wrap a `net.Conn` with a `TimeoutConnection` object that we create. This lets you set various timeouts and `ctx`'s on a connection. It's vital to note, however, that a `net.Conn` only has two timeouts, a `ReadTimeout` and a `WriteTimeout`. So we need to take all of our settings and condense them into those two values by taking the minimum for them to have any effect.

## How to Test

- Ran 5 GH actions on the HEAD of this branch, all succeeded. So it seems stable
- Did a test HTTP scan to be sure nothing was messed up with our connection timeouts, saw similar hit-rates to `master`
