### PR TITLE
replace blocked cloudflare.com test with working domain

### DIFF
--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -188,7 +188,7 @@ def test_large_http_body_contents():
 # Uses the dockerized zgrab to ensure that scanning real domains returns a 200 OK
 def test_scanning_real_domains():
     domains = [
-        "apnews.com",
+        "docker.io",
         "github.com",
         "en.wikipedia.org",
     ]

--- a/integration_tests/http/test.py
+++ b/integration_tests/http/test.py
@@ -188,7 +188,7 @@ def test_large_http_body_contents():
 # Uses the dockerized zgrab to ensure that scanning real domains returns a 200 OK
 def test_scanning_real_domains():
     domains = [
-        "cloudflare.com",
+        "apnews.com",
         "github.com",
         "en.wikipedia.org",
     ]


### PR DESCRIPTION
Looks like Cloudflare starting blocking scans with ZGrab to their domain with `403 Forbidden`, so swapping `cloudflare.com` -> `docker.io`.

Fixes the integration tests failing on `master`

