### PR TITLE
banner: add ZMap-compatible probe templates [COPILOT]

### DIFF
--- a/modules/banner/README.md
+++ b/modules/banner/README.md
@@ -1,0 +1,39 @@
+# Banner probe templates
+
+The `banner` module can expand probe data after opening each connection. This
+mode is opt-in so existing probes remain unchanged:
+
+```shell
+zgrab2 banner --expand-probe --probe-file request.tpl
+```
+
+The template syntax and field byte encodings match ZMap's UDP probe templates:
+
+| Field | Expansion |
+| --- | --- |
+| `${SADDR}`, `${DADDR}` | Source and destination IP addresses as text |
+| `${SPORT}`, `${DPORT}` | Source and destination ports as text |
+| `${SADDR_N}`, `${DADDR_N}` | IPv4 source and destination addresses in network byte order |
+| `${SPORT_N}`, `${DPORT_N}` | Source and destination ports in network byte order |
+| `${RAND_BYTE=n}` | `n` random bytes |
+| `${RAND_DIGIT=n}` | `n` random ASCII digits |
+| `${RAND_ALPHA=n}` | `n` random mixed-case ASCII letters |
+| `${RAND_ALPHANUM=n}` | `n` random ASCII letters or digits |
+| `${HEX=value}` | Hexadecimal `value` decoded to bytes |
+| `${UNIXTIME_SEC}` | Unix seconds in 32-bit network byte order |
+| `${UNIXTIME_USEC}` | Microseconds within the current second in 32-bit network byte order |
+| `${NTP_TIMESTAMP}` | RFC 5905 64-bit NTP timestamp in network byte order |
+
+Unknown fields are sent literally, matching ZMap. The `_N` address fields are
+defined by ZMap as four-byte IPv4 values and therefore fail on IPv6
+connections; `${SADDR}` and `${DADDR}` support IPv6 text.
+
+For example, this template:
+
+```text
+OPTIONS sip:${RAND_ALPHA=8}@${DADDR} SIP/2.0
+Via: SIP/2.0/TCP ${SADDR}:${SPORT}
+```
+
+is expanded using the actual local and remote socket addresses before the probe
+is sent. Expansion applies equally to `--probe` and `--probe-file`.

