### PR TITLE
Make timeout behavior user-changeable and easy-to-understand

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -279,9 +279,10 @@ func (d *Dialer) Dial(proto string, target string) (net.Conn, error) {
 }
 
 // GetTimeoutConnectionDialer gets a Dialer that dials connections with the given timeout.
-func GetTimeoutConnectionDialer(timeout time.Duration) *Dialer {
+func GetTimeoutConnectionDialer(dialTimeout, sessionTimeout time.Duration) *Dialer {
 	dialer := NewDialer(nil)
-	dialer.Timeout = timeout
+	dialer.Timeout = dialTimeout
+	dialer.SessionTimeout = sessionTimeout
 	return dialer
 }
 
@@ -293,14 +294,8 @@ func (d *Dialer) SetDefaults() *Dialer {
 	if d.BytesReadLimit == 0 {
 		d.BytesReadLimit = DefaultBytesReadLimit
 	}
-	if d.SessionTimeout == 0 {
-		d.SessionTimeout = DefaultSessionTimeout
-	}
 	if d.Dialer == nil {
-		d.Dialer = &net.Dialer{
-			Timeout:   d.SessionTimeout,
-			KeepAlive: d.SessionTimeout,
-		}
+		d.Dialer = &net.Dialer{}
 		// Use custom DNS as default if set
 		if config.CustomDNS != "" {
 			d.Dialer.Resolver = &net.Resolver{

--- a/conn.go
+++ b/conn.go
@@ -206,16 +206,20 @@ func (c *TimeoutConnection) checkContext() error {
 }
 
 // NewTimeoutConnection returns a new TimeoutConnection with the appropriate defaults.
-func NewTimeoutConnection(ctx context.Context, conn net.Conn, timeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) *TimeoutConnection {
+func NewTimeoutConnection(ctx context.Context, conn net.Conn, sessionTimeout, readTimeout, writeTimeout time.Duration, bytesReadLimit int) *TimeoutConnection {
 	ret := &TimeoutConnection{
 		ctx:            ctx,
 		Conn:           conn,
-		SessionTimeout: timeout,
+		SessionTimeout: sessionTimeout,
 		ReadTimeout:    readTimeout,
 		WriteTimeout:   writeTimeout,
 		BytesReadLimit: bytesReadLimit,
 	}
-	ret.ctx, ret.Cancel = context.WithTimeout(ctx, timeout)
+	if sessionTimeout > 0 {
+		ret.ctx, ret.Cancel = context.WithTimeout(ctx, sessionTimeout)
+	} else {
+		ret.ctx, ret.Cancel = context.WithCancel(ctx)
+	}
 	ret.SaturateTimeoutsToReadAndWriteTimeouts()
 	return ret
 }

--- a/integration_tests/amqp091/test.sh
+++ b/integration_tests/amqp091/test.sh
@@ -24,7 +24,7 @@ function doTest() {
   CONTAINER_NAME="zgrab_amqp091-${MQ_VERSION}"
   OUTPUT_FILE="$ZGRAB_OUTPUT/amqp091/${MQ_VERSION}${SUFFIX}.json"
   echo "amqp091/test: Testing RabbitMQ Version ${MQ_VERSION}${SUFFIX}..."
-  CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh amqp091 $AUTH_ARGS --timeout 10s >$OUTPUT_FILE
+  CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh amqp091 $AUTH_ARGS --target-timeout 10s >$OUTPUT_FILE
   SERVER_VERSION=$(jp -u data.amqp091.result.server_properties.version <$OUTPUT_FILE)
   if [[ "$SERVER_VERSION" == "$MQ_VERSION" ]]; then
     echo "amqp091/test: Server version matches expected version: $SERVER_VERSION == $MQ_VERSION"

--- a/integration_tests/ipp/test.sh
+++ b/integration_tests/ipp/test.sh
@@ -14,7 +14,7 @@ versions="cups cups-tls"
 function test_cups() {
     echo "ipp/test: Tests runner for ipp_cups"
 
-    CONTAINER_NAME="zgrab_ipp_cups" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --timeout 3s --verbose > "$OUTPUT_ROOT/cups.json"
+    CONTAINER_NAME="zgrab_ipp_cups" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --target-timeout 3s --verbose > "$OUTPUT_ROOT/cups.json"
     # FIXME: No good reason to use a tmp file & saved file, b/c I'm not testing any failure states yet
     #CONTAINER_NAME="zgrab_ipp_cups" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --timeout 3 --verbose > out.tmp
     major=$(jp -u data.ipp.result.version_major < "$OUTPUT_ROOT/cups.json")
@@ -38,7 +38,7 @@ function test_cups() {
 function test_cups_tls() {
     echo "ipp/test: Tests runner for ipp_cups-tls"
 
-    CONTAINER_NAME="zgrab_ipp_cups-tls" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --timeout 3s --ipps --verbose > "$OUTPUT_ROOT/cups-tls.json"
+    CONTAINER_NAME="zgrab_ipp_cups-tls" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --target-timeout 3s --ipps --verbose > "$OUTPUT_ROOT/cups-tls.json"
     # FIXME: No good reason to use a tmp file & saved file, b/c I'm not testing any failure states yet
     #CONTAINER_NAME="zgrab_ipp_cups-tls" $ZGRAB_ROOT/docker-runner/docker-run.sh ipp --timeout 3 --ipps --verbose > out.tmp
     major=$(jp -u data.ipp.result.version_major < "$OUTPUT_ROOT/cups-tls.json")

--- a/integration_tests/mysql/test.sh
+++ b/integration_tests/mysql/test.sh
@@ -19,7 +19,7 @@ function doTest() {
   CONTAINER_NAME="zgrab_mysql-$MYSQL_VERSION"
   OUTPUT_FILE="$ZGRAB_OUTPUT/mysql/$MYSQL_VERSION.json"
   echo "mysql/test: Testing MySQL Version $MYSQL_VERSION..."
-  CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh mysql --timeout 10s > $OUTPUT_FILE
+  CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh mysql --target-timeout 10s > $OUTPUT_FILE
   SERVER_VERSION=$(jp -u data.mysql.result.server_version < $OUTPUT_FILE)
   if [[ "$SERVER_VERSION" == "$MYSQL_VERSION."* ]]; then
     echo "mysql/test: Server version matches expected version: $SERVER_VERSION == $MYSQL_VERSION.*"

--- a/integration_tests/ntp/test.sh
+++ b/integration_tests/ntp/test.sh
@@ -15,10 +15,10 @@ versions="openntp 4.2.6"
 function test_openntp() {
     echo "ntp/test: Tests runner for ntp_openntp"
 
-    CONTAINER_NAME="zgrab_ntp_openntp" $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s > "$OUTPUT_ROOT/openntp.json"
+    CONTAINER_NAME="zgrab_ntp_openntp" $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s > "$OUTPUT_ROOT/openntp.json"
     
     # Don't drop this in the standard output root, since it will not have status = success
-    CONTAINER_NAME="zgrab_ntp_openntp" $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s --monlist > out.tmp
+    CONTAINER_NAME="zgrab_ntp_openntp" $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s --monlist > out.tmp
     time=$(jp -u data.ntp.result.time < out.tmp)
     version=$(jp -u data.ntp.result.version < out.tmp)
     rm -f out.tmp
@@ -35,7 +35,7 @@ function test_openntp() {
 function test_bad_req() {
     code=$1
     expected_error=$2
-    CONTAINER_NAME="zgrab_ntp_4.2.6" $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s --monlist --request-code $code --skip-get-time > out.tmp
+    CONTAINER_NAME="zgrab_ntp_4.2.6" $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s --monlist --request-code $code --skip-get-time > out.tmp
     status=$(jp -u data.ntp.status < out.tmp)
     error=$(jp -u data.ntp.error < out.tmp)
     rm -f out.tmp
@@ -54,13 +54,13 @@ function test_4_2_6() {
 
     echo "ntp/test: Tests runner for ntp_4.2.6"
 
-    CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s > "$OUTPUT_ROOT/4.2.6_normal.json"
-    CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s --monlist > "$OUTPUT_ROOT/4.2.6_monlist.json"
+    CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s > "$OUTPUT_ROOT/4.2.6_normal.json"
+    CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s --monlist > "$OUTPUT_ROOT/4.2.6_monlist.json"
 
     request_codes="REQ_MON_GETLIST_1 REQ_MON_GETLIST"
     for code in $request_codes; do
-        CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s --monlist --request-code $code > "$OUTPUT_ROOT/4.2.6_$code.json"
-        CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --timeout 3s --monlist --request-code $code --skip-get-time > "$OUTPUT_ROOT/4.2.6_${code}_solo.json"
+        CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s --monlist --request-code $code > "$OUTPUT_ROOT/4.2.6_$code.json"
+        CONTAINER_NAME=$CONTAINER_NAME $ZGRAB_ROOT/docker-runner/docker-run.sh ntp --target-timeout 3s --monlist --request-code $code --skip-get-time > "$OUTPUT_ROOT/4.2.6_${code}_solo.json"
     done
 
     # Check that when the server returns with a valid error code that we return status = application-error and we forward the INFO_ERR code from the server

--- a/module.go
+++ b/module.go
@@ -230,8 +230,8 @@ type ScanFlags interface {
 type BaseFlags struct {
 	Port           uint          `short:"p" long:"port" description:"Specify port to grab on"`
 	Name           string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
-	ConnectTimeout time.Duration `long:"connect-timeout" description:"Set how long to wait for initial connection establishment (0 = no timeout)" default:"10s"`
-	TargetTimeout  time.Duration `short:"t" long:"target-timeout" description:"Set how long a scan of a single target (IP, Domain, etc) should take (0 = no timeout)" default:"60s"`
+	ConnectTimeout time.Duration `long:"connect-timeout" description:"Set max for how long to wait for initial connection establishment (0 = no timeout)" default:"10s"`
+	TargetTimeout  time.Duration `short:"t" long:"target-timeout" description:"Set max for how long a scan of a single target (IP, Domain, etc) can take (0 = no timeout)" default:"60s"`
 	Trigger        string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
 }
 

--- a/module.go
+++ b/module.go
@@ -230,8 +230,8 @@ type ScanFlags interface {
 type BaseFlags struct {
 	Port           uint          `short:"p" long:"port" description:"Specify port to grab on"`
 	Name           string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
-	ConnectTimeout time.Duration `short:"t" long:"connect-timeout" description:"Set how long to wait for initial connection establishment (0 = no timeout)" default:"10s"`
-	TargetTimeout  time.Duration `long:"target-timeout" description:"Set how long a scan of a single target (IP, Domain, etc) should take (0 = no timeout)" default:"60s"`
+	ConnectTimeout time.Duration `long:"connect-timeout" description:"Set how long to wait for initial connection establishment (0 = no timeout)" default:"10s"`
+	TargetTimeout  time.Duration `short:"t" long:"target-timeout" description:"Set how long a scan of a single target (IP, Domain, etc) should take (0 = no timeout)" default:"60s"`
 	Trigger        string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
 }
 

--- a/module.go
+++ b/module.go
@@ -228,10 +228,11 @@ type ScanFlags interface {
 
 // BaseFlags contains the options that every flags type must embed
 type BaseFlags struct {
-	Port    uint          `short:"p" long:"port" description:"Specify port to grab on"`
-	Name    string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
-	Timeout time.Duration `short:"t" long:"timeout" description:"Set connection timeout (0 = no timeout)" default:"10s"`
-	Trigger string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
+	Port           uint          `short:"p" long:"port" description:"Specify port to grab on"`
+	Name           string        `short:"n" long:"name" description:"Specify name for output json, only necessary if scanning multiple modules"`
+	ConnectTimeout time.Duration `short:"t" long:"connect-timeout" description:"Set how long to wait for initial connection establishment (0 = no timeout)" default:"10s"`
+	TargetTimeout  time.Duration `long:"target-timeout" description:"Set how long a scan of a single target (IP, Domain, etc) should take (0 = no timeout)" default:"60s"`
+	Trigger        string        `short:"g" long:"trigger" description:"Invoke only on targets with specified tag"`
 }
 
 // GetName returns the name of the respective scanner

--- a/modules/http/http_readlimit_test.go
+++ b/modules/http/http_readlimit_test.go
@@ -176,7 +176,7 @@ func (cfg *readLimitTestConfig) getScanner(t *testing.T) *Scanner {
 	}
 	flags.MaxSize = cfg.maxBodySize / 1024
 	flags.MaxRedirects = 0
-	flags.Timeout = 1 * time.Second
+	flags.ConnectTimeout = 1 * time.Second
 	flags.Port = uint(cfg.port)
 	flags.UseHTTPS = cfg.tls
 	zgrab2.DefaultBytesReadLimit = cfg.maxReadSize
@@ -393,8 +393,8 @@ func (cfg *readLimitTestConfig) runTest(t *testing.T, testName string) {
 		Port: uint(cfg.port),
 	}
 	baseFlags := &zgrab2.BaseFlags{
-		Port:    80,
-		Timeout: time.Second * 10,
+		Port:           80,
+		ConnectTimeout: time.Second * 10,
 	}
 	tlsFlags := &zgrab2.TLSFlags{}
 	dialerGroupConfig := zgrab2.DialerGroupConfig{

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -383,8 +383,8 @@ func (scanner *Scanner) newHTTPScan(ctx context.Context, t *zgrab2.ScanTarget, u
 		},
 		client: http.MakeNewClient(),
 	}
-	if scanner.config.Timeout != 0 {
-		ret.globalDeadline = time.Now().Add(scanner.config.Timeout)
+	if scanner.config.TargetTimeout != 0 {
+		ret.globalDeadline = time.Now().Add(scanner.config.TargetTimeout)
 	}
 	ret.transport.DialTLS = func(network, addr string) (net.Conn, error) {
 		ctx = ret.withDeadlineContext(ctx)
@@ -408,7 +408,7 @@ func (scanner *Scanner) newHTTPScan(ctx context.Context, t *zgrab2.ScanTarget, u
 	ret.client.CheckRedirect = ret.getCheckRedirect()
 	ret.client.Transport = ret.transport
 	ret.client.Jar = nil // Don't send or receive cookies (otherwise use CookieJar)
-	ret.client.Timeout = scanner.config.Timeout
+	ret.client.Timeout = scanner.config.ConnectTimeout
 	if deadline, ok := ctx.Deadline(); ok {
 		ret.client.Timeout = min(ret.client.Timeout, deadline.Sub(time.Now()))
 	}

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -277,6 +277,9 @@ func (scan *scan) Cleanup() {
 // Get a context whose deadline is the earliest of the context's deadline (if it has one) and the
 // global scan deadline.
 func (scan *scan) withDeadlineContext(ctx context.Context) context.Context {
+	if scan.globalDeadline.IsZero() {
+		return ctx
+	}
 	ctxDeadline, ok := ctx.Deadline()
 	if !ok || scan.globalDeadline.Before(ctxDeadline) {
 		ret, _ := context.WithDeadline(ctx, scan.globalDeadline)
@@ -408,7 +411,6 @@ func (scanner *Scanner) newHTTPScan(ctx context.Context, t *zgrab2.ScanTarget, u
 	ret.client.CheckRedirect = ret.getCheckRedirect()
 	ret.client.Transport = ret.transport
 	ret.client.Jar = nil // Don't send or receive cookies (otherwise use CookieJar)
-	ret.client.Timeout = scanner.config.ConnectTimeout
 	if deadline, ok := ctx.Deadline(); ok {
 		ret.client.Timeout = min(ret.client.Timeout, deadline.Sub(time.Now()))
 	}

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -697,7 +697,7 @@ func (scanner *Scanner) tryGrabForVersions(ctx context.Context, target *zgrab2.S
 		MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 	}
 	transport.DialTLS = newScan.getTLSDialer(ctx, target, dialGroup)
-	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.ConnectTimeout).DialContext
+	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.ConnectTimeout, scanner.config.TargetTimeout).DialContext
 	newScan.client.CheckRedirect = newScan.getCheckRedirect(scanner)
 	newScan.client.UserAgent = scanner.config.UserAgent
 	newScan.client.Transport = transport

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -697,7 +697,7 @@ func (scanner *Scanner) tryGrabForVersions(ctx context.Context, target *zgrab2.S
 		MaxIdleConnsPerHost: scanner.config.MaxRedirects,
 	}
 	transport.DialTLS = newScan.getTLSDialer(ctx, target, dialGroup)
-	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.Timeout).DialContext
+	transport.DialContext = zgrab2.GetTimeoutConnectionDialer(scanner.config.ConnectTimeout).DialContext
 	newScan.client.CheckRedirect = newScan.getCheckRedirect(scanner)
 	newScan.client.UserAgent = scanner.config.UserAgent
 	newScan.client.Transport = transport

--- a/modules/jarm/scanner.go
+++ b/modules/jarm/scanner.go
@@ -117,6 +117,9 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 
 	// Loop through each Probe type
 	for _, probe := range jarm.GetProbes(target.Host(), int(scanner.GetPort())) {
+		if zgrab2.HasCtxExpired(ctx) {
+			return zgrab2.SCAN_IO_TIMEOUT, nil, errors.New("scan timed out")
+		}
 		var (
 			conn net.Conn
 			err  error

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -103,7 +103,7 @@ func (s *SSHScanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t 
 	rhost := net.JoinHostPort(t.Host(), portStr)
 
 	sshConfig := ssh.MakeSSHConfig()
-	sshConfig.Timeout = s.config.Timeout
+	sshConfig.Timeout = s.config.ConnectTimeout
 	sshConfig.ConnLog = data
 	sshConfig.ClientVersion = s.config.ClientID
 	sshConfig.HelloOnly = s.config.HelloOnly
@@ -134,8 +134,8 @@ func (s *SSHScanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t 
 		err = fmt.Errorf("failed to dial target %s: %w", t.String(), err)
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
-	if s.config.Timeout != 0 {
-		err = conn.SetDeadline(time.Now().Add(s.config.Timeout))
+	if s.config.ConnectTimeout != 0 {
+		err = conn.SetDeadline(time.Now().Add(s.config.ConnectTimeout))
 		if err != nil {
 			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("failed to set connection deadline: %w", err)
 		}

--- a/modules/telnet/telnet.go
+++ b/modules/telnet/telnet.go
@@ -100,7 +100,7 @@ func GetTelnetBanner(logStruct *TelnetLog, conn net.Conn, maxReadSize int) (err 
 	}
 	// Keep reading until READ_BUFFER_LENGTH chunks until
 	// 	(a) a read takes longer than 500ms
-	//  (b) the combined reads take longer than the configured timeout for the connection (--timeout command line flag)
+	//  (b) the combined reads take longer than the configured timeout for the connection (--target-timeout command line flag)
 	//  (c) the banner is maxReadSize bytes long [taking into account the fact that logStruct.Banner may already have some data from NegotiateOptions]
 	bannerSlice, err := zgrab2.ReadAvailableWithOptions(conn, READ_BUFFER_LENGTH, 500*time.Millisecond, 0, maxReadSize-len(logStruct.Banner))
 	if bannerSlice != nil {

--- a/processing.go
+++ b/processing.go
@@ -61,7 +61,7 @@ func (target *ScanTarget) Host() string {
 // GetDefaultTCPDialer returns a TCP dialer suitable for modules with default TCP behavior
 func GetDefaultTCPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	// create dialer once and reuse it
-	dialer := GetTimeoutConnectionDialer(flags.Timeout)
+	dialer := GetTimeoutConnectionDialer(flags.ConnectTimeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 		// If the scan is for a specific IP, and a domain name is provided, we
 		// don't want to just let the http library resolve the domain.  Create
@@ -146,7 +146,7 @@ func GetDefaultTLSWrapper(tlsFlags *TLSFlags) func(ctx context.Context, t *ScanT
 // GetDefaultUDPDialer returns a UDP dialer suitable for modules with default UDP behavior
 func GetDefaultUDPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	// create dialer once and reuse it
-	dialer := GetTimeoutConnectionDialer(flags.Timeout)
+	dialer := GetTimeoutConnectionDialer(flags.ConnectTimeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 		err := dialer.SetRandomLocalAddr("udp", config.localAddrs, config.localPorts)
 		if err != nil {

--- a/processing.go
+++ b/processing.go
@@ -61,7 +61,7 @@ func (target *ScanTarget) Host() string {
 // GetDefaultTCPDialer returns a TCP dialer suitable for modules with default TCP behavior
 func GetDefaultTCPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	// create dialer once and reuse it
-	dialer := GetTimeoutConnectionDialer(flags.ConnectTimeout)
+	dialer := GetTimeoutConnectionDialer(flags.ConnectTimeout, flags.TargetTimeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 		// If the scan is for a specific IP, and a domain name is provided, we
 		// don't want to just let the http library resolve the domain.  Create
@@ -146,7 +146,7 @@ func GetDefaultTLSWrapper(tlsFlags *TLSFlags) func(ctx context.Context, t *ScanT
 // GetDefaultUDPDialer returns a UDP dialer suitable for modules with default UDP behavior
 func GetDefaultUDPDialer(flags *BaseFlags) func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 	// create dialer once and reuse it
-	dialer := GetTimeoutConnectionDialer(flags.ConnectTimeout)
+	dialer := GetTimeoutConnectionDialer(flags.ConnectTimeout, flags.TargetTimeout)
 	return func(ctx context.Context, t *ScanTarget, addr string) (net.Conn, error) {
 		err := dialer.SetRandomLocalAddr("udp", config.localAddrs, config.localPorts)
 		if err != nil {

--- a/scanner.go
+++ b/scanner.go
@@ -66,6 +66,10 @@ func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanRespons
 		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusSuccess}
 		err = nil
 	} else {
+		if deadline, ok := ctx.Deadline(); ok && deadline.Before(time.Now()) {
+			// scan timed out
+			e = fmt.Errorf("ctx deadline exceeded: %w", e)
+		}
 		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusFailure}
 		errString := e.Error()
 		err = &errString

--- a/scanner.go
+++ b/scanner.go
@@ -57,9 +57,13 @@ func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanRespons
 	if target.Port == 0 {
 		target.Port = dialerGroupConfig.BaseFlags.Port
 	}
-
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(dialerGroupConfig.BaseFlags.TargetTimeout))
-	defer cancel()
+	ctx := context.Background()
+	if dialerGroupConfig.BaseFlags.TargetTimeout > 0 {
+		// timeout is set, use it on the context
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(dialerGroupConfig.BaseFlags.TargetTimeout))
+		defer cancel()
+	}
 	status, res, e := s.Scan(ctx, dialerGroup, &target)
 	var err *string
 	if e == nil {

--- a/scanner.go
+++ b/scanner.go
@@ -58,7 +58,9 @@ func RunScanner(s Scanner, mon *Monitor, target ScanTarget) (string, ScanRespons
 		target.Port = dialerGroupConfig.BaseFlags.Port
 	}
 
-	status, res, e := s.Scan(context.Background(), dialerGroup, &target)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(dialerGroupConfig.BaseFlags.TargetTimeout))
+	defer cancel()
+	status, res, e := s.Scan(ctx, dialerGroup, &target)
 	var err *string
 	if e == nil {
 		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusSuccess}

--- a/utility.go
+++ b/utility.go
@@ -1,6 +1,7 @@
 package zgrab2
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -269,5 +270,15 @@ func CloseConnAndHandleError(conn net.Conn) {
 	err := conn.Close()
 	if err != nil {
 		logrus.Errorf("could not close connection to %v: %v", conn.RemoteAddr(), err)
+	}
+}
+
+// HasCtxExpired checks if the context has expired. Common function used in various places.
+func HasCtxExpired(ctx context.Context) bool {
+	select {
+	case <-(ctx).Done():
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
More info on how `master` behaves before this branch is available in the linked issue.

This PR changes the existing `--timeout` flag that strictly set timeouts on how to wait for a response to a dialed connection to two separate timeouts:

```shell
          --connect-timeout=  Set max for how long to wait for initial connection establishment (0 = no timeout) (default: 10s)
      -t, --target-timeout=   Set max for how long a scan of a single target (IP, Domain, etc) can take (0 = no timeout) (default: 60s)

```

## How to Test

I'd earlier found a server that will establish a TCP connection but not respond to a TLS handshake. A JARM probe on `master` times out after 10 mins, the previous default non-user-modifiable timeout for a target.

This branch:
```shell
~/zgrab on  phillip/526-timeouts! ⌚ 21:01:50
$ echo "152.30.130.29" | ./zgrab2 jarm -p 443
INFO[0000] started grab at 2025-04-30T21:01:51Z
00h:00m:01s; 0 targets scanned; 0.00 targets/sec; 0.0% success rate
00h:00m:02s; 0 targets scanned; 0.00 targets/sec; 0.0% success rate
...
00h:01m:00s; 0 targets scanned; 0.00 targets/sec; 0.0% success rate
{"ip":"152.30.130.29","data":{"jarm":{"status":"unknown-error","protocol":"jarm","timestamp":"2025-04-30T21:01:51Z","error":"ctx deadline exceeded: could not dial target 152.30.130.29: dial context failed: dial tcp :0-\u003e152.30.130.29:443: i/o timeout"}}}
INFO[0060] finished grab at 2025-04-30T21:02:51Z
00h:01m:00s; Scan Complete; 1 targets scanned; 0.02 targets/sec; 0.0% success rate
{"statuses":{"jarm":{"successes":0,"failures":1}},"start":"2025-04-30T21:01:51Z","end":"2025-04-30T21:02:51Z","duration":"1m0.005287169s"}
```



## Issue Tracking

Resolves #526