### PR TITLE
initialize monitor map and avoid accessing before checking membership

### DIFF
--- a/bin/bin.go
+++ b/bin/bin.go
@@ -122,9 +122,9 @@ func ZGrab2Main() {
 		log.Fatalf("could not parse flags: %s", err)
 	}
 
+	var modTypes []string
 	if m, ok := flag.(*zgrab2.MultipleCommand); ok {
 		iniParser := zgrab2.NewIniParser()
-		var modTypes []string
 		var flagsReturned []any
 		if m.ConfigFileName == "-" {
 			modTypes, flagsReturned, err = iniParser.Parse(os.Stdin)
@@ -159,6 +159,7 @@ func ZGrab2Main() {
 			zgrab2.RegisterScan(s.GetName(), s)
 		}
 	} else {
+		modTypes = append(modTypes, moduleType)
 		mod := zgrab2.GetModule(moduleType)
 		s := mod.NewScanner()
 		scanModuleNameToScanModule[moduleType] = &s
@@ -169,7 +170,7 @@ func ZGrab2Main() {
 	}
 	zgrab2.ValidateAndHandleFrameworkConfiguration() // will panic if there is an error
 	wg := sync.WaitGroup{}
-	monitor := zgrab2.MakeMonitor(1, &wg)
+	monitor := zgrab2.MakeMonitor(1, &wg, modTypes)
 	monitor.Callback = func(_ string) {
 		dumpHeapProfile()
 	}
@@ -199,7 +200,6 @@ func ZGrab2Main() {
 		metadata := (*module).GetScanMetadata()
 		if metadata != nil {
 			// Need to lookup the appropriate field in the summary
-			s.PerModuleMetadata[moduleName].CustomMetadata = metadata
 			moduleSummaryMetadata, ok := s.PerModuleMetadata[moduleName]
 			if ok {
 				moduleSummaryMetadata.CustomMetadata = metadata

--- a/monitor.go
+++ b/monitor.go
@@ -90,11 +90,15 @@ func (m *Monitor) printStatus(isFinalPrint bool) {
 
 // MakeMonitor returns a Monitor object that can be used to collect and send
 // the status of a running scan
-func MakeMonitor(statusChanSize int, wg *sync.WaitGroup) *Monitor {
+func MakeMonitor(statusChanSize int, wg *sync.WaitGroup, moduleNames []string) *Monitor {
 	m := &Monitor{
 		statusesChan: make(chan moduleStatus, statusChanSize),
 		states:       make(map[string]*ModuleMetadata),
 		startTime:    time.Now(),
+	}
+	// Initialize an empty state for each module
+	for _, moduleName := range moduleNames {
+		m.states[moduleName] = &ModuleMetadata{}
 	}
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
Issue opener reported a seg fault when using the multiple module.

This specifically happens because:

1. We weren't checking for membership in the monitor map before lookups
2. The monitor metadata map was empty due to the use of triggers to exclude all input targets.

## Fix
- Initialize map before use
- Use the membership check for accessing the map to avoid segfault

## Testing
Issue openers test now does not segfault

```bash
./zgrab2 multiple --config-file ./multiple.ini < /dev/null                                                                                                                          15:28:11
INFO[0000] started grab at 2025-11-24T15:28:23-08:00    
{"ip":"191.252.130.194"}
INFO[0000] finished grab at 2025-11-24T15:28:23-08:00   
00h:00m:00s; Scan Complete; 0 targets scanned; 0.00 targets/sec; 0.0% success rate
{"statuses":{"smtp":{"successes":0,"failures":0,"custom_metadata":{"hosts_supporting_ehlo":0,"hosts_supporting_helo":0,"hosts_supporting_starttls":0}}},"start":"2025-11-24T15:28:23-08:00","end":"2025-11-24T15:28:23-08:00","duration":"1.40075ms","zgrab_cli_parameters":"./zgrab2 multiple --config-file ./multiple.ini","num_targets_scanned":0}
```

Closes #633 