### PR TITLE
feat: roll out SCAN_HANDSHAKE_ERROR to IMAP, POP3, FTP, ManageSieve, MySQL, Postgres

### DIFF
--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -275,6 +275,7 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	if err != nil {
 		return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error opening connection to target %v: %w", target.String(), err)
 	}
+	defer func() { zgrab2.CloseConnAndHandleError(conn) }()
 	if scanner.config.ImplicitTLS {
 		tlsWrapper := dialGroup.TLSWrapper
 		if tlsWrapper == nil {
@@ -301,7 +302,6 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	if tlsConn, ok := conn.(*zgrab2.TLSConnection); ok {
 		results.TLSLog = tlsConn.GetLog()
 	}
-	defer func() { zgrab2.CloseConnAndHandleError(conn) }()
 	ftp := Connection{conn: conn, config: scanner.config, results: results}
 	is200Banner, err := ftp.GetFTPBanner()
 	if err != nil {

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -233,22 +233,25 @@ func (ftp *Connection) SetupFTPS() (bool, error) {
 // First sends the AUTH TLS/AUTH SSL command to tell the server we want to
 // do a TLS handshake. If that fails, break. Otherwise, perform the handshake.
 // Taken over from the original zgrab.
-func (ftp *Connection) GetFTPSCertificates(ctx context.Context, target *zgrab2.ScanTarget, tlsWrapper func(ctx context.Context, target *zgrab2.ScanTarget, l4Conn net.Conn) (*zgrab2.TLSConnection, error)) error {
+func (ftp *Connection) GetFTPSCertificates(ctx context.Context, target *zgrab2.ScanTarget, tlsWrapper func(ctx context.Context, target *zgrab2.ScanTarget, l4Conn net.Conn) (*zgrab2.TLSConnection, error)) *zgrab2.ScanError {
 	ftpsReady, err := ftp.SetupFTPS()
 
 	if err != nil {
-		return fmt.Errorf("error setting up FTPS: %w", err)
+		return zgrab2.DetectScanError(fmt.Errorf("error setting up FTPS: %w", err))
 	}
 	if !ftpsReady {
 		return nil
 	}
 	var conn *zgrab2.TLSConnection
-	if conn, err = tlsWrapper(ctx, target, ftp.conn); err != nil {
-		return fmt.Errorf("error setting up TLS connection to target %s: %w", target.String(), err)
+	conn, err = tlsWrapper(ctx, target, ftp.conn)
+	if conn != nil {
+		ftp.results.TLSLog = conn.GetLog()
 	}
-	ftp.results.TLSLog = conn.GetLog()
-
+	if err != nil {
+		return zgrab2.NewScanError(zgrab2.SCAN_HANDSHAKE_ERROR, fmt.Errorf("error setting up TLS connection to target %s: %w", target.String(), err))
+	}
 	ftp.conn = conn
+
 	return nil
 }
 
@@ -277,22 +280,28 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 		if tlsWrapper == nil {
 			return zgrab2.SCAN_INVALID_INPUTS, nil, errors.New("TLS wrapper is required for implicit TLS")
 		}
-		conn, err = tlsWrapper(ctx, target, conn)
-		if err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		tlsConn, tlsErr := tlsWrapper(ctx, target, conn)
+		if tlsConn != nil {
+			conn = tlsConn
+		}
+		if tlsErr != nil {
+			result := ScanResults{ImplicitTLS: true}
+			if tlsConn != nil {
+				result.TLSLog = tlsConn.GetLog()
+			}
+
+			return zgrab2.SCAN_HANDSHAKE_ERROR, &result, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), tlsErr)
 		}
 	}
 	results := ScanResults{
 		ImplicitTLS: scanner.config.ImplicitTLS,
 	}
-	defer func() {
-		// Check if we have a TLS conn and grab the log
-		if tlsConn, ok := conn.(*zgrab2.TLSConnection); ok {
-			results.TLSLog = tlsConn.GetLog()
-		}
-		// cleanup conn
-		zgrab2.CloseConnAndHandleError(conn)
-	}()
+	// Capture TLSLog now so it is included in ftp.results (a value copy of results).
+	// For the AUTH TLS path, GetFTPSCertificates sets ftp.results.TLSLog directly.
+	if tlsConn, ok := conn.(*zgrab2.TLSConnection); ok {
+		results.TLSLog = tlsConn.GetLog()
+	}
+	defer func() { zgrab2.CloseConnAndHandleError(conn) }()
 	ftp := Connection{conn: conn, config: scanner.config, results: results}
 	is200Banner, err := ftp.GetFTPBanner()
 	if err != nil {
@@ -303,8 +312,8 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 		if tlsWrapper == nil {
 			return zgrab2.SCAN_INVALID_INPUTS, nil, errors.New("TLS wrapper is required for FTPS")
 		}
-		if err := ftp.GetFTPSCertificates(ctx, target, tlsWrapper); err != nil {
-			return zgrab2.TryGetScanStatus(err), &ftp.results, fmt.Errorf("error getting FTPS certificates for target %s: %w", target.String(), err)
+		if scanErr := ftp.GetFTPSCertificates(ctx, target, tlsWrapper); scanErr != nil {
+			return scanErr.Unpack(&ftp.results)
 		}
 	}
 	return zgrab2.SCAN_SUCCESS, &ftp.results, nil

--- a/modules/ftp/scanner_test.go
+++ b/modules/ftp/scanner_test.go
@@ -1,0 +1,93 @@
+package ftp
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules/testhelpers"
+)
+
+func TestFTPImplicitTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	scanner := &Scanner{config: &Flags{ImplicitTLS: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 990}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestFTPAuthTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	// Fake FTP server: send banner, accept AUTH TLS, then the TLS wrapper fails.
+	go func() {
+		defer serverConn.Close()
+		buf := make([]byte, 512)
+		serverConn.Write([]byte("220 FTP server ready\r\n"))
+		serverConn.Read(buf) // AUTH TLS
+		serverConn.Write([]byte("234 AUTH TLS OK\r\n"))
+	}()
+
+	scanner := &Scanner{config: &Flags{FTPAuthTLS: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 21}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestFTPImplicitTLSHandshakeCompletedSuccessfully(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	srvDone := testhelpers.RunTLSServer(t, serverConn, cert, func(srv *stdtls.Conn) {
+		srv.Write([]byte("220 FTP server ready\r\n"))
+	})
+
+	scanner := &Scanner{config: &Flags{ImplicitTLS: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 990}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-srvDone; err != nil {
+		t.Fatalf("server-side TLS error: %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Errorf("expected SCAN_SUCCESS, got %s", status)
+	}
+	ftpResult, ok := result.(*ScanResults)
+	if !ok || ftpResult == nil {
+		t.Fatal("expected non-nil *ScanResults")
+	}
+	if ftpResult.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !ftpResult.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true")
+	}
+}

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -216,10 +216,12 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	if scanner.config.IMAPSecure {
 		var tlsConn *zgrab2.TLSConnection
 		tlsConn, err = dialGroup.TLSWrapper(ctx, target, c)
-		if err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping TLS connection for target %s: %w", target.String(), err)
+		if tlsConn != nil {
+			result.TLSLog = tlsConn.GetLog()
 		}
-		result.TLSLog = tlsConn.GetLog()
+		if err != nil {
+			return zgrab2.SCAN_HANDSHAKE_ERROR, result, fmt.Errorf("error wrapping TLS connection for target %s: %w", target.String(), err)
+		}
 		c = tlsConn
 	}
 	conn := Connection{Conn: c}
@@ -245,10 +247,12 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 			return zgrab2.TryGetScanStatus(err), result, fmt.Errorf("error in response to STLS command for IMAP %s: %w", target.String(), err)
 		}
 		tlsConn, err := dialGroup.TLSWrapper(ctx, target, c)
-		if err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping TLS connection for target %s: %w", target.String(), err)
+		if tlsConn != nil {
+			result.TLSLog = tlsConn.GetLog()
 		}
-		result.TLSLog = tlsConn.GetLog()
+		if err != nil {
+			return zgrab2.SCAN_HANDSHAKE_ERROR, result, fmt.Errorf("error wrapping TLS connection for target %s: %w", target.String(), err)
+		}
 		conn.Conn = tlsConn
 	}
 	if scanner.config.SendCLOSE {

--- a/modules/imap/scanner_test.go
+++ b/modules/imap/scanner_test.go
@@ -1,0 +1,92 @@
+package imap
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules/testhelpers"
+)
+
+func TestIMAPSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	scanner := &Scanner{config: &Flags{IMAPSecure: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 993}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestIMAPSTARTTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	go func() {
+		defer serverConn.Close()
+		buf := make([]byte, 512)
+		serverConn.Write([]byte("* OK IMAP4 ready\r\n"))
+		serverConn.Read(buf) // a001 STARTTLS
+		serverConn.Write([]byte("a001 OK Begin TLS\r\n"))
+	}()
+
+	scanner := &Scanner{config: &Flags{StartTLS: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 143}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestIMAPSHandshakeCompletedSuccessfully(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	srvDone := testhelpers.RunTLSServer(t, serverConn, cert, func(srv *stdtls.Conn) {
+		srv.Write([]byte("* OK IMAP4 ready\r\n"))
+	})
+
+	scanner := &Scanner{config: &Flags{IMAPSecure: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 993}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-srvDone; err != nil {
+		t.Fatalf("server-side TLS error: %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Errorf("expected SCAN_SUCCESS, got %s", status)
+	}
+	imapResult, ok := result.(*ScanResults)
+	if !ok || imapResult == nil {
+		t.Fatal("expected non-nil *ScanResults")
+	}
+	if imapResult.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !imapResult.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true")
+	}
+}

--- a/modules/managesieve/scanner.go
+++ b/modules/managesieve/scanner.go
@@ -200,10 +200,12 @@ func (scanner *Scanner) Scan(ctx context.Context, dialerGroup *zgrab2.DialerGrou
 
 		// Initiate TLS Handshake
 		tlsConn, err := dialerGroup.TLSWrapper(ctx, target, conn)
-		if err != nil {
-			return zgrab2.TryGetScanStatus(err), results, fmt.Errorf("could not initiate a TLS connection with server that says it supports STARTTLS: %w", err)
+		if tlsConn != nil {
+			results.TLSLog = tlsConn.GetLog()
 		}
-		results.TLSLog = tlsConn.GetLog()
+		if err != nil {
+			return zgrab2.SCAN_HANDSHAKE_ERROR, results, fmt.Errorf("could not initiate a TLS connection with server that says it supports STARTTLS: %w", err)
+		}
 
 		// After TLS handshake, read capabilities again
 		// RFC 5804 Section 2.2 - "After the TLS layer is established, the server MUST re-issue the
@@ -213,7 +215,7 @@ func (scanner *Scanner) Scan(ctx context.Context, dialerGroup *zgrab2.DialerGrou
 		// STARTTLS capability."
 		postTLSCapResponse, err := scanner.readResponse(tlsConn, scanner.config.BannerTimeout)
 		if err != nil {
-			return zgrab2.SCAN_PROTOCOL_ERROR, results, fmt.Errorf("failed to read post-TLS capabilities: %v", err)
+			return zgrab2.SCAN_POST_TLS_APPLICATION_ERROR, results, fmt.Errorf("failed to read post-TLS capabilities: %v", err)
 		}
 		postTLSCapResponse = strings.ReplaceAll(postTLSCapResponse, "\"", "")
 		results.PostTLSCapabilities = strings.Split(postTLSCapResponse, "\n")

--- a/modules/managesieve/scanner_test.go
+++ b/modules/managesieve/scanner_test.go
@@ -1,0 +1,133 @@
+package managesieve
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules/testhelpers"
+)
+
+// runManageSievePreTLS performs the pre-STARTTLS exchange on serverConn
+// (banner → CAPABILITY → STARTTLS response) and then calls fn with serverConn
+// so the caller can handle the TLS phase. Runs in a goroutine; closes
+// serverConn when done.
+func runManageSievePreTLS(serverConn net.Conn, fn func(net.Conn)) {
+	go func() {
+		defer serverConn.Close()
+		buf := make([]byte, 512)
+		serverConn.Write([]byte("OK\r\n"))                 // initial greeting
+		serverConn.Read(buf)                               // CAPABILITY command
+		serverConn.Write([]byte("\"STARTTLS\"\r\nOK\r\n")) // capabilities with STARTTLS
+		serverConn.Read(buf)                               // STARTTLS command
+		serverConn.Write([]byte("OK\r\n"))                 // STARTTLS accepted
+		fn(serverConn)
+	}()
+}
+
+func TestManageSieveSTARTTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	runManageSievePreTLS(serverConn, func(_ net.Conn) {
+		// TLS wrapper will be called next and will fail; nothing to do here.
+	})
+
+	scanner := &Scanner{config: &Flags{BannerTimeout: 5 * time.Second}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 4190}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestManageSievePostTLSCapabilitiesError(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	// Complete STARTTLS exchange and TLS handshake, then close without sending
+	// post-TLS capabilities to trigger SCAN_POST_TLS_APPLICATION_ERROR.
+	runManageSievePreTLS(serverConn, func(conn net.Conn) {
+		srv := stdtls.Server(conn, &stdtls.Config{Certificates: []stdtls.Certificate{cert}})
+		srv.Handshake() //nolint:errcheck // close on error is handled by defer in runManageSievePreTLS
+		// Close immediately — scanner's readResponse on the TLS conn will get EOF.
+	})
+
+	scanner := &Scanner{config: &Flags{BannerTimeout: 5 * time.Second}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 4190}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_POST_TLS_APPLICATION_ERROR {
+		t.Errorf("expected SCAN_POST_TLS_APPLICATION_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	msResult, ok := result.(*ScanResults)
+	if !ok {
+		t.Fatal("expected *ScanResults")
+	}
+	if msResult.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !msResult.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true after successful TLS handshake")
+	}
+}
+
+func TestManageSieveHandshakeCompletedSuccessfully(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	done := make(chan error, 1)
+	runManageSievePreTLS(serverConn, func(conn net.Conn) {
+		srv := stdtls.Server(conn, &stdtls.Config{Certificates: []stdtls.Certificate{cert}})
+		if err := srv.Handshake(); err != nil {
+			done <- err
+
+			return
+		}
+		// Send post-TLS capabilities so the scanner reaches SCAN_SUCCESS.
+		srv.Write([]byte("OK\r\n"))
+		done <- nil
+	})
+
+	scanner := &Scanner{config: &Flags{BannerTimeout: 5 * time.Second}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 4190}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-done; err != nil {
+		t.Fatalf("server-side TLS error: %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Errorf("expected SCAN_SUCCESS, got %s", status)
+	}
+	msResult, ok := result.(*ScanResults)
+	if !ok || msResult == nil {
+		t.Fatal("expected non-nil *ScanResults")
+	}
+	if msResult.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !msResult.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true")
+	}
+}

--- a/modules/mysql/scanner.go
+++ b/modules/mysql/scanner.go
@@ -262,11 +262,18 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 		if tlsWrapper == nil {
 			return zgrab2.SCAN_PROTOCOL_ERROR, nil, errors.New("TLS wrapper required for mysql")
 		}
-		if tlsConn, err = tlsWrapper(ctx, target, conn); err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		tlsConn, err = tlsWrapper(ctx, target, conn)
+		if tlsConn != nil {
+			sql.Connection = tlsConn
 		}
-		// Replace sql.Connection to allow hypothetical future calls to go over the secure connection
-		sql.Connection = tlsConn
+		if err != nil {
+			result := readResultsFromConnectionLog(&sql.ConnectionLog)
+			if result != nil && tlsConn != nil {
+				result.TLSLog = tlsConn.GetLog()
+			}
+
+			return zgrab2.SCAN_HANDSHAKE_ERROR, result, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		}
 	}
 
 	result := readResultsFromConnectionLog(&sql.ConnectionLog)

--- a/modules/mysql/scanner_test.go
+++ b/modules/mysql/scanner_test.go
@@ -57,9 +57,12 @@ func TestMySQLTLSHandshakeError(t *testing.T) {
 		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
 	}
 
-	status, _, _ := scanner.Scan(context.Background(), dialGroup, target)
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
 	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
 		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
 	}
 }
 

--- a/modules/mysql/scanner_test.go
+++ b/modules/mysql/scanner_test.go
@@ -1,0 +1,110 @@
+package mysql
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules/testhelpers"
+)
+
+// mysqlHandshakeV10 returns a minimal MySQL HandshakeV10 packet with the
+// CLIENT_SSL capability flag set so that SupportsTLS() returns true.
+//
+// Byte layout (4-byte packet header + 38-byte payload):
+//
+//	header:  [0x26, 0x00, 0x00, 0x00]  length=38, sequence=0
+//	payload: protocol_version(1) + server_version("5.7.0\0", 6) +
+//	         connection_id(4) + auth_plugin_data_1(8) + filler(1) +
+//	         capability_flags_lower(2, CLIENT_SSL=0x0800 LE) +
+//	         character_set(1) + status_flags(2) +
+//	         capability_flags_upper(2) + auth_plugin_data_len(1) +
+//	         reserved(10)
+func mysqlHandshakeV10() []byte {
+	payload := []byte{
+		0x0a,                               // protocol version 10
+		0x35, 0x2e, 0x37, 0x2e, 0x30, 0x00, // "5.7.0\0"
+		0x01, 0x00, 0x00, 0x00, // connection_id = 1 (LE)
+		0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, // auth-plugin-data-1
+		0x00,       // filler
+		0x00, 0x08, // capability flags lower: CLIENT_SSL (0x0800, LE)
+		0x21,       // character set (utf8_general_ci)
+		0x00, 0x00, // status flags
+		0x00, 0x00, // capability flags upper
+		0x00,                                                       // auth_plugin_data_len
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reserved (10 bytes)
+	}
+	return append([]byte{byte(len(payload)), 0x00, 0x00, 0x00}, payload...)
+}
+
+func TestMySQLTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	go func() {
+		defer serverConn.Close()
+		serverConn.Write(mysqlHandshakeV10())
+		buf := make([]byte, 64)
+		serverConn.Read(buf) // SSLRequest from client
+		// TLS wrapper is called next and fails.
+	}()
+
+	scanner := &Scanner{config: &Flags{}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 3306}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, _, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+}
+
+func TestMySQLHandshakeCompletedSuccessfully(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	srvDone := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+		serverConn.Write(mysqlHandshakeV10())
+		buf := make([]byte, 64)
+		serverConn.Read(buf) // SSLRequest from client
+		// Now perform the TLS handshake as the server.
+		srv := stdtls.Server(serverConn, &stdtls.Config{Certificates: []stdtls.Certificate{cert}})
+		if err := srv.Handshake(); err != nil {
+			srvDone <- err
+
+			return
+		}
+		srvDone <- nil
+	}()
+
+	scanner := &Scanner{config: &Flags{}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 3306}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	_, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-srvDone; err != nil {
+		t.Fatalf("server-side TLS error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	mysqlResult, ok := result.(*ScanResults)
+	if !ok {
+		t.Fatal("expected *ScanResults")
+	}
+	if mysqlResult.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !mysqlResult.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true")
+	}
+}

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -234,10 +234,12 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 		// Perform a TLS handshake immediately
 		var tlsConn *zgrab2.TLSConnection
 		tlsConn, err = tlsWrapper(ctx, target, c)
-		if err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		if tlsConn != nil {
+			result.TLSLog = tlsConn.GetLog()
 		}
-		result.TLSLog = tlsConn.GetLog()
+		if err != nil {
+			return zgrab2.SCAN_HANDSHAKE_ERROR, result, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		}
 		c = tlsConn
 	}
 	conn := Connection{Conn: c}
@@ -278,10 +280,12 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 		}
 		var tlsConn *zgrab2.TLSConnection
 		tlsConn, err = tlsWrapper(ctx, target, conn.Conn)
-		if err != nil {
-			return zgrab2.TryGetScanStatus(err), nil, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		if tlsConn != nil {
+			result.TLSLog = tlsConn.GetLog()
 		}
-		result.TLSLog = tlsConn.GetLog()
+		if err != nil {
+			return zgrab2.SCAN_HANDSHAKE_ERROR, result, fmt.Errorf("error wrapping connection in TLS for target %s: %w", target.String(), err)
+		}
 		conn.Conn = tlsConn
 	}
 	if scanner.config.SendQUIT {

--- a/modules/pop3/scanner_test.go
+++ b/modules/pop3/scanner_test.go
@@ -1,0 +1,92 @@
+package pop3
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules/testhelpers"
+)
+
+func TestPOP3SHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	scanner := &Scanner{config: &Flags{POP3Secure: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 995}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestPOP3STARTTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	go func() {
+		defer serverConn.Close()
+		buf := make([]byte, 512)
+		serverConn.Write([]byte("+OK POP3 ready\r\n"))
+		serverConn.Read(buf) // STLS
+		serverConn.Write([]byte("+OK Begin TLS\r\n"))
+	}()
+
+	scanner := &Scanner{config: &Flags{StartTLS: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 110}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on handshake error")
+	}
+}
+
+func TestPOP3SHandshakeCompletedSuccessfully(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	srvDone := testhelpers.RunTLSServer(t, serverConn, cert, func(srv *stdtls.Conn) {
+		srv.Write([]byte("+OK POP3 ready\r\n"))
+	})
+
+	scanner := &Scanner{config: &Flags{POP3Secure: true}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 995}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-srvDone; err != nil {
+		t.Fatalf("server-side TLS error: %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Errorf("expected SCAN_SUCCESS, got %s", status)
+	}
+	pop3Result, ok := result.(*ScanResults)
+	if !ok || pop3Result == nil {
+		t.Fatal("expected non-nil *ScanResults")
+	}
+	if pop3Result.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !pop3Result.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true")
+	}
+}

--- a/modules/postgres/scanner.go
+++ b/modules/postgres/scanner.go
@@ -353,11 +353,15 @@ func (scanner *Scanner) DoSSL(ctx context.Context, sql *Connection, dialGroup *z
 	if tlsWrapper == nil {
 		return errors.New("dial group does not have a TLS wrapper")
 	}
-	if conn, err = tlsWrapper(ctx, sql.Target, sql.Connection); err != nil {
+	conn, err = tlsWrapper(ctx, sql.Target, sql.Connection)
+	if conn != nil {
+		// Store even on failure so GetTLSLog captures partial handshake data.
+		sql.Connection = conn
+	}
+	if err != nil {
 		return fmt.Errorf("could not wrap connection in TLS to %s: %w", sql.Target.String(), err)
 	}
-	// Replace sql.Connection to allow future calls to go over the secure connection
-	sql.Connection = conn
+
 	return nil
 }
 
@@ -383,7 +387,7 @@ func (scanner *Scanner) newConnection(ctx context.Context, target *zgrab2.ScanTa
 		}
 		if hasSSL {
 			if err = scanner.DoSSL(ctx, &sql, dialGroup); err != nil {
-				return nil, zgrab2.NewScanError(zgrab2.SCAN_APPLICATION_ERROR, err)
+				return nil, zgrab2.NewScanError(zgrab2.SCAN_HANDSHAKE_ERROR, err)
 			}
 			sql.IsSSL = true
 		}

--- a/modules/postgres/scanner_test.go
+++ b/modules/postgres/scanner_test.go
@@ -1,0 +1,99 @@
+package postgres
+
+import (
+	"context"
+	stdtls "crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/modules/testhelpers"
+)
+
+// runPostgresSSLServer accepts a single Postgres SSLRequest (8 bytes), replies
+// 'S' (SSL supported), then calls fn with the raw conn for the TLS phase.
+// Runs in a goroutine; the caller is responsible for closing serverConn via
+// the done channel or fn.
+func runPostgresSSLServer(serverConn net.Conn, fn func(net.Conn)) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+		buf := make([]byte, 8)
+		if _, err := serverConn.Read(buf); err != nil { // SSLRequest
+			done <- err
+
+			return
+		}
+		if _, err := serverConn.Write([]byte{'S'}); err != nil { // SSL supported
+			done <- err
+
+			return
+		}
+		fn(serverConn)
+		done <- nil
+	}()
+
+	return done
+}
+
+func TestPostgresTLSHandshakeError(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	srvDone := runPostgresSSLServer(serverConn, func(_ net.Conn) {
+		// TLS wrapper is called next and fails; nothing to do here.
+	})
+
+	scanner := &Scanner{Config: &Flags{}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 5432}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeFailingTLSWrapper(),
+	}
+
+	status, _, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-srvDone; err != nil {
+		t.Logf("server goroutine: %v", err) // may see a write error after client fails
+	}
+	if status != zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("expected SCAN_HANDSHAKE_ERROR, got %s", status)
+	}
+}
+
+func TestPostgresHandshakeCompletedSuccessfully(t *testing.T) {
+	cert := testhelpers.GenerateTestCert(t)
+	clientConn, serverConn := net.Pipe()
+
+	srvDone := runPostgresSSLServer(serverConn, func(conn net.Conn) {
+		srv := stdtls.Server(conn, &stdtls.Config{Certificates: []stdtls.Certificate{cert}})
+		srv.Handshake() //nolint:errcheck // close is handled by defer in runPostgresSSLServer
+		// Close after handshake; the scanner will get an error on its subsequent
+		// StartupMessage write, but results.TLSLog will already be set.
+	})
+
+	scanner := &Scanner{Config: &Flags{}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 5432}
+	dialGroup := &zgrab2.DialerGroup{
+		L4Dialer:   testhelpers.MakeL4Dialer(clientConn),
+		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
+	}
+
+	_, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	if err := <-srvDone; err != nil {
+		t.Logf("server goroutine: %v", err)
+	}
+	// The scan may not return SCAN_SUCCESS (post-TLS postgres conversation
+	// fails since the server closed), but TLSLog must be populated.
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	pgResult, ok := result.(*Results)
+	if !ok {
+		t.Fatal("expected *Results")
+	}
+	if pgResult.TLSLog == nil {
+		t.Fatal("expected TLSLog to be populated")
+	}
+	if !pgResult.TLSLog.HandshakeCompletedSuccessfully {
+		t.Error("expected HandshakeCompletedSuccessfully = true")
+	}
+}

