### PR TITLE
Remove unused Help function

### DIFF
--- a/module.go
+++ b/module.go
@@ -226,9 +226,6 @@ type ScanModule interface {
 // ScanFlags is an interface which must be implemented by all types sent to
 // the flag parser
 type ScanFlags interface {
-	// Help optionally returns any additional help text, e.g. specifying what empty defaults are interpreted as.
-	Help() string
-
 	// Validate enforces all command-line flags and positional arguments have valid values.
 	Validate([]string) error
 }

--- a/modules/amqp091/scanner.go
+++ b/modules/amqp091/scanner.go
@@ -131,11 +131,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, ok := flags.(*Flags)

--- a/modules/bacnet/scanner.go
+++ b/modules/bacnet/scanner.go
@@ -63,11 +63,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -125,11 +125,6 @@ func (m *Module) Description() string {
 	return "Fetch a raw banner by sending a static probe and checking the result against an optional regular expression"
 }
 
-// Help returns the module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner with the command-line flags.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	var err error

--- a/modules/dnp3/scanner.go
+++ b/modules/dnp3/scanner.go
@@ -62,11 +62,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/fox/scanner.go
+++ b/modules/fox/scanner.go
@@ -65,11 +65,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -111,11 +111,6 @@ func (f *Flags) Validate(_ []string) (err error) {
 	return
 }
 
-// Help returns this module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Protocol returns the protocol identifer for the scanner.
 func (scanner *Scanner) Protocol() string {
 	return "ftp"

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -148,11 +148,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns module-specific help
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Protocol returns the protocol identifer for the scanner.
 func (scanner *Scanner) Protocol() string {
 	return "http"

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -111,11 +111,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/ipp/scanner.go
+++ b/modules/ipp/scanner.go
@@ -158,12 +158,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	//TODO: Write a help string
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/jarm/scanner.go
+++ b/modules/jarm/scanner.go
@@ -94,11 +94,6 @@ func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner with the command-line flags.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/memcached/scanner.go
+++ b/modules/memcached/scanner.go
@@ -68,11 +68,6 @@ func (flags *Flags) Validate([]string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/modbus/scanner.go
+++ b/modules/modbus/scanner.go
@@ -87,11 +87,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/mongodb/scanner.go
+++ b/modules/mongodb/scanner.go
@@ -236,11 +236,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // NewFlags provides an empty instance of the flags that will be filled in by the framework
 func (module *Module) NewFlags() any {
 	return new(Flags)

--- a/modules/mqtt/scanner.go
+++ b/modules/mqtt/scanner.go
@@ -78,11 +78,6 @@ func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns this module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Protocol returns the protocol identifier for the scanner.
 func (scanner *Scanner) Protocol() string {
 	return "mqtt"

--- a/modules/mssql/scanner.go
+++ b/modules/mssql/scanner.go
@@ -85,11 +85,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the help string for this module.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner instance with the given command-line flags.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -181,11 +181,6 @@ func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner with the command-line flags.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/ntp/scanner.go
+++ b/modules/ntp/scanner.go
@@ -822,11 +822,6 @@ func (cfg *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string
-func (cfg *Flags) Help() string {
-	return ""
-}
-
 // Init initialized the scanner
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/oracle/scanner.go
+++ b/modules/oracle/scanner.go
@@ -152,11 +152,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -126,11 +126,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -294,11 +294,6 @@ func (f *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the scanner with the given flags.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/pptp/scanner.go
+++ b/modules/pptp/scanner.go
@@ -68,11 +68,6 @@ func (f *Flags) Validate(_ []string) (err error) {
 	return
 }
 
-// Help returns this module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Protocol returns the protocol identifier for the scanner.
 func (scanner *Scanner) Protocol() string {
 	return "pptp"

--- a/modules/redis/scanner.go
+++ b/modules/redis/scanner.go
@@ -192,11 +192,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the scanner
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/siemens/scanner.go
+++ b/modules/siemens/scanner.go
@@ -62,11 +62,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/smb/scanner.go
+++ b/modules/smb/scanner.go
@@ -62,11 +62,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -144,11 +144,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/socks5/scanner.go
+++ b/modules/socks5/scanner.go
@@ -75,11 +75,6 @@ func (f *Flags) Validate(_ []string) (err error) {
 	return
 }
 
-// Help returns this module's help string.
-func (f *Flags) Help() string {
-	return ""
-}
-
 // Protocol returns the protocol identifier for the scanner.
 func (scanner *Scanner) Protocol() string {
 	return "socks5"

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -61,10 +61,6 @@ func (f *SSHFlags) Validate(_ []string) error {
 	return nil
 }
 
-func (f *SSHFlags) Help() string {
-	return ""
-}
-
 func (s *SSHScanner) Init(flags zgrab2.ScanFlags) error {
 	sc := ssh.MakeSSHConfig() //dummy variable to get default for host key, kex algorithm, ciphers
 	f, _ := flags.(*SSHFlags)

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -69,11 +69,6 @@ func (flags *Flags) Validate(_ []string) error {
 	return nil
 }
 
-// Help returns the module's help string.
-func (flags *Flags) Help() string {
-	return ""
-}
-
 // Init initializes the Scanner.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -48,10 +48,6 @@ func (f *TLSFlags) Validate(_ []string) error {
 	return nil
 }
 
-func (f *TLSFlags) Help() string {
-	return ""
-}
-
 func (s *TLSScanner) Init(flags zgrab2.ScanFlags) error {
 	f, ok := flags.(*TLSFlags)
 	if !ok {

--- a/multiple.go
+++ b/multiple.go
@@ -17,8 +17,3 @@ func (x *MultipleCommand) Validate(_ []string) error {
 
 	return nil
 }
-
-// Help returns a usage string that will be output at the command line
-func (x *MultipleCommand) Help() string {
-	return ""
-}


### PR DESCRIPTION
Empty defaults should probably be returned by the helper text of the option
This isn't used in practice, so just clear up all the empty bits
