### PR TITLE
feat(http): add `SkipHost` request option

### DIFF
--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -69,6 +69,7 @@ type Flags struct {
 	CustomHeadersNames     string `long:"custom-headers-names" description:"CSV of custom HTTP headers to send to server"`
 	CustomHeadersValues    string `long:"custom-headers-values" description:"CSV of custom HTTP header values to send to server. Should match order of custom-headers-names."`
 	CustomHeadersDelimiter string `long:"custom-headers-delimiter" description:"Delimiter for customer header name/value CSVs"`
+	SkipHost               bool   `long:"skip-host" description:"Skip encoding the Host header"`
 
 	OverrideSH bool `long:"override-sig-hash" description:"Override the default SignatureAndHashes TLS option with more expansive default"`
 
@@ -490,6 +491,8 @@ func (scan *scan) Grab() *zgrab2.ScanError {
 	if err != nil {
 		return zgrab2.NewScanError(zgrab2.SCAN_UNKNOWN_ERROR, err)
 	}
+
+	request.SkipHost = scan.scanner.config.SkipHost
 
 	// By default, the following headers are *always* set:
 	// Host, User-Agent, Accept, Accept-Encoding


### PR DESCRIPTION
Adds a `SkipHost` option in `http.Request`. This skips encoding the host header, which is against the standard, but can be useful for some servers that immediately close the connection (without issuing any response) if the host header is not recognized.

## How to Test

Find a known HTTP server that returns an EOF error during scanning with no data received. Then issue an HTTP request with `SkipHost: true` and confirm that a 400 is returned.

## Notes & Caveats

This is a messy way of handling things, but some information is better than nothing at all unfortunately.

## Issue Tracking
