### PR TITLE
Fix manage sieve CI

### DIFF
--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -127,9 +127,11 @@ services:
     container_name: "zgrab_managesieve"
     networks:
       - managesieve-network
+    environment:
+      - STALWART_RECOVERY_ADMIN=admin:testpassword123
+    volumes:
+      - ./managesieve/config.json:/etc/stalwart/config.json
     hostname: "target"
-    depends_on:
-      - service_base
 
   memcached-1.6.0:
     image: "memcached:1.6.0"

--- a/integration_tests/managesieve/config.json
+++ b/integration_tests/managesieve/config.json
@@ -1,0 +1,4 @@
+{
+  "@type": "RocksDb",
+  "path": "/var/lib/stalwart"
+}


### PR DESCRIPTION
## Issue
Our CI was failing, specifically the `manage sieve` tests.

## Cause
We're using `stalwartlabs/stalwart:latest` as the image. They recently pushed a new version that requires you to use a `config.json` file to setup the mail server.

## Fix
Add a compatible `config.json` and everything works
