### PR TITLE
fix: initialise dnsRateLimiter to default to prevent nil panic

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -17,7 +17,11 @@ var orderedScanners []string
 var defaultDialerGroupToScanners map[string]*DialerGroup
 var defaultDialerGroupConfigToScanners map[string]*DialerGroupConfig
 var ipRateLimiter *ratelimit.PerObjectRateLimiter[netip.Addr]
-var dnsRateLimiter *rate.Limiter
+// dnsRateLimiter is initialised to the default rate here so that lookupIPs
+// never panics on a nil receiver when ValidateAndHandleFrameworkConfiguration
+// has not been called. ValidateAndHandleFrameworkConfiguration overwrites this
+// with the user-supplied value when invoked.
+var dnsRateLimiter = rate.NewLimiter(rate.Limit(10_000), 10_000)
 
 const (
 	maxLRUSize = 10_000_000       // Limiters track IP connects per second. There's no way we'll have over 10 million unique IPs per second, so this should be plenty.

--- a/scanner.go
+++ b/scanner.go
@@ -12,28 +12,17 @@ import (
 	"github.com/zmap/zgrab2/ratelimit"
 )
 
-var scanners map[string]*Scanner
+var scanners = make(map[string]*Scanner)
 var orderedScanners []string
-var defaultDialerGroupToScanners map[string]*DialerGroup
-var defaultDialerGroupConfigToScanners map[string]*DialerGroupConfig
-var ipRateLimiter *ratelimit.PerObjectRateLimiter[netip.Addr]
-// dnsRateLimiter is initialised to the default rate here so that lookupIPs
-// never panics on a nil receiver when ValidateAndHandleFrameworkConfiguration
-// has not been called. ValidateAndHandleFrameworkConfiguration overwrites this
-// with the user-supplied value when invoked.
-var dnsRateLimiter = rate.NewLimiter(rate.Limit(10_000), 10_000)
+var defaultDialerGroupToScanners = make(map[string]*DialerGroup)
+var defaultDialerGroupConfigToScanners = make(map[string]*DialerGroupConfig)
+var ipRateLimiter = ratelimit.NewPerObjectRateLimiter[netip.Addr](maxLRUSize, maxLRUTTL)
+var dnsRateLimiter = rate.NewLimiter(rate.Limit(defaultDNSServerRateLimit), defaultDNSServerRateLimit)
 
 const (
 	maxLRUSize = 10_000_000       // Limiters track IP connects per second. There's no way we'll have over 10 million unique IPs per second, so this should be plenty.
 	maxLRUTTL  = time.Second * 10 // Memory Leak Avoidance - We'll remove a limiter for an IP after 10 seconds of inactivity. It'll be re-created if the IP connects again after that time.
 )
-
-func init() {
-	scanners = make(map[string]*Scanner)
-	defaultDialerGroupToScanners = make(map[string]*DialerGroup)
-	defaultDialerGroupConfigToScanners = make(map[string]*DialerGroupConfig)
-	ipRateLimiter = ratelimit.NewPerObjectRateLimiter[netip.Addr](maxLRUSize, maxLRUTTL)
-}
 
 // RegisterScan registers each individual scanner to be ran by the framework
 func RegisterScan(name string, scanner Scanner) {


### PR DESCRIPTION
## Problem

`dnsRateLimiter` is declared as a nil `*rate.Limiter` in `scanner.go` and only assigned inside `ValidateAndHandleFrameworkConfiguration`. Library consumers that manage their own configuration and don't call that function will have a nil limiter at runtime.

When such a caller scans a target whose address resolves to a hostname — for example, when the HTTP scanner's transport follows a redirect to a `https://some-domain.com/...` URL — `lookupIPs` is called, which calls `dnsRateLimiter.Wait()` on the nil receiver:

```
panic: runtime error: invalid memory address or nil pointer dereference
...
golang.org/x/time/rate.(*Limiter).wait(0x0, ...)
    golang.org/x/time/rate/rate.go:254
github.com/zmap/zgrab2.(*Dialer).lookupIPs(...)
    conn.go:354
```

Because the panic originates inside a goroutine spawned by `(*Transport).startDialConnForLocked`, a `defer recover()` in the calling goroutine cannot catch it. The entire process crashes.

## Fix

Initialise `dnsRateLimiter` at declaration time with the same default value (10 000 req/s) that `ValidateAndHandleFrameworkConfiguration` would set. That function still overwrites the value when called, so behaviour for callers that do invoke it is unchanged.

## Alternative considered

Adding `if dnsRateLimiter != nil` guards inside `lookupIPs` would also prevent the panic but would silently skip rate limiting — the initialisation approach is safer and makes the intent clearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