--- a/modules/banner/probe_template.go
+++ b/modules/banner/probe_template.go
@@ -1,0 +1,309 @@
+package banner
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxTemplateFieldLength = 1472
+
+type templateFieldType uint8
+
+const (
+	templateLiteral templateFieldType = iota
+	templateSourceAddressNetwork
+	templateSourceAddress
+	templateDestinationAddressNetwork
+	templateDestinationAddress
+	templateSourcePortNetwork
+	templateSourcePort
+	templateDestinationPortNetwork
+	templateDestinationPort
+	templateRandomBytes
+	templateRandomDigits
+	templateRandomAlpha
+	templateRandomAlphanumeric
+	templateHex
+	templateUnixTimeSeconds
+	templateUnixTimeMicroseconds
+	templateNTPTimestamp
+)
+
+type templateField struct {
+	fieldType templateFieldType
+	data      []byte
+	length    int
+}
+
+type probeTemplate struct {
+	fields []templateField
+}
+
+type probeTemplateContext struct {
+	sourceIP        net.IP
+	destinationIP   net.IP
+	sourcePort      uint16
+	destinationPort uint16
+	now             time.Time
+	random          io.Reader
+}
+
+func parseProbeTemplate(probe []byte) (*probeTemplate, error) {
+	template := &probeTemplate{}
+
+	for cursor := 0; cursor < len(probe); {
+		startOffset := bytes.Index(probe[cursor:], []byte("${"))
+		if startOffset < 0 {
+			template.addLiteral(probe[cursor:])
+			break
+		}
+
+		start := cursor + startOffset
+		template.addLiteral(probe[cursor:start])
+
+		endOffset := bytes.IndexByte(probe[start+2:], '}')
+		if endOffset < 0 {
+			template.addLiteral(probe[start:])
+			break
+		}
+
+		end := start + 2 + endOffset
+		field, recognized, err := parseTemplateField(string(probe[start+2 : end]))
+		if err != nil {
+			return nil, err
+		}
+		if recognized {
+			template.fields = append(template.fields, field)
+		} else {
+			template.addLiteral(probe[start : end+1])
+		}
+		cursor = end + 1
+	}
+
+	return template, nil
+}
+
+func (template *probeTemplate) addLiteral(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	copied := append([]byte(nil), data...)
+	if len(template.fields) > 0 && template.fields[len(template.fields)-1].fieldType == templateLiteral {
+		template.fields[len(template.fields)-1].data = append(template.fields[len(template.fields)-1].data, copied...)
+		return
+	}
+	template.fields = append(template.fields, templateField{fieldType: templateLiteral, data: copied})
+}
+
+func parseTemplateField(spec string) (templateField, bool, error) {
+	name, parameter, hasParameter := strings.Cut(spec, "=")
+	fieldType, recognized := templateFieldTypes[name]
+	if !recognized {
+		return templateField{}, false, nil
+	}
+
+	field := templateField{fieldType: fieldType}
+	switch fieldType {
+	case templateHex:
+		if !hasParameter || parameter == "" {
+			return templateField{}, true, errors.New("template field HEX requires a hex value")
+		}
+		if len(parameter)%2 != 0 {
+			return templateField{}, true, fmt.Errorf("template field HEX has odd-length value %q", parameter)
+		}
+		decoded, err := hex.DecodeString(parameter)
+		if err != nil {
+			return templateField{}, true, fmt.Errorf("template field HEX has invalid value %q: %w", parameter, err)
+		}
+		if len(decoded) > maxTemplateFieldLength {
+			return templateField{}, true, fmt.Errorf("template field HEX exceeds maximum length %d", maxTemplateFieldLength)
+		}
+		field.data = decoded
+	case templateRandomBytes, templateRandomDigits, templateRandomAlpha, templateRandomAlphanumeric:
+		if !hasParameter {
+			field.length = 0
+			return field, true, nil
+		}
+		if parameter == "" {
+			return templateField{}, true, fmt.Errorf("template field %s has an empty length", name)
+		}
+		length, err := strconv.Atoi(parameter)
+		if err != nil {
+			return templateField{}, true, fmt.Errorf("template field %s has invalid length %q: %w", name, parameter, err)
+		}
+		if length < 0 || length > maxTemplateFieldLength {
+			return templateField{}, true, fmt.Errorf("template field %s length must be between 0 and %d", name, maxTemplateFieldLength)
+		}
+		field.length = length
+	default:
+		if hasParameter {
+			if parameter == "" {
+				return templateField{}, true, fmt.Errorf("template field %s has an empty parameter", name)
+			}
+			length, err := strconv.Atoi(parameter)
+			if err != nil || length < 0 || length > maxTemplateFieldLength {
+				return templateField{}, true, fmt.Errorf("template field %s has invalid parameter %q", name, parameter)
+			}
+		}
+	}
+	return field, true, nil
+}
+
+var templateFieldTypes = map[string]templateFieldType{
+	"SADDR_N":       templateSourceAddressNetwork,
+	"SADDR":         templateSourceAddress,
+	"DADDR_N":       templateDestinationAddressNetwork,
+	"DADDR":         templateDestinationAddress,
+	"SPORT_N":       templateSourcePortNetwork,
+	"SPORT":         templateSourcePort,
+	"DPORT_N":       templateDestinationPortNetwork,
+	"DPORT":         templateDestinationPort,
+	"RAND_BYTE":     templateRandomBytes,
+	"RAND_DIGIT":    templateRandomDigits,
+	"RAND_ALPHA":    templateRandomAlpha,
+	"RAND_ALPHANUM": templateRandomAlphanumeric,
+	"HEX":           templateHex,
+	"UNIXTIME_SEC":  templateUnixTimeSeconds,
+	"UNIXTIME_USEC": templateUnixTimeMicroseconds,
+	"NTP_TIMESTAMP": templateNTPTimestamp,
+}
+
+func newProbeTemplateContext(conn net.Conn) (*probeTemplateContext, error) {
+	sourceIP, sourcePort, err := parseTemplateAddress(conn.LocalAddr())
+	if err != nil {
+		return nil, fmt.Errorf("parse local address for probe template: %w", err)
+	}
+	destinationIP, destinationPort, err := parseTemplateAddress(conn.RemoteAddr())
+	if err != nil {
+		return nil, fmt.Errorf("parse remote address for probe template: %w", err)
+	}
+	return &probeTemplateContext{
+		sourceIP:        sourceIP,
+		destinationIP:   destinationIP,
+		sourcePort:      sourcePort,
+		destinationPort: destinationPort,
+		now:             time.Now(),
+		random:          rand.Reader,
+	}, nil
+}
+
+func parseTemplateAddress(address net.Addr) (net.IP, uint16, error) {
+	if address == nil {
+		return nil, 0, errors.New("address is nil")
+	}
+	switch typedAddress := address.(type) {
+	case *net.TCPAddr:
+		if typedAddress.Port < 0 || typedAddress.Port > 65535 {
+			return nil, 0, fmt.Errorf("invalid TCP port %d", typedAddress.Port)
+		}
+		return typedAddress.IP, uint16(typedAddress.Port), nil
+	case *net.UDPAddr:
+		if typedAddress.Port < 0 || typedAddress.Port > 65535 {
+			return nil, 0, fmt.Errorf("invalid UDP port %d", typedAddress.Port)
+		}
+		return typedAddress.IP, uint16(typedAddress.Port), nil
+	}
+	host, portString, err := net.SplitHostPort(address.String())
+	if err != nil {
+		return nil, 0, err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return nil, 0, fmt.Errorf("address host %q is not an IP address", host)
+	}
+	port, err := strconv.ParseUint(portString, 10, 16)
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid port %q: %w", portString, err)
+	}
+	return ip, uint16(port), nil
+}
+
+func (template *probeTemplate) expand(context *probeTemplateContext) ([]byte, error) {
+	var output []byte
+	for _, field := range template.fields {
+		var err error
+		output, err = expandTemplateField(output, field, context)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return output, nil
+}
+
+func expandTemplateField(output []byte, field templateField, context *probeTemplateContext) ([]byte, error) {
+	switch field.fieldType {
+	case templateLiteral, templateHex:
+		output = append(output, field.data...)
+	case templateSourceAddressNetwork:
+		return writeIPv4(output, context.sourceIP, "SADDR_N")
+	case templateSourceAddress:
+		output = append(output, context.sourceIP.String()...)
+	case templateDestinationAddressNetwork:
+		return writeIPv4(output, context.destinationIP, "DADDR_N")
+	case templateDestinationAddress:
+		output = append(output, context.destinationIP.String()...)
+	case templateSourcePortNetwork:
+		output = binary.BigEndian.AppendUint16(output, context.sourcePort)
+	case templateSourcePort:
+		output = strconv.AppendUint(output, uint64(context.sourcePort), 10)
+	case templateDestinationPortNetwork:
+		output = binary.BigEndian.AppendUint16(output, context.destinationPort)
+	case templateDestinationPort:
+		output = strconv.AppendUint(output, uint64(context.destinationPort), 10)
+	case templateRandomBytes:
+		value := make([]byte, field.length)
+		if _, err := io.ReadFull(context.random, value); err != nil {
+			return nil, fmt.Errorf("generate RAND_BYTE value: %w", err)
+		}
+		for i := range value {
+			value[i]++
+		}
+		output = append(output, value...)
+	case templateRandomDigits:
+		return writeRandomText(output, context.random, field.length, "0123456789")
+	case templateRandomAlpha:
+		return writeRandomText(output, context.random, field.length, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	case templateRandomAlphanumeric:
+		return writeRandomText(output, context.random, field.length, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	case templateUnixTimeSeconds:
+		output = binary.BigEndian.AppendUint32(output, uint32(context.now.Unix()))
+	case templateUnixTimeMicroseconds:
+		output = binary.BigEndian.AppendUint32(output, uint32(context.now.Nanosecond()/1000))
+	case templateNTPTimestamp:
+		const ntpEpochOffset = 2208988800
+		output = binary.BigEndian.AppendUint32(output, uint32(context.now.Unix()+ntpEpochOffset))
+		fraction := uint32((uint64(context.now.Nanosecond()) << 32) / 1_000_000_000)
+		output = binary.BigEndian.AppendUint32(output, fraction)
+	default:
+		return nil, fmt.Errorf("unsupported probe template field type %d", field.fieldType)
+	}
+	return output, nil
+}
+
+func writeIPv4(output []byte, ip net.IP, fieldName string) ([]byte, error) {
+	ipv4 := ip.To4()
+	if ipv4 == nil {
+		return nil, fmt.Errorf("template field %s requires an IPv4 connection, got %s", fieldName, ip)
+	}
+	return append(output, ipv4...), nil
+}
+
+func writeRandomText(output []byte, random io.Reader, length int, alphabet string) ([]byte, error) {
+	value := make([]byte, length)
+	if _, err := io.ReadFull(random, value); err != nil {
+		return nil, fmt.Errorf("generate random template value: %w", err)
+	}
+	for i := range value {
+		value[i] = alphabet[int(value[i])%len(alphabet)]
+	}
+	return append(output, value...), nil
+}

--- a/modules/banner/probe_template.go
+++ b/modules/banner/probe_template.go
@@ -16,26 +16,26 @@ import (
 
 const maxTemplateFieldLength = 1472
 
-type templateFieldType uint8
+type templateFieldType string
 
 const (
-	templateLiteral templateFieldType = iota
-	templateSourceAddressNetwork
-	templateSourceAddress
-	templateDestinationAddressNetwork
-	templateDestinationAddress
-	templateSourcePortNetwork
-	templateSourcePort
-	templateDestinationPortNetwork
-	templateDestinationPort
-	templateRandomBytes
-	templateRandomDigits
-	templateRandomAlpha
-	templateRandomAlphanumeric
-	templateHex
-	templateUnixTimeSeconds
-	templateUnixTimeMicroseconds
-	templateNTPTimestamp
+	templateLiteral      templateFieldType = ""
+	templateSADDRN       templateFieldType = "SADDR_N"
+	templateSADDR        templateFieldType = "SADDR"
+	templateDADDRN       templateFieldType = "DADDR_N"
+	templateDADDR        templateFieldType = "DADDR"
+	templateSPORTN       templateFieldType = "SPORT_N"
+	templateSPORT        templateFieldType = "SPORT"
+	templateDPORTN       templateFieldType = "DPORT_N"
+	templateDPORT        templateFieldType = "DPORT"
+	templateRANDByte     templateFieldType = "RAND_BYTE"
+	templateRANDDigit    templateFieldType = "RAND_DIGIT"
+	templateRANDAlpha    templateFieldType = "RAND_ALPHA"
+	templateRANDAlphaNum templateFieldType = "RAND_ALPHANUM"
+	templateHEX          templateFieldType = "HEX"
+	templateUnixTimeSec  templateFieldType = "UNIXTIME_SEC"
+	templateUnixTimeUsec templateFieldType = "UNIXTIME_USEC"
+	templateNTPTimestamp templateFieldType = "NTP_TIMESTAMP"
 )
 
 type templateField struct {
@@ -106,14 +106,10 @@ func (template *probeTemplate) addLiteral(data []byte) {
 
 func parseTemplateField(spec string) (templateField, bool, error) {
 	name, parameter, hasParameter := strings.Cut(spec, "=")
-	fieldType, recognized := templateFieldTypes[name]
-	if !recognized {
-		return templateField{}, false, nil
-	}
-
+	fieldType := templateFieldType(name)
 	field := templateField{fieldType: fieldType}
 	switch fieldType {
-	case templateHex:
+	case templateHEX:
 		if !hasParameter || parameter == "" {
 			return templateField{}, true, errors.New("template field HEX requires a hex value")
 		}
@@ -128,7 +124,7 @@ func parseTemplateField(spec string) (templateField, bool, error) {
 			return templateField{}, true, fmt.Errorf("template field HEX exceeds maximum length %d", maxTemplateFieldLength)
 		}
 		field.data = decoded
-	case templateRandomBytes, templateRandomDigits, templateRandomAlpha, templateRandomAlphanumeric:
+	case templateRANDByte, templateRANDDigit, templateRANDAlpha, templateRANDAlphaNum:
 		if !hasParameter {
 			field.length = 0
 			return field, true, nil
@@ -144,7 +140,9 @@ func parseTemplateField(spec string) (templateField, bool, error) {
 			return templateField{}, true, fmt.Errorf("template field %s length must be between 0 and %d", name, maxTemplateFieldLength)
 		}
 		field.length = length
-	default:
+	case templateSADDRN, templateSADDR, templateDADDRN, templateDADDR,
+		templateSPORTN, templateSPORT, templateDPORTN, templateDPORT,
+		templateUnixTimeSec, templateUnixTimeUsec, templateNTPTimestamp:
 		if hasParameter {
 			if parameter == "" {
 				return templateField{}, true, fmt.Errorf("template field %s has an empty parameter", name)
@@ -154,27 +152,10 @@ func parseTemplateField(spec string) (templateField, bool, error) {
 				return templateField{}, true, fmt.Errorf("template field %s has invalid parameter %q", name, parameter)
 			}
 		}
+	default:
+		return templateField{}, false, nil
 	}
 	return field, true, nil
-}
-
-var templateFieldTypes = map[string]templateFieldType{
-	"SADDR_N":       templateSourceAddressNetwork,
-	"SADDR":         templateSourceAddress,
-	"DADDR_N":       templateDestinationAddressNetwork,
-	"DADDR":         templateDestinationAddress,
-	"SPORT_N":       templateSourcePortNetwork,
-	"SPORT":         templateSourcePort,
-	"DPORT_N":       templateDestinationPortNetwork,
-	"DPORT":         templateDestinationPort,
-	"RAND_BYTE":     templateRandomBytes,
-	"RAND_DIGIT":    templateRandomDigits,
-	"RAND_ALPHA":    templateRandomAlpha,
-	"RAND_ALPHANUM": templateRandomAlphanumeric,
-	"HEX":           templateHex,
-	"UNIXTIME_SEC":  templateUnixTimeSeconds,
-	"UNIXTIME_USEC": templateUnixTimeMicroseconds,
-	"NTP_TIMESTAMP": templateNTPTimestamp,
 }
 
 func newProbeTemplateContext(conn net.Conn) (*probeTemplateContext, error) {
@@ -241,25 +222,25 @@ func (template *probeTemplate) expand(context *probeTemplateContext) ([]byte, er
 
 func expandTemplateField(output []byte, field templateField, context *probeTemplateContext) ([]byte, error) {
 	switch field.fieldType {
-	case templateLiteral, templateHex:
+	case templateLiteral, templateHEX:
 		output = append(output, field.data...)
-	case templateSourceAddressNetwork:
-		return writeIPv4(output, context.sourceIP, "SADDR_N")
-	case templateSourceAddress:
+	case templateSADDRN:
+		return writeIPv4(output, context.sourceIP, string(field.fieldType))
+	case templateSADDR:
 		output = append(output, context.sourceIP.String()...)
-	case templateDestinationAddressNetwork:
-		return writeIPv4(output, context.destinationIP, "DADDR_N")
-	case templateDestinationAddress:
+	case templateDADDRN:
+		return writeIPv4(output, context.destinationIP, string(field.fieldType))
+	case templateDADDR:
 		output = append(output, context.destinationIP.String()...)
-	case templateSourcePortNetwork:
+	case templateSPORTN:
 		output = binary.BigEndian.AppendUint16(output, context.sourcePort)
-	case templateSourcePort:
+	case templateSPORT:
 		output = strconv.AppendUint(output, uint64(context.sourcePort), 10)
-	case templateDestinationPortNetwork:
+	case templateDPORTN:
 		output = binary.BigEndian.AppendUint16(output, context.destinationPort)
-	case templateDestinationPort:
+	case templateDPORT:
 		output = strconv.AppendUint(output, uint64(context.destinationPort), 10)
-	case templateRandomBytes:
+	case templateRANDByte:
 		value := make([]byte, field.length)
 		if _, err := io.ReadFull(context.random, value); err != nil {
 			return nil, fmt.Errorf("generate RAND_BYTE value: %w", err)
@@ -268,15 +249,15 @@ func expandTemplateField(output []byte, field templateField, context *probeTempl
 			value[i]++
 		}
 		output = append(output, value...)
-	case templateRandomDigits:
+	case templateRANDDigit:
 		return writeRandomText(output, context.random, field.length, "0123456789")
-	case templateRandomAlpha:
+	case templateRANDAlpha:
 		return writeRandomText(output, context.random, field.length, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	case templateRandomAlphanumeric:
+	case templateRANDAlphaNum:
 		return writeRandomText(output, context.random, field.length, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-	case templateUnixTimeSeconds:
+	case templateUnixTimeSec:
 		output = binary.BigEndian.AppendUint32(output, uint32(context.now.Unix()))
-	case templateUnixTimeMicroseconds:
+	case templateUnixTimeUsec:
 		output = binary.BigEndian.AppendUint32(output, uint32(context.now.Nanosecond()/1000))
 	case templateNTPTimestamp:
 		const ntpEpochOffset = 2208988800
@@ -284,7 +265,7 @@ func expandTemplateField(output []byte, field templateField, context *probeTempl
 		fraction := uint32((uint64(context.now.Nanosecond()) << 32) / 1_000_000_000)
 		output = binary.BigEndian.AppendUint32(output, fraction)
 	default:
-		return nil, fmt.Errorf("unsupported probe template field type %d", field.fieldType)
+		return nil, fmt.Errorf("unsupported probe template field type %q", field.fieldType)
 	}
 	return output, nil
 }

--- a/modules/banner/probe_template_fuzz_test.go
+++ b/modules/banner/probe_template_fuzz_test.go
@@ -1,0 +1,41 @@
+package banner
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+type zeroReader struct{}
+
+func (zeroReader) Read(data []byte) (int, error) {
+	clear(data)
+	return len(data), nil
+}
+
+func FuzzParseProbeTemplate(f *testing.F) {
+	f.Add([]byte("static probe"))
+	f.Add([]byte("${SADDR}:${SPORT}"))
+	f.Add([]byte("${RAND_BYTE=16}${HEX=00ff}${NTP_TIMESTAMP}"))
+	f.Add([]byte("${UNKNOWN=literal}${DADDR"))
+	f.Add([]byte("${RAND_ALPHA=-1}"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		template, err := parseProbeTemplate(data)
+		if err != nil || len(data) > 4096 {
+			return
+		}
+
+		_, err = template.expand(&probeTemplateContext{
+			sourceIP:        net.IPv4(192, 0, 2, 1),
+			destinationIP:   net.IPv4(198, 51, 100, 2),
+			sourcePort:      12345,
+			destinationPort: 443,
+			now:             time.Unix(1_700_000_000, 500_000_000),
+			random:          zeroReader{},
+		})
+		if err != nil {
+			t.Fatalf("expand parsed template: %v", err)
+		}
+	})
+}

--- a/modules/banner/probe_template_test.go
+++ b/modules/banner/probe_template_test.go
@@ -1,0 +1,153 @@
+package banner
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProbeTemplateExpandAllFields(t *testing.T) {
+	template, err := parseProbeTemplate([]byte(
+		"${SADDR}|${DADDR}|${SPORT}|${DPORT}|" +
+			"${SADDR_N}${DADDR_N}${SPORT_N}${DPORT_N}|" +
+			"${RAND_BYTE=2}|${RAND_DIGIT=2}|${RAND_ALPHA=2}|${RAND_ALPHANUM=2}|" +
+			"${HEX=00ff}|${UNIXTIME_SEC}${UNIXTIME_USEC}${NTP_TIMESTAMP}",
+	))
+	if err != nil {
+		t.Fatalf("parseProbeTemplate() error = %v", err)
+	}
+
+	now := time.Unix(1_700_000_000, 500_000_000)
+	context := &probeTemplateContext{
+		sourceIP:        net.ParseIP("192.0.2.1"),
+		destinationIP:   net.ParseIP("198.51.100.2"),
+		sourcePort:      12345,
+		destinationPort: 443,
+		now:             now,
+		random:          bytes.NewReader([]byte{0x00, 0xff, 0, 1, 0, 51, 0, 61}),
+	}
+
+	got, err := template.expand(context)
+	if err != nil {
+		t.Fatalf("expand() error = %v", err)
+	}
+
+	var want bytes.Buffer
+	want.WriteString("192.0.2.1|198.51.100.2|12345|443|")
+	want.Write(net.ParseIP("192.0.2.1").To4())
+	want.Write(net.ParseIP("198.51.100.2").To4())
+	_ = binary.Write(&want, binary.BigEndian, uint16(12345))
+	_ = binary.Write(&want, binary.BigEndian, uint16(443))
+	want.WriteByte('|')
+	want.Write([]byte{0x01, 0x00})
+	want.WriteString("|01|aZ|a9|")
+	want.Write([]byte{0x00, 0xff})
+	want.WriteByte('|')
+	_ = binary.Write(&want, binary.BigEndian, uint32(now.Unix()))
+	_ = binary.Write(&want, binary.BigEndian, uint32(500_000))
+	_ = binary.Write(&want, binary.BigEndian, uint32(now.Unix()+2_208_988_800))
+	_ = binary.Write(&want, binary.BigEndian, uint32(1<<31))
+
+	if !bytes.Equal(got, want.Bytes()) {
+		t.Fatalf("expand() = %x, want %x", got, want.Bytes())
+	}
+}
+
+func TestProbeTemplateLeavesUnknownAndUnclosedFieldsLiteral(t *testing.T) {
+	input := []byte("a${UNKNOWN=bad}b${DADDR")
+	template, err := parseProbeTemplate(input)
+	if err != nil {
+		t.Fatalf("parseProbeTemplate() error = %v", err)
+	}
+	got, err := template.expand(&probeTemplateContext{})
+	if err != nil {
+		t.Fatalf("expand() error = %v", err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("expand() = %q, want %q", got, input)
+	}
+}
+
+func TestProbeTemplateValidation(t *testing.T) {
+	tests := []string{
+		"${HEX}",
+		"${HEX=0}",
+		"${HEX=zz}",
+		"${RAND_BYTE=}",
+		"${RAND_DIGIT=-1}",
+		"${RAND_ALPHA=nope}",
+		"${RAND_ALPHANUM=1473}",
+		"${DADDR=bad}",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if _, err := parseProbeTemplate([]byte(input)); err == nil {
+				t.Fatalf("parseProbeTemplate(%q) error = nil", input)
+			}
+		})
+	}
+}
+
+func TestProbeTemplateAcceptsMaximumRandomLength(t *testing.T) {
+	template, err := parseProbeTemplate([]byte("${RAND_BYTE=1472}"))
+	if err != nil {
+		t.Fatalf("parseProbeTemplate() error = %v", err)
+	}
+	got, err := template.expand(&probeTemplateContext{
+		random: strings.NewReader(strings.Repeat("x", maxTemplateFieldLength)),
+	})
+	if err != nil {
+		t.Fatalf("expand() error = %v", err)
+	}
+	if len(got) != maxTemplateFieldLength {
+		t.Fatalf("expand() length = %d, want %d", len(got), maxTemplateFieldLength)
+	}
+}
+
+func TestProbeTemplateNetworkAddressRequiresIPv4(t *testing.T) {
+	template, err := parseProbeTemplate([]byte("${SADDR_N}${DADDR_N}"))
+	if err != nil {
+		t.Fatalf("parseProbeTemplate() error = %v", err)
+	}
+	_, err = template.expand(&probeTemplateContext{
+		sourceIP:      net.ParseIP("2001:db8::1"),
+		destinationIP: net.ParseIP("2001:db8::2"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "SADDR_N requires an IPv4 connection") {
+		t.Fatalf("expand() error = %v, want IPv4 requirement", err)
+	}
+}
+
+func TestProbeTemplateTextAddressesSupportIPv6(t *testing.T) {
+	template, err := parseProbeTemplate([]byte("${SADDR}|${DADDR}"))
+	if err != nil {
+		t.Fatalf("parseProbeTemplate() error = %v", err)
+	}
+	got, err := template.expand(&probeTemplateContext{
+		sourceIP:      net.ParseIP("2001:db8::1"),
+		destinationIP: net.ParseIP("2001:db8::2"),
+	})
+	if err != nil {
+		t.Fatalf("expand() error = %v", err)
+	}
+	if string(got) != "2001:db8::1|2001:db8::2" {
+		t.Fatalf("expand() = %q", got)
+	}
+}
+
+func TestParseTemplateAddress(t *testing.T) {
+	ip, port, err := parseTemplateAddress(&net.TCPAddr{
+		IP:   net.ParseIP("2001:db8::1"),
+		Port: 1234,
+		Zone: "test",
+	})
+	if err != nil {
+		t.Fatalf("parseTemplateAddress() error = %v", err)
+	}
+	if !ip.Equal(net.ParseIP("2001:db8::1")) || port != 1234 {
+		t.Fatalf("parseTemplateAddress() = %s:%d", ip, port)
+	}
+}

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -34,6 +34,7 @@ type Flags struct {
 	MaxReadSize       int    `long:"max-read-size" default:"512" description:"Maximum amount of data to read in KiB (1024 bytes)"`
 	Probe             string `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file."`
 	ProbeFile         string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe."`
+	ExpandProbe       bool   `long:"expand-probe" description:"Expand ZMap-compatible ${...} template fields in the probe after connecting."`
 	Pattern           string `long:"pattern" description:"Pattern to match, must be valid regexp."`
 	UseTLS            bool   `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options."`
 	AllowTLSDowngrade bool   `long:"allow-tls-downgrade" description:"If --tls is enabled and the TLS handshake fails, fall back to plaintext instead of aborting. Requires --tls."`
@@ -50,7 +51,7 @@ func NewModule() *zgrab2.TypedModule[Flags, Scanner, *Scanner] {
 	return zgrab2.NewTypedModule[Flags, Scanner, *Scanner](
 		"banner",
 		"Fetch a raw banner from a server with optional regex matching",
-		"Fetch a raw banner by sending a static probe and checking the result against an optional regular expression",
+		"Fetch a raw banner by sending a static or ZMap-compatible templated probe and checking the result against an optional regular expression",
 		80,
 	)
 }
@@ -58,9 +59,10 @@ func NewModule() *zgrab2.TypedModule[Flags, Scanner, *Scanner] {
 // Scanner is the implementation of the zgrab2.Scanner interface.
 type Scanner struct {
 	zgrab2.BaseScanner
-	config *Flags
-	regex  *regexp.Regexp
-	probe  []byte
+	config   *Flags
+	regex    *regexp.Regexp
+	probe    []byte
+	template *probeTemplate
 }
 
 // ScanResults instances are returned by the module's Scan function.
@@ -88,6 +90,11 @@ func (f Flags) Validate(_ []string) error {
 	return nil
 }
 
+// Help returns additional help text for the flags.
+func (f Flags) Help() string {
+	return "With --expand-probe, probes use ZMap UDP template fields: ${SADDR_N}, ${SADDR}, ${DADDR_N}, ${DADDR}, ${SPORT_N}, ${SPORT}, ${DPORT_N}, ${DPORT}, ${RAND_BYTE=n}, ${RAND_DIGIT=n}, ${RAND_ALPHA=n}, ${RAND_ALPHANUM=n}, ${HEX=...}, ${UNIXTIME_SEC}, ${UNIXTIME_USEC}, and ${NTP_TIMESTAMP}. Unknown fields remain unchanged."
+}
+
 // Init initializes the Scanner with the command-line flags.
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	var err error
@@ -104,11 +111,17 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 			return zgrab2.ErrInvalidArguments
 		}
 	} else {
-		strProbe, err := strconv.Unquote(fmt.Sprintf(`"%s"`, scanner.config.Probe))
-		if err != nil {
+		strProbe, unquoteErr := strconv.Unquote(fmt.Sprintf(`"%s"`, scanner.config.Probe))
+		if unquoteErr != nil {
 			panic("Probe error")
 		}
 		scanner.probe = []byte(strProbe)
+	}
+	if f.ExpandProbe {
+		scanner.template, err = parseProbeTemplate(scanner.probe)
+		if err != nil {
+			return fmt.Errorf("invalid probe template: %w", err)
+		}
 	}
 	scanner.DialerGroupConfig = &zgrab2.DialerGroupConfig{
 		TransportAgnosticDialerProtocol: zgrab2.TransportTCP,
@@ -158,9 +171,20 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 	}()
 
 	var data []byte
+	probe := scanner.probe
+	if scanner.template != nil {
+		templateContext, templateErr := newProbeTemplateContext(conn)
+		if templateErr != nil {
+			return zgrab2.SCAN_UNKNOWN_ERROR, nil, templateErr
+		}
+		probe, templateErr = scanner.template.expand(templateContext)
+		if templateErr != nil {
+			return zgrab2.SCAN_UNKNOWN_ERROR, nil, templateErr
+		}
+	}
 
 	for try := 0; try < scanner.config.MaxTries; try++ {
-		_, err = conn.Write(scanner.probe)
+		_, err = conn.Write(probe)
 		data, readErr = zgrab2.ReadAvailableWithOptions(conn,
 			scanner.config.BufferSize,
 			time.Duration(scanner.config.ReadTimeout)*time.Millisecond,

--- a/modules/banner/scanner_test.go
+++ b/modules/banner/scanner_test.go
@@ -1,0 +1,108 @@
+package banner
+
+import (
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zmap/zgrab2"
+)
+
+type addressedConn struct {
+	net.Conn
+	localAddress  net.Addr
+	remoteAddress net.Addr
+}
+
+func (conn *addressedConn) LocalAddr() net.Addr {
+	return conn.localAddress
+}
+
+func (conn *addressedConn) RemoteAddr() net.Addr {
+	return conn.remoteAddress
+}
+
+func TestScannerProbeExpansion(t *testing.T) {
+	testScannerProbe(t, Flags{
+		Probe:       "${SADDR}:${SPORT}->${DADDR}:${DPORT}",
+		ExpandProbe: true,
+	}, "192.0.2.1:12345->198.51.100.2:80")
+}
+
+func TestScannerProbeExpansionDisabledByDefault(t *testing.T) {
+	testScannerProbe(t, Flags{
+		Probe: "${DADDR}:${DPORT}",
+	}, "${DADDR}:${DPORT}")
+}
+
+func TestScannerProbeFileExpansion(t *testing.T) {
+	probePath := filepath.Join(t.TempDir(), "probe.tpl")
+	if err := os.WriteFile(probePath, []byte("${DADDR}:${DPORT}"), 0o600); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+	testScannerProbe(t, Flags{
+		Probe:       "\\n",
+		ProbeFile:   probePath,
+		ExpandProbe: true,
+	}, "198.51.100.2:80")
+}
+
+func testScannerProbe(t *testing.T, flags Flags, expectedProbe string) {
+	t.Helper()
+	flags.Port = 80
+	flags.MaxTries = 1
+	flags.BufferSize = 1024
+	flags.MaxReadSize = 1
+	flags.ReadTimeout = 100
+
+	scanner := &Scanner{}
+	if err := scanner.Init(&flags); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	client, server := net.Pipe()
+	clientConn := &addressedConn{
+		Conn:          client,
+		localAddress:  &net.TCPAddr{IP: net.ParseIP("192.0.2.1"), Port: 12345},
+		remoteAddress: &net.TCPAddr{IP: net.ParseIP("198.51.100.2"), Port: 80},
+	}
+	received := make(chan string, 1)
+	go func() {
+		defer server.Close()
+		probe := make([]byte, len(expectedProbe))
+		if _, err := io.ReadFull(server, probe); err != nil {
+			received <- "read error: " + err.Error()
+			return
+		}
+		received <- string(probe)
+		_, _ = server.Write([]byte("ok"))
+		_, _ = io.Copy(io.Discard, server)
+	}()
+
+	dialGroup := &zgrab2.DialerGroup{
+		TransportAgnosticDialer: func(context.Context, *zgrab2.ScanTarget) (net.Conn, error) {
+			return clientConn, nil
+		},
+	}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("198.51.100.2"), Port: 80}
+	status, result, err := scanner.Scan(context.Background(), dialGroup, target)
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Fatalf("Scan() status = %s, want %s", status, zgrab2.SCAN_SUCCESS)
+	}
+	if got := <-received; got != expectedProbe {
+		t.Fatalf("sent probe = %q, want %q", got, expectedProbe)
+	}
+	typedResult, ok := result.(*Results)
+	if !ok {
+		t.Fatalf("Scan() result type = %T, want *Results", result)
+	}
+	if typedResult.Banner != "ok" {
+		t.Fatalf("Scan() banner = %q, want %q", typedResult.Banner, "ok")
+	}
+}


### PR DESCRIPTION
## Summary

I have a set of scans where I encode some data in the probe, similar to how zmap's UDP templating works
I currently have a custom module for this, but am aiming to retire it by contributing back a bigger set of changes to zgrab2 proper

## Changes

- Add `--expand-probe` without changing existing static-probe behavior.
- Support the full ZMap UDP template macro set, including socket addresses and ports, random values, hexadecimal bytes, Unix timestamps, and NTP timestamps.
- Preserve unknown template fields literally, matching ZMap behavior.
- Expand connection-dependent fields from the established socket and explicitly reject IPv4 network-order address fields on IPv6 connections.
- Document template syntax, byte encodings, and examples.
- Add parser, expansion, validation, IPv4/IPv6, file-probe, inline-probe, and scanner integration tests.

## Testing

- `go test ./modules/banner`
- `go test -race ./modules/banner`
- `golangci-lint run ./modules/banner/...`
- `go test ./...`
- Built `cmd/zgrab2` and inspected `zgrab2 banner --help`

## Session

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
