### PR TITLE
[bug-fix] - Fix not including the body of a re-directed HTTP request

### DIFF
--- a/integration_tests/http/container/Dockerfile
+++ b/integration_tests/http/container/Dockerfile
@@ -14,6 +14,9 @@ COPY index-http.html index.html
 COPY favicon.ico favicon.ico
 RUN curl https://gist.githubusercontent.com/phillip-stephens/3f1a8d2874b4ff33e4fc46035810b7f9/raw/5bd8ed7fb1b923607c26807ea8ea0643825e6e16/index-very-large-http.html > large.html
 
+COPY index-redirect.html index-redirect.html
+COPY index-redirect-2.html index-redirect-2.html
+
 WORKDIR /var/lighttpd/htdocs/https
 COPY index-https.html index.html
 

--- a/integration_tests/http/container/index-redirect-2.html
+++ b/integration_tests/http/container/index-redirect-2.html
@@ -1,0 +1,1 @@
+<html><body>HTTP REDIRECT 2 INDEX</body></html>

--- a/integration_tests/http/container/index-redirect.html
+++ b/integration_tests/http/container/index-redirect.html
@@ -1,0 +1,1 @@
+<html><body>HTTP REDIRECT INDEX</body></html>

--- a/integration_tests/http/container/lighttpd.conf
+++ b/integration_tests/http/container/lighttpd.conf
@@ -44,3 +44,7 @@ $SERVER["socket"] == "0.0.0.0:443" {
   # server.name = "your.domain.com"
   server.document-root = var.confdir + "/htdocs/https"
 }
+
+$HTTP["url"] == "/index-redirect.html" {
+  url.redirect = ( "" => "/index-redirect-2.html" )
+}

--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -49,6 +49,68 @@ def test_basic_http():
     )
 
 
+def test_http_with_redirect():
+    print("http/test: Run http test in default port (should be 80)")
+    cmd = f"CONTAINER_NAME={container_name} {zgrab_root}/docker-runner/docker-run.sh http --endpoint=/index-redirect.html"
+    actual_content = run_command(
+        cmd,
+        output_file=os.path.join(output_root, "http-no-follow-redirect.json"),
+    )
+    # Check scan is successful but status code is 301, location header set to /index-redirect-2.html
+    response = json.loads(actual_content)
+    status_code = (
+        response.get("data", {})
+        .get("http", {})
+        .get("result", {})
+        .get("response", {})
+        .get("status_code")
+    )
+    assert (
+        status_code == 301
+    ), f"Expected status code 301 since we aren't following re-directs, got {status_code}"
+    location = (
+        response.get("data", {})
+        .get("http", {})
+        .get("result", {})
+        .get("response", {})
+        .get("headers", {})
+        .get("location")
+    )
+    assert (
+        location[0] == "/index-redirect-2.html"
+    ), f"Expected Location header to be /index-redirect-2.html, got {location}"
+
+    # Now run the same command but with redirects
+    cmd += " --max-redirects=1"
+    actual_content = run_command(
+        cmd,
+        output_file=os.path.join(output_root, "http-follow-redirect.json"),
+    )
+    # Check scan is successful and status code is 200, location header set to /index-redirect-2.html
+    response = json.loads(actual_content)
+    status_code = (
+        response.get("data", {})
+        .get("http", {})
+        .get("result", {})
+        .get("response", {})
+        .get("status_code")
+    )
+    assert (
+        status_code == 200
+    ), f"Expected status code 200 after following re-directs, got {status_code}"
+    actual_body = (
+        response.get("data", {})
+        .get("http", {})
+        .get("result", {})
+        .get("response", {})
+        .get("body")
+    )
+    expected_body = "<html><body>HTTP REDIRECT 2 INDEX</body></html>"
+    assert (
+        actual_body == expected_body
+    ), f"Expected body to be '{expected_body}', got '{actual_body}'"
+
+
 def test_basic_https():
     print("http/test: Run https test on port 443")
     run_command(

--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -109,6 +109,11 @@ def test_http_with_redirect():
     assert (
         actual_body == expected_body
     ), f"Expected body to be '{expected_body}', got '{actual_body}'"
+    # Check that the referring request is documented
+    actual_referrer_chain = (response.get("data", {}).get("http", {}).get("result", {}).get("redirect_response_chain", {}))
+    assert len(actual_referrer_chain) == 1, f"Expected 1 redirect response, got {len(actual_referrer_chain)}"
+    # check the referring request location is set
+    assert actual_referrer_chain[0].get("headers").get("location")[0] == "/index-redirect-2.html", f"Expected referring request location to be '/index-redirect-2.html', got {actual_referrer_chain[0].get('headers').get('location')[0]}"
 
 
 def test_basic_https():

--- a/lib/http/client.go
+++ b/lib/http/client.go
@@ -597,6 +597,13 @@ func (c *Client) Do(req *Request) (resp *Response, err error) {
 			}
 			return nil, uerr(err)
 		}
+
+		var shouldRedirect bool
+		redirectMethod, shouldRedirect, includeBody = redirectBehavior(req.Method, resp, reqs[0])
+		if !shouldRedirect {
+			return resp, nil
+		}
+
 		err = c.checkRedirect(req, resp, reqs)
 
 		// Sentinel error to let users select the
@@ -612,12 +619,6 @@ func (c *Client) Do(req *Request) (resp *Response, err error) {
 			ue := uerr(err)
 			ue.(*url.Error).URL = loc
 			return resp, err
-		}
-
-		var shouldRedirect bool
-		redirectMethod, shouldRedirect, includeBody = redirectBehavior(req.Method, resp, reqs[0])
-		if !shouldRedirect {
-			return resp, nil
 		}
 
 		req.closeBody()


### PR DESCRIPTION
Fixes a bug where when following re-directs, the `body_text` was not being output.

## Root Cause
Traced this to commit [8981](https://github.com/zmap/zgrab2/commit/898141778c2aa3c0818befee82beca000b3c03ad), specifically [here](https://github.com/zmap/zgrab2/commit/898141778c2aa3c0818befee82beca000b3c03ad#diff-dddc8e7eb09019004b9ea48a345b3fb794995c7b661e5e2aa0494d56d6ce7bd3R536-R600).

The fix is to first check if we _should_ follow the re-direct, and then check the redirect. Something in `checkRedirect` was messing up the buffer we read the `body_text` from.

## Integration Tests
Added a test for `http` redirects to our integration tests. Confirmed it did not pass prior to this change and passes now.

## How to Test
This fails on `master` to retrieve the `body_text`, but works on this branch:
```shell
echo "prstephens.com" | zgrab2 http --max-redirects=1 | jq ".data.http.result.response.body"
```