--- a/modules/postgres/scanner_test.go
+++ b/modules/postgres/scanner_test.go
@@ -77,12 +77,16 @@ func TestPostgresHandshakeCompletedSuccessfully(t *testing.T) {
 		TLSWrapper: testhelpers.MakeInsecureTLSWrapper(),
 	}
 
-	_, result, _ := scanner.Scan(context.Background(), dialGroup, target)
+	status, result, _ := scanner.Scan(context.Background(), dialGroup, target)
 	if err := <-srvDone; err != nil {
 		t.Logf("server goroutine: %v", err)
 	}
-	// The scan may not return SCAN_SUCCESS (post-TLS postgres conversation
-	// fails since the server closed), but TLSLog must be populated.
+	// The server closes after the handshake, so the scan will not reach
+	// SCAN_SUCCESS, but the TLS handshake did complete — SCAN_HANDSHAKE_ERROR
+	// would indicate a regression where HandshakeCompletedSuccessfully is lost.
+	if status == zgrab2.SCAN_HANDSHAKE_ERROR {
+		t.Errorf("unexpected SCAN_HANDSHAKE_ERROR: TLS handshake completed successfully")
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}

--- a/modules/testhelpers/testhelpers.go
+++ b/modules/testhelpers/testhelpers.go
@@ -1,0 +1,100 @@
+// Package testhelpers provides shared utilities for zgrab2 module scanner tests.
+package testhelpers
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	stdtls "crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	zcryptotls "github.com/zmap/zcrypto/tls"
+
+	"github.com/zmap/zgrab2"
+)
+
+// MakeL4Dialer returns an L4Dialer that always returns conn regardless of the
+// target or address arguments.
+func MakeL4Dialer(conn net.Conn) func(*zgrab2.ScanTarget) func(context.Context, string, string) (net.Conn, error) {
+	return func(*zgrab2.ScanTarget) func(context.Context, string, string) (net.Conn, error) {
+		return func(context.Context, string, string) (net.Conn, error) {
+			return conn, nil
+		}
+	}
+}
+
+// GenerateTestCert generates a throwaway self-signed RSA certificate suitable
+// for use in TLS tests. The server side can use stdlib crypto/tls with this
+// certificate and the client side can accept it with InsecureSkipVerify.
+func GenerateTestCert(t *testing.T) stdtls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	cert, err := stdtls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("load TLS cert: %v", err)
+	}
+
+	return cert
+}
+
+// RunTLSServer starts a stdlib TLS server on serverConn using cert, completes
+// the handshake, calls fn with the established connection for any
+// protocol-specific writes, and returns a channel that receives the first
+// server-side error (nil on success). The caller should drain the channel to
+// detect handshake failures in the server goroutine.
+func RunTLSServer(t *testing.T, serverConn net.Conn, cert stdtls.Certificate, fn func(*stdtls.Conn)) <-chan error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+		srv := stdtls.Server(serverConn, &stdtls.Config{Certificates: []stdtls.Certificate{cert}})
+		if err := srv.Handshake(); err != nil {
+			done <- err
+
+			return
+		}
+		fn(srv)
+		done <- nil
+	}()
+
+	return done
+}
+
+// MakeFailingTLSWrapper returns a TLS wrapper that immediately returns a
+// handshake error without attempting a real handshake.
+func MakeFailingTLSWrapper() func(context.Context, *zgrab2.ScanTarget, net.Conn) (*zgrab2.TLSConnection, error) {
+	return func(_ context.Context, _ *zgrab2.ScanTarget, _ net.Conn) (*zgrab2.TLSConnection, error) {
+		return nil, errors.New("tls: handshake failure")
+	}
+}
+
+// MakeInsecureTLSWrapper returns a real zcrypto TLS wrapper with
+// InsecureSkipVerify set, allowing it to accept the self-signed test
+// certificates produced by GenerateTestCert.
+func MakeInsecureTLSWrapper() func(context.Context, *zgrab2.ScanTarget, net.Conn) (*zgrab2.TLSConnection, error) {
+	return zgrab2.GetDefaultTLSWrapper(&zgrab2.BaseFlags{}, &zgrab2.TLSFlags{
+		Config: &zcryptotls.Config{InsecureSkipVerify: true},
+	})
+}


