### PR TITLE
Return all the TLS handshake details we have even if handshake fails

### DIFF
--- a/modules/tls.go
+++ b/modules/tls.go
@@ -87,7 +87,6 @@ func (s *TLSScanner) Scan(ctx context.Context, dialerGroup *zgrab2.DialerGroup, 
 	if conn != nil {
 		defer zgrab2.CloseConnAndHandleError(conn)
 	}
-	// TODO Phillip - we should have an integration test for this behavior, that we return handshake info on error
 	if err != nil {
 		// Even on an error, we want to give the TLS Log if we have it.
 		if conn != nil {

--- a/modules/tls.go
+++ b/modules/tls.go
@@ -3,7 +3,6 @@ package modules
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -85,22 +84,31 @@ func (s *TLSScanner) InitPerSender(senderID int) error {
 // heartbleed, if enabled).
 func (s *TLSScanner) Scan(ctx context.Context, dialerGroup *zgrab2.DialerGroup, target *zgrab2.ScanTarget) (zgrab2.ScanStatus, any, error) {
 	conn, err := dialerGroup.Dial(ctx, target)
-	if err != nil {
-		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("failed to dial target %s: %w", target.String(), err)
+	if conn != nil {
+		defer zgrab2.CloseConnAndHandleError(conn)
 	}
-	defer zgrab2.CloseConnAndHandleError(conn)
+	// TODO Phillip - we should have an integration test for this behavior, that we return handshake info on error
+	if err != nil {
+		// Even on an error, we want to give the TLS Log if we have it.
+		if conn != nil {
+			if tlsConn, ok := conn.(*zgrab2.TLSConnection); ok {
+				if tlsLog := tlsConn.GetLog(); tlsLog != nil {
+					if tlsLog.HandshakeLog.ServerHello != nil {
+						// If we got far enough to get a valid ServerHello, then
+						// consider it to be a positive TLS detection.
+						return zgrab2.TryGetScanStatus(err), tlsLog, err
+					}
+					// Otherwise, detection failed.
+				}
+			}
+		}
+		return zgrab2.TryGetScanStatus(err), nil, err
+	}
 	tlsConn, ok := conn.(*zgrab2.TLSConnection)
 	if !ok {
-		return zgrab2.SCAN_INVALID_INPUTS, nil, errors.New("tls scanner requires a default dialer that creates TLS connections")
+		return zgrab2.SCAN_UNKNOWN_ERROR, nil, errors.New("scan returned non-TLS connection")
 	}
-	tlsLog := tlsConn.GetLog()
-	if tlsLog != nil && tlsLog.HandshakeLog.ServerHello != nil {
-		// If we got far enough to get a valid ServerHello, then
-		// consider it to be a positive TLS detection.
-		return zgrab2.SCAN_SUCCESS, tlsLog, nil
-	}
-	// Otherwise detection failed
-	return zgrab2.SCAN_HANDSHAKE_ERROR, nil, errors.New("tls handshake failed")
+	return zgrab2.SCAN_SUCCESS, tlsConn.GetLog(), nil
 }
 
 // Protocol returns the protocol identifer for the scanner.

--- a/processing.go
+++ b/processing.go
@@ -139,8 +139,12 @@ func GetDefaultTLSWrapper(tlsFlags *TLSFlags) func(ctx context.Context, t *ScanT
 			flags: tlsFlags,
 		}
 		err = tlsConn.Handshake()
-		if err != nil {
+		if err != nil && tlsConn.log == nil {
+			// If the handshake fails and we have no log, just return error
 			return nil, fmt.Errorf("could not perform tls handshake for target %s: %w", t.String(), err)
+		} else if err != nil {
+			// We'll return both the error and the connection so ZGrab can return the handshake log
+			return &tlsConn, fmt.Errorf("could not successfully complete tls handshake for target %s: %w", t.String(), err)
 		}
 		return &tlsConn, err
 	}


### PR DESCRIPTION
This fixes a regression added in #336455 where on TLS handshake errors, we error out. This means the user only gets an error message when they could get all the details from the host that we've already recovered.

## How to Test

## Live Hosts
Using the Issue opener's Shodan search, I found a couple hosts to test against and `master` definitely has the behavior they describe:
```shell
echo "192.29.83.136" | ./zgrab2-master tls                                                                                                                                                                                                                                                                     15:09:17
INFO[0000] started grab at 2025-09-22T15:23:04-07:00    
{"ip":"192.29.83.136","data":{"tls":{"status":"unknown-error","protocol":"tls","port":443,"timestamp":"2025-09-22T15:23:04-07:00","error":"failed to dial target 192.29.83.136: could not perform tls handshake for target 192.29.83.136: remote error: tls: bad certificate"}}}
INFO[0000] finished grab at 2025-09-22T15:23:04-07:00   
00h:00m:00s; Scan Complete; 1 targets scanned; 4.21 targets/sec; 0.0% success rate
```
With this fix:
```shell
 echo "192.29.83.136" | ./zgrab2 tls                                                                                                                                                                                                                                                                            15:23:27
INFO[0000] started grab at 2025-09-22T15:23:35-07:00    
{"ip":"192.29.83.136","data":{"tls":{"status":"unknown-error","protocol":"tls","port":443,"result":{"handshake_log":{"server_hello":{"version":{"name":"TLSv1.2","value":771},"random":"OHX8LGxJDqw+oUaFaQpTvrXx7Hd0TANu5dCj09PGIXI=","session_id":"LnZVVfGbWNPwLNpI4MR7U4eRGYei/ehnR8OD9XEIjdU=","cipher_suite":{"hex":"0xC02F","name":"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","value":49199},"compression_method":{"hex":"0x00","name":"NULL","value":0},"ocsp_stapling":false,"ticket":false,"secure_renegotiation":false,"heartbeat":false,"extended_master_secret":false,"extension_identifiers":[65281]},"server_certificates":{"certificate"
...
```

## Docker Tests
I tried to get a dockerized test server to simulate the TLS: Bad Certificate error I was see right after the client sends their client key exchange (just offer Server Hello)
<img width="1295" height="79" alt="image" src="https://github.com/user-attachments/assets/2a56c3e3-c3c9-4f59-be02-3a333b70f086" />

But couldn't replicate the behavior on either `nginx` or `openssl s_server`. Doesn't mean it isn't possible, I just could never get it working. 

## Issue Tracking

Resolves #582 

