### PR TITLE
Downgrade to using v7 of redis, since v8 is buggy right now

### DIFF
--- a/integration_tests/redis/container/Dockerfile
+++ b/integration_tests/redis/container/Dockerfile
@@ -1,2 +1,2 @@
-FROM redis
+FROM redis:7
 COPY *.conf /usr/local/etc/redis/


### PR DESCRIPTION
Noticed recently that the integration tests have all of a sudden starting failing on `master`, specifically on the `Redis` container.

It looks like redisv8 is under active development and v7 is the [latest released version](https://redis.io/docs/latest/operate/rs/release-notes/), so I'll pin that version.