### PR DESCRIPTION
## Summary

Follow-on to #718, which introduced `SCAN_HANDSHAKE_ERROR` and `SCAN_POST_TLS_APPLICATION_ERROR` for SMTP. This PR rolls the same error-status alignment out to the remaining TLS-using modules.

**Key decision from #718 review:** `SCAN_POST_TLS_APPLICATION_ERROR` is only appropriate for protocols with application-layer exchanges both _before and after_ the TLS handshake (SMTP, ManageSieve). All other modules (IMAP, POP3, FTP, MySQL, Postgres) are TCP→TLS→App and keep `SCAN_APPLICATION_ERROR` for app-level errors — only TLS handshake failures move to `SCAN_HANDSHAKE_ERROR`.

### Per-module changes

| Module | TLS handshake failure | Post-TLS app error |
|---|---|---|
| IMAP | `SCAN_HANDSHAKE_ERROR` | kept `SCAN_APPLICATION_ERROR` |
| POP3 | `SCAN_HANDSHAKE_ERROR` | kept `SCAN_APPLICATION_ERROR` |
| FTP | `SCAN_HANDSHAKE_ERROR` | N/A |
| ManageSieve | `SCAN_HANDSHAKE_ERROR` | `SCAN_POST_TLS_APPLICATION_ERROR` |
| MySQL | `SCAN_HANDSHAKE_ERROR` | kept `SCAN_APPLICATION_ERROR` |
| Postgres | `SCAN_HANDSHAKE_ERROR` | kept `SCAN_APPLICATION_ERROR` |

In all cases, any partial `TLSLog` (including `HandshakeCompletedSuccessfully`) is now captured before returning the error.

### Additional fixes

- **FTP `GetFTPSCertificates`**: return type changed from `error` to `*zgrab2.ScanError` so the caller propagates the exact status without going through `TryGetScanStatus`.
- **FTP implicit TLS (bugfix)**: `TLSLog` was being written into a local `results` variable via a `defer`, but the return value was `&ftp.results` (a value copy made before the defer ran) — so `TLSLog` was silently `nil` on every implicit-TLS success. Fixed by capturing it directly before initialising `ftp`.
- **Postgres `DoSSL`**: stores the `TLS` connection even on handshake failure so `GetTLSLog` can surface partial handshake data. Also fixes an unintended retry: the SSL-retry loop checked `connectErr.Status == SCAN_APPLICATION_ERROR` to decide whether to fall back to non-SSL — a `DoSSL` failure was incorrectly triggering that retry since it was previously `SCAN_APPLICATION_ERROR`. Now it's `SCAN_HANDSHAKE_ERROR` and the retry no longer fires.
