### PR TITLE
MySQL Length Check for Version 9 Packets

### DIFF
--- a/lib/mysql/mysql.go
+++ b/lib/mysql/mysql.go
@@ -339,7 +339,7 @@ func (c *Connection) readHandshakePacket(body []byte) (*HandshakePacket, error) 
 	ret.CapabilityFlags = uint32(binary.LittleEndian.Uint16(rest[13:15]))
 
 	// Unlike the ERRPacket case, the docs explicitly say to go by the body length here
-	if len(body) > 8 {
+	if len(body) > 8 && len(rest) >= 31 {
 		ret.ShortHandshake = false
 		ret.CharacterSet = rest[15]
 		ret.StatusFlags = binary.LittleEndian.Uint16(rest[16:18])
@@ -352,10 +352,12 @@ func (c *Connection) readHandshakePacket(body []byte) (*HandshakePacket, error) 
 			if part2Len < 13 {
 				part2Len = 13
 			}
-			ret.AuthPluginData2 = rest[31 : 31+part2Len]
-			if ret.CapabilityFlags&CLIENT_SECURE_CONNECTION != 0 {
-				// If AuthPluginName does include a NUL terminator, strip it.
-				ret.AuthPluginName = strings.Trim(string(rest[31+part2Len:]), "\u0000")
+			if byte(len(rest)-31) >= part2Len {
+				ret.AuthPluginData2 = rest[31 : 31+part2Len]
+				if ret.CapabilityFlags&CLIENT_SECURE_CONNECTION != 0 {
+					// If AuthPluginName does include a NUL terminator, strip it.
+					ret.AuthPluginName = strings.Trim(string(rest[31+part2Len:]), "\u0000")
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
## Overview
Added two length checks in mysql.go to determine whether a MySQL packet included all of the necessary fields. 

## Details
In the ```readHandshakePacket``` method in ```lib/mysql/mysql.go``` there is a note saying that OK packets should be verified by checking whether the body length is over 8. If the body length is less than 8, it will be marked as a "ShortHandshake". 

From what I can tell, ```ShortHandshake``` might either mean a bug in the server causing not all fields to appear or it may be denoting MySQL version 9 vs. MySQL version 10. The later is most likely, but I could not find a direct answer in the code (I very well might have missed it). 

Notably, version 9 (https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v9.html) does not include anything past the authentication plugin data (meaning that is probably what's meant by ```ShortHandshake```). In version 10, there are numerous other flags (https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_v10.html) after the initial 4. 

I've been observing a bug where, occasionally, IP's will send back packets that claim to be version 10 MySQL, but are not necessarily version 10 compatible (they are missing some later fields). This will crash ZGrab as it will attempt to read past the bounds of the packet in ```readHandshakePacket```. Images of a successful and crashing version are below. 

<img width="582" height="179" alt="mysql_crashing_packet" src="https://github.com/user-attachments/assets/4125ea5d-5a26-4be5-ae28-a17995f7fcfb" />
<img width="582" height="318" alt="mysql_valid_packet" src="https://github.com/user-attachments/assets/a6068151-4705-496c-bec7-17fdb0065d3a" />

The crashing version appears to MySQL 3.21.32a-log (an old version of MySQL). It's my understanding this uses version 9 of MySQL by default (but I don't have a good cite for that). Either way it claims to be using version 10 so either:
- it's using version 9 and the version is wrong;
- It tried to use version 10 but failed to implement it correctly; or
- Something else is wrong we don't understand. 

Either way, circling back to ```readHandshakePacket``` the body length check will pass in this case (the packet body is over 8 bytes long), but later field extraction will crash.

To fix this temporarily, in ```lib/mysql/mysql.go``` I added an additional check on line 342 to see if the additional fields string was at least 31 bytes long (since that's how far we read), and added a check in line 355 to ensure the packet is as long as the ```AuthPluginDataLen``` field says it is before we read ```AuthPluginData2```. 

## How to Test

I verified on the first 250K port 80 responsive and first 50K port 3306 responsive, and no longer saw an error (as well as testing against known crashing IPs). 

For future testing, the best evaluation would be against a full scan of port 80 and port 3306. 

## Notes & Caveats

- I put more detail into this PR, because I'm not sure how you'd like to return these IPs. They technically aren't correctly formatted version 10 MySQL, but they do appear to be running MySQL. I couldn't find where in the documentation it said to check body length (per the comment), so there might be some nuance here that is being missed. Regardless, it seemed useful to at least stop these IPs from crashing ZGrab for now, and mark them as short handshakes for the time being. 
- For the second length check on line 355, I've never observed a packet triggering a crash on this line, but given that the crash for line 342 was only a single IP I was observing, I thought it would be useful to add a length check on 355 as well, in case of future malformed packets. 

## Issue Tracking

While a different issue, this might be somewhat associated with: https://github.com/zmap/zgrab2/issues/624
(i.e. it would be useful to verify more broadly length checking on packets, in case there are malformed packets in the future). The tricky part is that many of the corner cases may not appear (or may be a single IP on a non-standard port), so it's hard to catch them until they do.  
