### PR TITLE
Normalize scanning module variable usage

### DIFF
--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -218,7 +218,7 @@ func (scanner *Scanner) GetName() string {
 }
 
 // Protocol returns the protocol identifer for the scanner.
-func (s *Scanner) Protocol() string {
+func (scanner *Scanner) Protocol() string {
 	return "mongodb"
 }
 

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -188,13 +188,13 @@ func (f *Flags) Help() string {
 }
 
 // Init initializes the Scanner with the command-line flags.
-func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
-	s.config = f
+	scanner.config = f
 	if f.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}
-	s.dialerGroupConfig = &zgrab2.DialerGroupConfig{
+	scanner.dialerGroupConfig = &zgrab2.DialerGroupConfig{
 		TransportAgnosticDialerProtocol: zgrab2.TransportTCP,
 		NeedSeparateL4Dialer:            true,
 		BaseFlags:                       &f.BaseFlags,
@@ -205,12 +205,12 @@ func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 }
 
 // InitPerSender does nothing in this module.
-func (s *Scanner) InitPerSender(senderID int) error {
+func (scanner *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
 // Protocol returns the protocol identifer for the scanner.
-func (s *Scanner) Protocol() string {
+func (scanner *Scanner) Protocol() string {
 	return "mysql"
 }
 
@@ -219,13 +219,13 @@ func (scanner *Scanner) GetDialerGroupConfig() *zgrab2.DialerGroupConfig {
 }
 
 // GetName returns the name from the command line flags.
-func (s *Scanner) GetName() string {
-	return s.config.Name
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
 }
 
 // GetTrigger returns the Trigger defined in the Flags.
-func (s *Scanner) GetTrigger() string {
-	return s.config.Trigger
+func (scanner *Scanner) GetTrigger() string {
+	return scanner.config.Trigger
 }
 
 // Scan probles the target for a MySQL server.
@@ -233,7 +233,7 @@ func (s *Scanner) GetTrigger() string {
 //  2. If the server supports SSL, send an SSLRequest packet, then
 //     perform the standard TLS actions.
 //  3. Process and return the results.
-func (s *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (status zgrab2.ScanStatus, result any, thrown error) {
+func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	// check for necessary dialers
 	l4Dialer := dialGroup.L4Dialer
 	if l4Dialer == nil {
@@ -241,38 +241,36 @@ func (s *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zg
 	}
 	sql := mysql.NewConnection(&mysql.Config{})
 	defer func() {
-		result = readResultsFromConnectionLog(&sql.ConnectionLog)
+		result := readResultsFromConnectionLog(&sql.ConnectionLog)
 		// attempt to capture TLS log
 		if tlsConn, ok := sql.Connection.(*zgrab2.TLSConnection); ok {
-			if scanResults, ok := result.(*ScanResults); ok {
-				scanResults.TLSLog = tlsConn.GetLog()
-			}
+			result.TLSLog = tlsConn.GetLog()
 		}
 		err := sql.Disconnect()
 		if err != nil {
-			log.Errorf("error disconnecting from target %s: %v", t.String(), err)
+			log.Errorf("error disconnecting from target %s: %v", target.String(), err)
 		}
 	}()
 	var err error
 	var tlsConn *zgrab2.TLSConnection
 
-	conn, err := l4Dialer(t)(ctx, "tcp", net.JoinHostPort(t.Host(), strconv.Itoa(int(t.Port))))
+	conn, err := l4Dialer(target)(ctx, "tcp", net.JoinHostPort(target.Host(), strconv.Itoa(int(target.Port))))
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error dialing target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error dialing target %s: %w", target.String(), err)
 	}
 	if err = sql.Connect(conn); err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error connecting to target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error connecting to target %s: %w", target.String(), err)
 	}
 	if sql.SupportsTLS() {
 		if err = sql.NegotiateTLS(); err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error negotiating TLS for target %s: %w", t.String(), err)
+			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error negotiating TLS for target %s: %w", target.String(), err)
 		}
 		tlsWrapper := dialGroup.TLSWrapper
 		if tlsWrapper == nil {
 			return zgrab2.SCAN_PROTOCOL_ERROR, nil, errors.New("TLS wrapper required for mysql")
 		}
-		if tlsConn, err = tlsWrapper(ctx, t, conn); err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping connection in TLS for target %s: %w", t.String(), err)
+		if tlsConn, err = tlsWrapper(ctx, target, conn); err != nil {
+			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
 		}
 		// Replace sql.Connection to allow hypothetical future calls to go over the secure connection
 		sql.Connection = tlsConn

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -998,10 +998,10 @@ func (scanner *Scanner) GetTime(sock net.Conn) (*NTPHeader, error) {
 // a valid NTP packet, then the result will be nil.
 // The presence of a DDoS-amplifying target can be inferred by
 // result.MonListReponse being present.
-func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
-	sock, err := dialGroup.Dial(ctx, t)
+func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
+	sock, err := dialGroup.Dial(ctx, target)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("could not connect to target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("could not connect to target %s: %w", target.String(), err)
 	}
 	defer zgrab2.CloseConnAndHandleError(sock)
 	result := &Results{}

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -230,12 +230,12 @@ func (scanner *Scanner) getTNSDriver() *TNSDriver {
 //     into the results, then send a Native Security Negotiation Data packet.
 //  8. If the response is not a Data packet, exit with SCAN_APPLICATION_ERROR.
 //  9. Pull the versions out of the response and exit with SCAN_SUCCESS.
-func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
+func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	results := new(ScanResults)
 
-	sock, err := dialGroup.Dial(ctx, t)
+	sock, err := dialGroup.Dial(ctx, target)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("could not connect to target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("could not connect to target %s: %w", target.String(), err)
 	}
 	if tlsConn, ok := sock.(*zgrab2.TLSConnection); ok {
 		results.TLSLog = tlsConn.GetLog()
@@ -244,7 +244,7 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	conn := Connection{
 		conn:      sock,
 		scanner:   scanner,
-		target:    t,
+		target:    target,
 		tnsDriver: scanner.getTNSDriver(),
 	}
 	connectDescriptor := scanner.config.ConnectDescriptor

--- a/modules/pptp/scanner.go
+++ b/modules/pptp/scanner.go
@@ -156,11 +156,11 @@ func (pptp *Connection) readResponse() (string, error) {
 }
 
 // Scan performs the configured scan on the PPTP server
-func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
+func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	var err error
-	conn, err := dialGroup.Dial(ctx, t)
+	conn, err := dialGroup.Dial(ctx, target)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error opening connection to target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error opening connection to target %s: %w", target.String(), err)
 	}
 	defer zgrab2.CloseConnAndHandleError(conn)
 
@@ -172,13 +172,13 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	request := createSCCRMessage()
 	_, err = pptp.conn.Write(request)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), &pptp.results, fmt.Errorf("error sending PPTP SCCR message to target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), &pptp.results, fmt.Errorf("error sending PPTP SCCR message to target %s: %w", target.String(), err)
 	}
 
 	// Read the response
 	response, err := pptp.readResponse()
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), &pptp.results, fmt.Errorf("error reading PPTP response from target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), &pptp.results, fmt.Errorf("error reading PPTP response from target %s: %w", target.String(), err)
 	}
 
 	// Store the banner and control message

--- a/modules/socks5/scanner.go
+++ b/modules/socks5/scanner.go
@@ -82,7 +82,7 @@ func (f *Flags) Help() string {
 }
 
 // Protocol returns the protocol identifier for the scanner.
-func (s *Scanner) Protocol() string {
+func (scanner *Scanner) Protocol() string {
 	return "socks5"
 }
 
@@ -91,10 +91,10 @@ func (scanner *Scanner) GetDialerGroupConfig() *zgrab2.DialerGroupConfig {
 }
 
 // Init initializes the Scanner instance with the flags from the command line.
-func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
+func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
-	s.config = f
-	s.dialerGroupConfig = &zgrab2.DialerGroupConfig{
+	scanner.config = f
+	scanner.dialerGroupConfig = &zgrab2.DialerGroupConfig{
 		TransportAgnosticDialerProtocol: zgrab2.TransportTCP,
 		BaseFlags:                       &f.BaseFlags,
 	}
@@ -102,13 +102,13 @@ func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 }
 
 // InitPerSender does nothing in this module.
-func (s *Scanner) InitPerSender(senderID int) error {
+func (scanner *Scanner) InitPerSender(senderID int) error {
 	return nil
 }
 
 // GetName returns the configured name for the Scanner.
-func (s *Scanner) GetName() string {
-	return s.config.Name
+func (scanner *Scanner) GetName() string {
+	return scanner.config.Name
 }
 
 // GetTrigger returns the Trigger defined in the Flags.
@@ -235,16 +235,16 @@ func (conn *Connection) PerformConnectionRequest() error {
 }
 
 // Scan performs the configured scan on the SOCKS5 server.
-func (s *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (status zgrab2.ScanStatus, result any, thrown error) {
+func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	var have_auth bool
-	conn, err := dialGroup.Dial(ctx, t)
+	conn, err := dialGroup.Dial(ctx, target)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error opening connection to %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error opening connection to %s: %w", target.String(), err)
 	}
 	defer zgrab2.CloseConnAndHandleError(conn)
 
 	results := ScanResults{}
-	socks5Conn := Connection{conn: conn, config: s.config, results: results}
+	socks5Conn := Connection{conn: conn, config: scanner.config, results: results}
 
 	have_auth, err = socks5Conn.PerformHandshake()
 	if err != nil {

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -98,10 +98,10 @@ func (s *SSHScanner) GetTrigger() string {
 	return s.config.Trigger
 }
 
-func (s *SSHScanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
+func (s *SSHScanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	data := new(ssh.HandshakeLog)
-	portStr := strconv.Itoa(int(t.Port))
-	rhost := net.JoinHostPort(t.Host(), portStr)
+	portStr := strconv.Itoa(int(target.Port))
+	rhost := net.JoinHostPort(target.Host(), portStr)
 
 	sshConfig := ssh.MakeSSHConfig()
 	sshConfig.Timeout = s.config.ConnectTimeout
@@ -130,9 +130,9 @@ func (s *SSHScanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t 
 	}
 	sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 	// Implementation taken from lib/ssh/client.go
-	conn, err := dialGroup.Dial(ctx, t)
+	conn, err := dialGroup.Dial(ctx, target)
 	if err != nil {
-		err = fmt.Errorf("failed to dial target %s: %w", t.String(), err)
+		err = fmt.Errorf("failed to dial target %s: %w", target.String(), err)
 		return zgrab2.TryGetScanStatus(err), nil, err
 	}
 	if s.config.ConnectTimeout != 0 {
@@ -149,7 +149,7 @@ func (s *SSHScanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup, t 
 	defer func() {
 		err = sshClient.Close()
 		if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			log.Errorf("error closing SSH client for target %s: %v", t.String(), err)
+			log.Errorf("error closing SSH client for target %s: %v", target.String(), err)
 		}
 	}()
 

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -83,10 +83,10 @@ func (s *TLSScanner) InitPerSender(senderID int) error {
 // a TLS handshake. If the handshake gets past the ServerHello stage, the
 // handshake log is returned (along with any other TLS-related logs, such as
 // heartbleed, if enabled).
-func (s *TLSScanner) Scan(ctx context.Context, dialerGroup *zgrab2.DialerGroup, t *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
-	conn, err := dialerGroup.Dial(ctx, t)
+func (s *TLSScanner) Scan(ctx context.Context, dialerGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
+	conn, err := dialerGroup.Dial(ctx, target)
 	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("failed to dial target %s: %w", t.String(), err)
+		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("failed to dial target %s: %w", target.String(), err)
 	}
 	defer zgrab2.CloseConnAndHandleError(conn)
 	tlsConn, ok := conn.(*zgrab2.TLSConnection)

--- a/scanner.go
+++ b/scanner.go
@@ -32,13 +32,13 @@ func init() {
 }
 
 // RegisterScan registers each individual scanner to be ran by the framework
-func RegisterScan(name string, s Scanner) {
+func RegisterScan(name string, scanner Scanner) {
 	//add to list and map
 	if scanners[name] != nil || defaultDialerGroupToScanners[name] != nil {
 		log.Fatalf("name: %s already used", name)
 	}
 	orderedScanners = append(orderedScanners, name)
-	dialerConfig := s.GetDialerGroupConfig()
+	dialerConfig := scanner.GetDialerGroupConfig()
 	if dialerConfig == nil {
 		log.Fatalf("no dialer config for %s", name)
 	}
@@ -51,7 +51,7 @@ func RegisterScan(name string, s Scanner) {
 		log.Fatalf("error getting default dialer group for %s: %v", name, err)
 	}
 	defaultDialerGroupToScanners[name] = dialerGroup
-	scanners[name] = &s
+	scanners[name] = &scanner
 }
 
 // PrintScanners prints all registered scanners
@@ -62,15 +62,15 @@ func PrintScanners() {
 }
 
 // RunScanner runs a single scan on a target and returns the resulting data
-func RunScanner(ctx context.Context, s Scanner, mon *Monitor, target ScanTarget) (string, ScanResponse) {
+func RunScanner(ctx context.Context, scanner Scanner, mon *Monitor, target ScanTarget) (string, ScanResponse) {
 	t := time.Now()
-	dialerGroupConfig, ok := defaultDialerGroupConfigToScanners[s.GetName()]
+	dialerGroupConfig, ok := defaultDialerGroupConfigToScanners[scanner.GetName()]
 	if !ok {
-		log.Fatalf("no default dialer group config for %s", s.GetName())
+		log.Fatalf("no default dialer group config for %s", scanner.GetName())
 	}
-	dialerGroup, ok := defaultDialerGroupToScanners[s.GetName()]
+	dialerGroup, ok := defaultDialerGroupToScanners[scanner.GetName()]
 	if !ok {
-		log.Fatalf("no default dialer group for %s", s.GetName())
+		log.Fatalf("no default dialer group for %s", scanner.GetName())
 	}
 	// if target's port isn't set, use default. Won't affect the caller's ScanTarget since it's passed by value
 	if target.Port == 0 {
@@ -82,20 +82,20 @@ func RunScanner(ctx context.Context, s Scanner, mon *Monitor, target ScanTarget)
 		ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(dialerGroupConfig.BaseFlags.TargetTimeout))
 		defer cancel()
 	}
-	status, res, e := s.Scan(ctx, dialerGroup, &target)
+	status, res, e := scanner.Scan(ctx, dialerGroup, &target)
 	var err *string
 	if e == nil {
-		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusSuccess}
+		mon.statusesChan <- moduleStatus{name: scanner.GetName(), st: statusSuccess}
 		err = nil
 	} else {
 		if deadline, ok := ctx.Deadline(); ok && deadline.Before(time.Now()) {
 			// scan timed out
 			e = fmt.Errorf("ctx deadline exceeded: %w", e)
 		}
-		mon.statusesChan <- moduleStatus{name: s.GetName(), st: statusFailure}
+		mon.statusesChan <- moduleStatus{name: scanner.GetName(), st: statusFailure}
 		errString := e.Error()
 		err = &errString
 	}
-	resp := ScanResponse{Result: res, Protocol: s.Protocol(), Error: err, Timestamp: t.Format(time.RFC3339), Status: status}
-	return s.GetName(), resp
+	resp := ScanResponse{Result: res, Protocol: scanner.Protocol(), Error: err, Timestamp: t.Format(time.RFC3339), Status: status}
+	return scanner.GetName(), resp
 }


### PR DESCRIPTION
I noticed a mix of:
scanner/s
target/t
return statement with and without named variables

This PR normalizes this to
scanner
target
without named variables for consistency

_Add a description of your changes here._

## How to Test

_Add brief instructions on how to test your changes._

## Notes & Caveats

_If necessary, explain the motivation for this PR, and note any caveats that apply to your changes or future work that will be needed._ 

## Issue Tracking

_Add a link to the relevant GitHub issue(s) if the pull request resolves it._
