### PR TITLE
fix: return errors on BACnet tag mismatches instead of nil

### DIFF
--- a/modules/bacnet/objects.go
+++ b/modules/bacnet/objects.go
@@ -68,16 +68,25 @@ func readInstanceNumber(b []byte) (leftovers []byte, instanceNumber uint32, err 
 	buf := bytes.NewBuffer(b)
 	leftovers = b
 	var openByte, appByte, closeByte byte
-	if openByte, err = buf.ReadByte(); openByte != 0x3e {
+	if openByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if openByte != 0x3e {
+		err = errInvalidPacket
 		return
 	}
-	if appByte, err = buf.ReadByte(); appByte != 0xc4 {
+	if appByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if appByte != 0xc4 {
+		err = errInvalidPacket
 		return
 	}
 	if err = binary.Read(buf, binary.BigEndian, &instanceNumber); err != nil {
 		return
 	}
-	if closeByte, err = buf.ReadByte(); closeByte != 0x3f {
+	if closeByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if closeByte != 0x3f {
+		err = errInvalidPacket
 		return
 	}
 	bytesRead := len(b) - buf.Len()
@@ -90,10 +99,16 @@ func readVendorID(b []byte) (leftovers []byte, vendorID uint16, err error) {
 	buf := bytes.NewBuffer(b)
 	leftovers = b
 	var openByte, appByte, closeByte byte
-	if openByte, err = buf.ReadByte(); openByte != 0x3e {
+	if openByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if openByte != 0x3e {
+		err = errInvalidPacket
 		return
 	}
-	if appByte, err = buf.ReadByte(); appByte != 0x22 && appByte != 0x21 {
+	if appByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if appByte != 0x22 && appByte != 0x21 {
+		err = errInvalidPacket
 		return
 	}
 	if appByte == 0x22 {
@@ -107,7 +122,10 @@ func readVendorID(b []byte) (leftovers []byte, vendorID uint16, err error) {
 		}
 		vendorID = uint16(vendorIDByte)
 	}
-	if closeByte, err = buf.ReadByte(); closeByte != 0x3f {
+	if closeByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if closeByte != 0x3f {
+		err = errInvalidPacket
 		return
 	}
 	bytesRead := len(b) - buf.Len()
@@ -119,10 +137,16 @@ func readStringProperty(b []byte) (leftovers []byte, value string, err error) {
 	buf := bytes.NewBuffer(b)
 	leftovers = b
 	var openByte, appByte, closeByte, lengthByte byte
-	if openByte, err = buf.ReadByte(); openByte != 0x3e {
+	if openByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if openByte != 0x3e {
+		err = errInvalidPacket
 		return
 	}
-	if appByte, err = buf.ReadByte(); appByte&0xF8 != 0x70 {
+	if appByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if appByte&0xF8 != 0x70 {
+		err = errInvalidPacket
 		return
 	}
 	lengthBits := appByte & 0x07
@@ -143,7 +167,10 @@ func readStringProperty(b []byte) (leftovers []byte, value string, err error) {
 		return
 	}
 	value = string(propertyBytes[1:])
-	if closeByte, err = buf.ReadByte(); closeByte != 0x3f {
+	if closeByte, err = buf.ReadByte(); err != nil {
+		return
+	} else if closeByte != 0x3f {
+		err = errInvalidPacket
 		return
 	}
 	bytesRead := len(b) - buf.Len()

--- a/modules/bacnet/objects_security_test.go
+++ b/modules/bacnet/objects_security_test.go
@@ -8,11 +8,11 @@ import (
 // --- readInstanceNumber tests ---
 
 func buildInstanceNumber(open, app byte, instanceNum uint32, close byte) []byte {
-	buf := []byte{open, app}
-	numBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(numBytes, instanceNum)
-	buf = append(buf, numBytes...)
-	buf = append(buf, close)
+	buf := make([]byte, 7)
+	buf[0] = open
+	buf[1] = app
+	binary.BigEndian.PutUint32(buf[2:], instanceNum)
+	buf[6] = close
 	return buf
 }
 
@@ -73,11 +73,11 @@ func TestReadInstanceNumber_TruncatedAfterApp(t *testing.T) {
 // --- readVendorID tests ---
 
 func TestReadVendorID_Valid16Bit(t *testing.T) {
-	buf := []byte{0x3e, 0x22}
-	vendorBytes := make([]byte, 2)
-	binary.BigEndian.PutUint16(vendorBytes, 0x1234)
-	buf = append(buf, vendorBytes...)
-	buf = append(buf, 0x3f)
+	buf := make([]byte, 5)
+	buf[0] = 0x3e
+	buf[1] = 0x22
+	binary.BigEndian.PutUint16(buf[2:], 0x1234) // Vendor Bytes
+	buf[4] = 0x3f
 
 	_, vendorID, err := readVendorID(buf)
 	if err != nil {
@@ -133,9 +133,11 @@ func TestReadVendorID_Empty(t *testing.T) {
 // --- readStringProperty tests ---
 
 func buildStringProperty(open, appByte byte, content []byte, close byte) []byte {
-	buf := []byte{open, appByte}
-	buf = append(buf, content...)
-	buf = append(buf, close)
+	buf := make([]byte, 2+len(content)+1)
+	buf[0] = open
+	buf[1] = appByte
+	copy(buf[2:], content)
+	buf[len(buf)-1] = close
 	return buf
 }
 

--- a/modules/bacnet/objects_security_test.go
+++ b/modules/bacnet/objects_security_test.go
@@ -1,0 +1,187 @@
+package bacnet
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// --- readInstanceNumber tests ---
+
+func buildInstanceNumber(open, app byte, instanceNum uint32, close byte) []byte {
+	buf := []byte{open, app}
+	numBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(numBytes, instanceNum)
+	buf = append(buf, numBytes...)
+	buf = append(buf, close)
+	return buf
+}
+
+func TestReadInstanceNumber_Valid(t *testing.T) {
+	b := buildInstanceNumber(0x3e, 0xc4, 0x00010042, 0x3f)
+	leftovers, instanceNumber, err := readInstanceNumber(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := uint32(0x00010042) & 0x0003ffff
+	if instanceNumber != expected {
+		t.Errorf("expected instance %d, got %d", expected, instanceNumber)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("expected no leftovers, got %d bytes", len(leftovers))
+	}
+}
+
+func TestReadInstanceNumber_BadOpenTag(t *testing.T) {
+	b := buildInstanceNumber(0x99, 0xc4, 42, 0x3f)
+	_, _, err := readInstanceNumber(b)
+	if err == nil {
+		t.Fatal("expected error for bad open tag, got nil")
+	}
+}
+
+func TestReadInstanceNumber_BadAppTag(t *testing.T) {
+	b := buildInstanceNumber(0x3e, 0x99, 42, 0x3f)
+	_, _, err := readInstanceNumber(b)
+	if err == nil {
+		t.Fatal("expected error for bad app tag, got nil")
+	}
+}
+
+func TestReadInstanceNumber_BadCloseTag(t *testing.T) {
+	b := buildInstanceNumber(0x3e, 0xc4, 42, 0x99)
+	_, _, err := readInstanceNumber(b)
+	if err == nil {
+		t.Fatal("expected error for bad close tag, got nil")
+	}
+}
+
+func TestReadInstanceNumber_Empty(t *testing.T) {
+	_, _, err := readInstanceNumber([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+func TestReadInstanceNumber_TruncatedAfterApp(t *testing.T) {
+	// open + app but no instance number bytes
+	_, _, err := readInstanceNumber([]byte{0x3e, 0xc4})
+	if err == nil {
+		t.Fatal("expected error for truncated input, got nil")
+	}
+}
+
+// --- readVendorID tests ---
+
+func TestReadVendorID_Valid16Bit(t *testing.T) {
+	buf := []byte{0x3e, 0x22}
+	vendorBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(vendorBytes, 0x1234)
+	buf = append(buf, vendorBytes...)
+	buf = append(buf, 0x3f)
+
+	_, vendorID, err := readVendorID(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vendorID != 0x1234 {
+		t.Errorf("expected vendor 0x1234, got 0x%04x", vendorID)
+	}
+}
+
+func TestReadVendorID_Valid8Bit(t *testing.T) {
+	buf := []byte{0x3e, 0x21, 0x42, 0x3f}
+	_, vendorID, err := readVendorID(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vendorID != 0x42 {
+		t.Errorf("expected vendor 0x42, got 0x%04x", vendorID)
+	}
+}
+
+func TestReadVendorID_BadOpenTag(t *testing.T) {
+	buf := []byte{0x99, 0x22, 0x00, 0x01, 0x3f}
+	_, _, err := readVendorID(buf)
+	if err == nil {
+		t.Fatal("expected error for bad open tag, got nil")
+	}
+}
+
+func TestReadVendorID_BadAppTag(t *testing.T) {
+	buf := []byte{0x3e, 0x99, 0x00, 0x01, 0x3f}
+	_, _, err := readVendorID(buf)
+	if err == nil {
+		t.Fatal("expected error for bad app tag, got nil")
+	}
+}
+
+func TestReadVendorID_BadCloseTag(t *testing.T) {
+	buf := []byte{0x3e, 0x21, 0x42, 0x99}
+	_, _, err := readVendorID(buf)
+	if err == nil {
+		t.Fatal("expected error for bad close tag, got nil")
+	}
+}
+
+func TestReadVendorID_Empty(t *testing.T) {
+	_, _, err := readVendorID([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}
+
+// --- readStringProperty tests ---
+
+func buildStringProperty(open, appByte byte, content []byte, close byte) []byte {
+	buf := []byte{open, appByte}
+	buf = append(buf, content...)
+	buf = append(buf, close)
+	return buf
+}
+
+func TestReadStringProperty_Valid(t *testing.T) {
+	// appByte 0x74 = 0x70 | 0x04 (length=4), content = encoding(1) + "abc"(3)
+	content := []byte{0x00, 'a', 'b', 'c'}
+	b := buildStringProperty(0x3e, 0x74, content, 0x3f)
+	_, value, err := readStringProperty(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != "abc" {
+		t.Errorf("expected 'abc', got %q", value)
+	}
+}
+
+func TestReadStringProperty_BadOpenTag(t *testing.T) {
+	content := []byte{0x00, 'x'}
+	b := buildStringProperty(0x99, 0x72, content, 0x3f)
+	_, _, err := readStringProperty(b)
+	if err == nil {
+		t.Fatal("expected error for bad open tag, got nil")
+	}
+}
+
+func TestReadStringProperty_BadAppTag(t *testing.T) {
+	content := []byte{0x00, 'x'}
+	b := buildStringProperty(0x3e, 0x50, content, 0x3f)
+	_, _, err := readStringProperty(b)
+	if err == nil {
+		t.Fatal("expected error for bad app tag, got nil")
+	}
+}
+
+func TestReadStringProperty_BadCloseTag(t *testing.T) {
+	content := []byte{0x00, 'a', 'b', 'c'}
+	b := buildStringProperty(0x3e, 0x74, content, 0x99)
+	_, _, err := readStringProperty(b)
+	if err == nil {
+		t.Fatal("expected error for bad close tag, got nil")
+	}
+}
+
+func TestReadStringProperty_Empty(t *testing.T) {
+	_, _, err := readStringProperty([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+}


### PR DESCRIPTION
Three BACnet parsing functions (readInstanceNumber, readVendorID, readStringProperty) used a pattern where ReadByte() success was checked alongside a value comparison in a single if-statement:

    if openByte, err = buf.ReadByte(); openByte != 0x3e { return }

When ReadByte() succeeds but the value doesn't match, err remains nil and the function returns with no error — silently accepting malformed input. Callers checking only err treat the result as valid with zero-value fields.

Fix: separate the I/O error check from the value check, returning errInvalidPacket when the tag byte doesn't match the expected value.

## How to Test

Integration tests pass and new unit tests checks boundary conditions

## Notes & Caveats

My workplace is expanding security scans for software we use. This one is more of a consistency issue where we aren't necessarily returning the correct error.
While I don't think I've run into these in the wild, it also seems straightforward to implement these checks and avoid panics