### PR TITLE
prealloc array at least as big as minimum element

### DIFF
--- a/modules/redis/types.go
+++ b/modules/redis/types.go
@@ -170,9 +170,8 @@ func (RedisArray) Type() RedisType {
 // Encode returns the encoding of the array, e.g.
 // "*<base10Size>\r\n<element 1><element 2>..."
 func (array RedisArray) Encode() []byte {
-	var ret []byte
 	prefix := fmt.Sprintf("*%d\r\n", len(array))
-	ret = append(ret, []byte(prefix)...)
+	ret := []byte(prefix)
 	for _, item := range array {
 		ret = append(ret, item.Encode()...)
 	}


### PR DESCRIPTION
Preallocate an array within the `redis` module. (Linter was complaining about it and while ofc in general preallocation is a good idea, I doubt we'll get much speedup with this since we can't know the full size we need to allocate to beforehand.

