### PR TITLE
fix: recover from scanner panics without killing the process

### DIFF
--- a/processing.go
+++ b/processing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"runtime/debug"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -258,9 +259,13 @@ func grabTarget(ctx context.Context, input ScanTarget, m *Monitor) *Grab {
 		}
 		defer func(name string) {
 			if e := recover(); e != nil {
-				log.Errorf("Panic on scanner %s when scanning target %s: %#v", scannerName, input.String(), e)
-				// Bubble out original error (with original stack) in lieu of explicitly logging the stack / error
-				panic(e)
+				log.Errorf("Panic on scanner %s when scanning target %s: %#v\n%s", name, input.String(), e, debug.Stack())
+				errMsg := fmt.Sprintf("panic: %v", e)
+				moduleResult[name] = ScanResponse{
+					Status:   SCAN_UNKNOWN_ERROR,
+					Protocol: name,
+					Error:    &errMsg,
+				}
 			}
 		}(scannerName)
 		name, res := RunScanner(ctx, *scanner, m, input)


### PR DESCRIPTION
The deferred recover() in grabTarget() was re-panicking after logging, which propagates up to the worker goroutine in Process() that has no recover. A single panic in any scanner (e.g. nil deref parsing a malformed server response) would terminate the entire zgrab2 process, killing all in-flight workers and preventing buffered output from flushing.

Changes:
- Remove re-panic; record a SCAN_UNKNOWN_ERROR result instead
- Log the full stack trace via debug.Stack() for diagnostics
- Use the captured 'name' parameter instead of the loop variable 'scannerName' which may have advanced past the panicking scanner