### PR TITLE
ci: pin goimports for Go 1.25

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -69,7 +69,7 @@ jobs:
           go-version: ${{ steps.go_version.outputs.GO_VERSION }}
       - name: Other lint
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
+          go install golang.org/x/tools/cmd/goimports@v0.49.0
           output=$(goimports -d -local "github.com/zmap/zdns" ./)
           if [ -n "$output" ]; then
             echo "goimports found issues:"


### PR DESCRIPTION
## Summary
Pins goimports to a release compatible with the repository's Go 1.25 CI environment.

## Changes
- Replace `goimports@latest` with `goimports@v0.49.0` in the lint workflow.
- Restore lint execution after `golang.org/x/tools@latest` raised its minimum Go version to 1.26.