### PR TITLE
Close connection when TimeoutConnection wrapping fails

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -318,6 +318,8 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 	}
 	ret, err := NewTimeoutConnection(ctx, conn, d.SessionTimeout, d.ReadTimeout, d.WriteTimeout, d.BytesReadLimit)
 	if err != nil {
+		// Avoid leaking the established connection if wrapping it fails.
+		_ = conn.Close()
 		return nil, err
 	}
 	ret.BytesReadLimit = d.BytesReadLimit


### PR DESCRIPTION
*This PR was generated with the assistance of GitHub Copilot CLI and may require human review.*

## Problem
In `Dialer.DialContext` (`conn.go`), if `NewTimeoutConnection` returns an error after the underlying connection has already been established, the function returns the error without closing the connection — leaking the established socket.

## Fix
Close the connection on the error path before returning.

```go
ret, err := NewTimeoutConnection(ctx, conn, ...)
if err != nil {
    _ = conn.Close() // avoid leaking the established connection
    return nil, err
}
```

Severity: low. Found via AI code review.