### PR TITLE
mssql: prevent uint16 overflow in PRELOGIN option bounds check

### DIFF
--- a/modules/mssql/connection.go
+++ b/modules/mssql/connection.go
@@ -443,16 +443,20 @@ func decodePreloginOptions(body []byte) (result *PreloginOptions, rest []byte, e
 			return nil, nil, ErrInvalidData
 		}
 		token := PreloginOptionToken(cursor[0])
-		offset := binary.BigEndian.Uint16(cursor[1:3])
-		length := binary.BigEndian.Uint16(cursor[3:5])
-		if len(body) < int(offset+length) {
+		// Widen to int before adding: offset and length are attacker-controlled
+		// uint16s, so offset+length can overflow uint16 and wrap to a small
+		// value, defeating the bounds check below and causing an out-of-range
+		// slice panic on the following line.
+		offset := int(binary.BigEndian.Uint16(cursor[1:3]))
+		length := int(binary.BigEndian.Uint16(cursor[3:5]))
+		if len(body) < offset+length {
 			return nil, nil, ErrInvalidData
 		}
 		options[token] = body[offset : offset+length]
 
-		if int(offset+length) > max {
+		if offset+length > max {
 			// max points to the byte after the last byte consumed in body
-			max = int(offset + length)
+			max = offset + length
 		}
 		cursor = cursor[5:]
 	}

--- a/modules/mssql/connection_test.go
+++ b/modules/mssql/connection_test.go
@@ -1,0 +1,40 @@
+package mssql
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestDecodePreloginOptionsOverflow ensures a PRELOGIN option whose
+// offset+length overflows a uint16 is rejected as invalid data rather than
+// panicking with an out-of-range slice. A malicious MSSQL server controls
+// these fields, so the bounds check must not be defeated by integer overflow.
+func TestDecodePreloginOptionsOverflow(t *testing.T) {
+	// token=0x00, offset=0xFFFF, length=0x0002 (offset+length wraps to 1 in
+	// uint16 arithmetic), terminator=0xff.
+	body := []byte{0x00, 0xFF, 0xFF, 0x00, 0x02, 0xFF}
+	opts, rest, err := decodePreloginOptions(body)
+	if !errors.Is(err, ErrInvalidData) {
+		t.Fatalf("expected ErrInvalidData, got opts=%v rest=%v err=%v", opts, rest, err)
+	}
+}
+
+// TestDecodePreloginOptionsValid confirms a well-formed PRELOGIN body still
+// decodes correctly after the overflow-hardening change.
+func TestDecodePreloginOptionsValid(t *testing.T) {
+	// One option: token=0x00, offset=0x0006 (points just past the 6-byte
+	// header: 5-byte option entry + 0xff terminator), length=0x0002; followed
+	// by the terminator and the 2 value bytes.
+	body := []byte{0x00, 0x00, 0x06, 0x00, 0x02, 0xFF, 0xAB, 0xCD}
+	opts, _, err := decodePreloginOptions(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, ok := (*opts)[PreloginOptionToken(0x00)]
+	if !ok {
+		t.Fatalf("expected token 0x00 to be present, got %v", *opts)
+	}
+	if want := []byte{0xAB, 0xCD}; string(got) != string(want) {
+		t.Fatalf("expected value %v, got %v", want, got)
+	}
+}


### PR DESCRIPTION
A malformed MSSQL PRELOGIN response can crash a scan because the offset+length bounds check in `decodePreloginOptions` is computed in `uint16` arithmetic and can overflow, so this widens both values to `int` before the check.

`offset` and `length` are read straight from the server's PRELOGIN response as `uint16`. The guard `if len(body) < int(offset+length)` evaluates `offset+length` as a `uint16`, so a large offset wraps around instead of failing the check. For example `offset=0xFFFF, length=0x0002` wraps to `1`, the check passes, and the next line `body[offset : offset+length]` slices `body[65535:1]`, panicking with `slice bounds out of range [65535:1]`. Since a scanned server fully controls these bytes, any host can trigger the panic. The fix converts `offset` and `length` to `int` at read time so the addition can't wrap, and the existing check then correctly rejects the packet with `ErrInvalidData`.

## How to Test

`go test ./modules/mssql/`

Two new tests in `modules/mssql/connection_test.go` cover it:
- `TestDecodePreloginOptionsOverflow` feeds the overflowing option above and asserts `ErrInvalidData` is returned (before the fix this test panics).
- `TestDecodePreloginOptionsValid` confirms a well-formed PRELOGIN body still decodes to the right option value.

## Notes & Caveats

Behavior is unchanged for valid packets; only inputs that previously panicked now return `ErrInvalidData`, matching how other malformed PRELOGIN bodies are already handled in this function.

## Issue Tracking

No existing issue; found while reviewing the PRELOGIN parser.
