### PR TITLE
Bump minimum version for go to 1.24

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: Other lint
         run: |
           go install golang.org/x/tools/cmd/goimports@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## Build image ##
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 FROM golang:${GO_VERSION}-alpine3.21 AS build
 
 # System dependencies

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ go version go1.21.13 linux/arm64
 export GOTOOLCHAIN=auto
 git clone https://github.com/zmap/zgrab2.git
 cd zgrab2
-make install # Go will download the required 1.23 toolchain automatically
+make install # Go will download the required 1.24 toolchain automatically
 zgrab2 http --help # to see the http module's help message
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/zmap/zgrab2
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.5
+toolchain go1.24.7
 
 require (
 	github.com/censys/cidranger v1.1.3


### PR DESCRIPTION
With the release of Go 1.25 and following our pattern of supporting the last 2 stable releases, this PR bumps the minimum Go version to 1.24.


