### PR TITLE
Improve IP capability detection performance and over VPNs

### DIFF
--- a/config.go
+++ b/config.go
@@ -216,7 +216,7 @@ func validateFrameworkConfiguration() {
 			}
 		}
 		if !config.useIPv4 && !config.useIPv6 {
-			log.Fatalf("could not reach one.one.one.one by either IPv4/v6 to detect IP capability, are you connected to the internet?")
+			log.Fatalf("could not reach one.one.one.one by either IPv4/IPv6 to detect IP capability, are you connected to the internet?")
 		}
 	}
 


### PR DESCRIPTION
Changes

- Detect IPv4 and v6 host capability in parallel rather than sequentially
- Attempt connection to port 80 rather than port 53, should be more resilient to VPN's forcing us to use certain DNS servers

## How to Test
 Using the below, this hangs for 2 min. on `master` with VPN enabled (Mullvad tested)
```shell
echo "example.com" | ./zgrab2 http
```

It no longer hangs with this change.

## Notes & Caveats

Prior to this change, we attempted to detect IPv4 and IPv6 capability by connecting to cloudflare's DNS over v4 and v6 sequentially and with the default Dial timeout of 1 min. That meant in the worst case, the user's terminal hung for 2 mins while we attempted to detect capability. This change lowers the timeout to 10s, connects in parallel, and switches to connecting to port 80, since VPNs that mess with DNS wouldn't let us connect to 1.1.1.1:53 over UDP.

Found this issue the hard way when developing while having Mullvad VPN up and running. ZGrab seemed fully unresponsive and narrowed it down to our IP capability detection. Mullvad was doing some DNS modifications and forcing DNS to all route to their server IP, which meant attempting to directly connect to Cloudflare's would just hang (ie: `dig example.com @1.1.1.1`)

Using DNS seems more prone to VPNs mucking around with it and we just require a known open port on the destination to get IP capability, so switched to port 80.

