### PR TITLE
Have default make target build, not install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ uninstall:
 	fi
 
 setup-config:
-	@echo "Setting up zgrab2 configuration directory at $(CONFIG_DIR) and installing ZGrab2"
+	@echo "Setting up zgrab2 configuration directory at $(CONFIG_DIR)"
 # Make sure the config directory exists
 	mkdir -p $(CONFIG_DIR)
 # Copy the default config file if it doesn't exist

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 GO_FILES = $(shell find . -type f -name '*.go')
 TEST_MODULES ?=
-.DEFAULT_GOAL := install
+.DEFAULT_GOAL := zgrab2
 
 all: zgrab2
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Replace `/path/to/your/config.ini` with the path to your configuration file on t
 ### Building from Source
 
 ZGrab2 requires Go 1.23 or later to build from source.
+If you run into issues with `command not found: zgrab2`, ensure that your `$GOPATH/bin` is in your `PATH` environment variable.
+Add the following line to your shell configuration file (e.g., `~/.bashrc`, `~/.zshrc`):
+```shell
+export PATH=$PATH:$GOPATH/bin
+```
 
 ```shell
 git clone https://github.com/zmap/zgrab2.git
@@ -46,7 +51,7 @@ export GOTOOLCHAIN=auto
 git clone https://github.com/zmap/zgrab2.git
 cd zgrab2
 make install # Go will download the required 1.23 toolchain automatically
-./zgrab2 http --help # to see the http module's help message
+zgrab2 http --help # to see the http module's help message
 ```
 
 ## Single Module Usage 


### PR DESCRIPTION
Makes the default behavior of `make` only build. This is more canonical and we still offer `make install` as an option. This forces the user to be explicit if they want to install binaries to their computer, otherwise we'll build locally in the same directory.

This reverts an earlier change I made to have `make` refer to `make install` by default. 

