### PR TITLE
Fix SNMP fallback and BER parsing [COPILOT]

### DIFF
--- a/integration_tests/docker-compose.yml
+++ b/integration_tests/docker-compose.yml
@@ -517,6 +517,14 @@ services:
       - socks5-network
     hostname: "target"
 
+  snmp:
+    build:
+      context: ./snmp
+    container_name: "zgrab_snmp"
+    networks:
+      - snmp-network
+    hostname: "target"
+
   ssh:
     container_name: "zgrab_ssh"
     build:
@@ -753,6 +761,11 @@ networks:
     ipam:
       config:
         - subnet: 100.64.0.168/30
+  snmp-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 100.64.0.200/30
   ssh-network:
     driver: bridge
     ipam:

--- a/integration_tests/snmp/Dockerfile
+++ b/integration_tests/snmp/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.13-alpine
+
+COPY server.py /server.py
+
+CMD ["python3", "/server.py"]

--- a/integration_tests/snmp/server.py
+++ b/integration_tests/snmp/server.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import os
+import socket
+
+
+def tlv(tag, value):
+    return bytes((tag, len(value))) + value
+
+
+response = tlv(
+    0x30,
+    tlv(0x02, b"\x00")
+    + tlv(0x04, b"public")
+    + tlv(
+        0xA2,
+        tlv(0x02, b"\x01")
+        + tlv(0x02, b"\x00")
+        + tlv(0x02, b"\x00")
+        + tlv(0x30, b""),
+    ),
+)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("0.0.0.0", int(os.getenv("SNMP_PORT", "161"))))
+
+
+def request_version(data):
+    if len(data) < 5 or data[0] != 0x30:
+        return None
+    length_octets = data[1] & 0x7F if data[1] & 0x80 else 0
+    offset = 2 + length_octets
+    if len(data) < offset + 3 or data[offset : offset + 2] != b"\x02\x01":
+        return None
+    return data[offset + 2]
+
+
+while True:
+    data, address = sock.recvfrom(65535)
+    if request_version(data) == 0:
+        sock.sendto(response, address)

--- a/integration_tests/snmp/test.sh
+++ b/integration_tests/snmp/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ZGRAB_ROOT=$(git rev-parse --show-toplevel)
+OUTPUT_ROOT="$ZGRAB_ROOT/zgrab-output/snmp"
+mkdir -p "$OUTPUT_ROOT"
+
+CONTAINER_NAME=zgrab_snmp "$ZGRAB_ROOT/docker-runner/docker-run.sh" \
+    snmp --version auto --target-timeout 1s > "$OUTPUT_ROOT/v1-fallback.json"
+
+version=$(jp -u data.snmp.result.version < "$OUTPUT_ROOT/v1-fallback.json")
+if [ "$version" != "1" ]; then
+    echo "snmp/test: expected auto mode to fall back to SNMPv1, got $version"
+    exit 1
+fi

--- a/modules/snmp/messages.go
+++ b/modules/snmp/messages.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -413,10 +414,10 @@ func encodeOID(s string) ([]byte, error) {
 		}
 		nums[i] = n
 	}
-	if nums[0] > 2 || nums[1] > 39 {
+	if nums[0] > 2 || (nums[0] < 2 && nums[1] > 39) {
 		return nil, fmt.Errorf("invalid oid %q", s)
 	}
-	out := []byte{byte(nums[0]*40 + nums[1])}
+	out := encodeBase128(nums[0]*40 + nums[1])
 	for _, n := range nums[2:] {
 		out = append(out, encodeBase128(n)...)
 	}
@@ -442,18 +443,37 @@ func decodeOID(b []byte) (string, error) {
 	if len(b) == 0 {
 		return "", errInvalidSNMP
 	}
-	parts := []int{int(b[0]) / 40, int(b[0]) % 40}
+	var subIDs []int
 	var value int
-	for _, v := range b[1:] {
-		value = (value << 7) | int(v&0x7f)
-		if v&0x80 == 0 {
-			parts = append(parts, value)
-			value = 0
+	unterminated := false
+	for _, v := range b {
+		if value > math.MaxInt>>7 {
+			return "", errInvalidSNMP
 		}
+		value = (value << 7) | int(v&0x7f)
+		unterminated = v&0x80 != 0
+		if unterminated {
+			continue
+		}
+		subIDs = append(subIDs, value)
+		value = 0
 	}
-	if value != 0 {
+	if unterminated || len(subIDs) == 0 {
 		return "", errInvalidSNMP
 	}
+
+	first := subIDs[0]
+	var parts []int
+	switch {
+	case first < 40:
+		parts = []int{0, first}
+	case first < 80:
+		parts = []int{1, first - 40}
+	default:
+		parts = []int{2, first - 80}
+	}
+	parts = append(parts, subIDs[1:]...)
+
 	strs := make([]string, len(parts))
 	for i, part := range parts {
 		strs[i] = strconv.Itoa(part)

--- a/modules/snmp/messages_fuzz_test.go
+++ b/modules/snmp/messages_fuzz_test.go
@@ -1,0 +1,41 @@
+package snmp
+
+import "testing"
+
+func FuzzDecodeOID(f *testing.F) {
+	for _, seed := range [][]byte{
+		{0x2b},
+		{0x2b, 0x06, 0x01, 0x02, 0x01},
+		{0x81, 0x34, 0x03},
+		{0x2b, 0x80},
+		{},
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		oid, err := decodeOID(data)
+		if err != nil {
+			return
+		}
+		encoded, err := encodeOID(oid)
+		if err != nil {
+			t.Fatalf("encodeOID(%q) failed after successful decode: %v", oid, err)
+		}
+		decoded, err := decodeOID(encoded)
+		if err != nil || decoded != oid {
+			t.Fatalf("OID round trip failed: decoded=%q err=%v", decoded, err)
+		}
+	})
+}
+
+func FuzzParseResponse(f *testing.F) {
+	f.Add(buildTestResponse("1"))
+	f.Add(buildTestResponse("2c"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ParseResponse(data)
+		_, _ = ParseV3DiscoveryResponse(data)
+	})
+}

--- a/modules/snmp/messages_test.go
+++ b/modules/snmp/messages_test.go
@@ -1,0 +1,46 @@
+package snmp
+
+import "testing"
+
+func TestOIDRoundTrip(t *testing.T) {
+	for _, oid := range []string{
+		"0.0",
+		"1.3.6.1.2.1.1.1.0",
+		"2.40.3",
+		"2.999.123456",
+	} {
+		t.Run(oid, func(t *testing.T) {
+			encoded, err := encodeOID(oid)
+			if err != nil {
+				t.Fatalf("encodeOID() error = %v", err)
+			}
+			decoded, err := decodeOID(encoded)
+			if err != nil {
+				t.Fatalf("decodeOID() error = %v", err)
+			}
+			if decoded != oid {
+				t.Fatalf("decodeOID(encodeOID(%q)) = %q", oid, decoded)
+			}
+		})
+	}
+}
+
+func TestDecodeOIDRejectsUnterminatedSubidentifier(t *testing.T) {
+	for _, encoded := range [][]byte{
+		{0x2b, 0x80},
+		{0x2b, 0x81},
+		{0x2b, 0x81, 0x80},
+	} {
+		if _, err := decodeOID(encoded); err == nil {
+			t.Fatalf("decodeOID(%x) unexpectedly succeeded", encoded)
+		}
+	}
+}
+
+func TestEncodeOIDValidatesFirstArcs(t *testing.T) {
+	for _, oid := range []string{"3.0", "0.40", "1.40"} {
+		if _, err := encodeOID(oid); err == nil {
+			t.Fatalf("encodeOID(%q) unexpectedly succeeded", oid)
+		}
+	}
+}

--- a/modules/snmp/scanner.go
+++ b/modules/snmp/scanner.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/zmap/zgrab2"
 )
@@ -17,7 +18,7 @@ type Flags struct {
 	zgrab2.BaseFlags `group:"Basic Options"`
 
 	Community string `long:"community" default:"public" description:"SNMP community string to use for the read-only GET request."`
-	Version   string `long:"version" default:"auto" choice:"auto,1,2c,3" description:"SNMP probe version to use. auto tries SNMPv3 discovery, then v1/v2c GET."`
+	Version   string `long:"version" default:"auto" description:"SNMP probe version to use: auto, 1, 2c, or 3. auto tries SNMPv3 discovery, then v2c/v1 GET."`
 }
 
 func NewModule() *zgrab2.TypedModule[Flags, Scanner, *Scanner] {
@@ -36,6 +37,11 @@ type Scanner struct {
 
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
+	switch strings.ToLower(f.Version) {
+	case "auto", "1", "2c", "3":
+	default:
+		return fmt.Errorf("unsupported SNMP version %q", f.Version)
+	}
 	scanner.config = f
 	scanner.SetBaseFlags(&f.BaseFlags)
 	scanner.DialerGroupConfig = &zgrab2.DialerGroupConfig{
@@ -52,11 +58,15 @@ func (scanner *Scanner) Scan(ctx context.Context, dialGroup *zgrab2.DialerGroup,
 		// agent on 162. With --version auto, try agent first and only fall
 		// back to the trap-receiver probe if the agent scan fails.
 		if strings.ToLower(scanner.config.Version) == "auto" {
-			if status, result, err := scanner.scanAgent(ctx, dialGroup, target); err == nil {
+			agentCtx, cancel := splitAttemptContext(ctx, 2)
+			status, result, err := scanner.scanAgent(agentCtx, dialGroup, target)
+			cancel()
+			if err == nil {
 				return status, result, nil
 			}
+			return scanner.scanTrapReceiver(ctx, dialGroup, target)
 		}
-		return scanner.scanTrapReceiver(ctx, dialGroup, target)
+		return scanner.scanAgent(ctx, dialGroup, target)
 	default:
 		return scanner.scanAgent(ctx, dialGroup, target)
 	}
@@ -70,7 +80,9 @@ func (scanner *Scanner) scanAgent(ctx context.Context, dialGroup *zgrab2.DialerG
 	case "1", "2c":
 		return scanner.scanCommunity(ctx, dialGroup, target, version)
 	case "auto":
-		v3Status, v3Any, v3Err := scanner.scanV3(ctx, dialGroup, target)
+		v3Ctx, cancelV3 := splitAttemptContext(ctx, 3)
+		v3Status, v3Any, v3Err := scanner.scanV3(v3Ctx, dialGroup, target)
+		cancelV3()
 		if v3Err == nil {
 			// v3 discovery succeeded — enrich with community GET to populate sys* fields.
 			if v3Log, ok := v3Any.(*Log); ok {
@@ -78,14 +90,32 @@ func (scanner *Scanner) scanAgent(ctx context.Context, dialGroup *zgrab2.DialerG
 			}
 			return v3Status, v3Any, nil
 		}
-		commStatus, commAny, commErr := scanner.scanCommunity(ctx, dialGroup, target, "2c")
-		if commErr == nil {
-			return commStatus, commAny, nil
+		v2cCtx, cancelV2c := splitAttemptContext(ctx, 2)
+		v2cStatus, v2cAny, v2cErr := scanner.scanCommunity(v2cCtx, dialGroup, target, "2c")
+		cancelV2c()
+		if v2cErr == nil {
+			return v2cStatus, v2cAny, nil
 		}
-		return zgrab2.TryGetScanStatus(v3Err), nil, fmt.Errorf("SNMPv3 discovery failed: %w; SNMPv2c GET failed: %w", v3Err, commErr)
+		v1Status, v1Any, v1Err := scanner.scanCommunity(ctx, dialGroup, target, "1")
+		if v1Err == nil {
+			return v1Status, v1Any, nil
+		}
+		return zgrab2.TryGetScanStatus(v3Err), nil, fmt.Errorf("SNMPv3 discovery failed: %w; SNMPv2c GET failed: %v; SNMPv1 GET failed: %v", v3Err, v2cErr, v1Err)
 	default:
 		return zgrab2.SCAN_APPLICATION_ERROR, nil, fmt.Errorf("unsupported SNMP version %q", scanner.config.Version)
 	}
+}
+
+func splitAttemptContext(ctx context.Context, remainingAttempts int) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok || remainingAttempts <= 1 {
+		return context.WithCancel(ctx)
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, remaining/time.Duration(remainingAttempts))
 }
 
 // enrichWithSysInfo attempts a SNMPv2c community GET after v3 discovery so
@@ -246,7 +276,7 @@ func (scanner *Scanner) scanTrapReceiver(ctx context.Context, dialGroup *zgrab2.
 		if errors.Is(err, io.EOF) {
 			return zgrab2.SCAN_CONNECTION_CLOSED, inconclusiveResult, nil
 		}
-		return zgrab2.TryGetScanStatus(err), inconclusiveResult, err
+		return zgrab2.TryGetScanStatus(err), inconclusiveResult, nil
 	}
 
 	raw := buf[:n]

--- a/modules/snmp/scanner_test.go
+++ b/modules/snmp/scanner_test.go
@@ -1,0 +1,140 @@
+package snmp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zmap/zgrab2"
+)
+
+func buildTestResponse(version string) []byte {
+	versionNumber, err := snmpVersionNumber(version)
+	if err != nil {
+		panic(err)
+	}
+	return wrap(tagSequence, concat(
+		wrap(tagInteger, encodeInteger(versionNumber)),
+		wrap(tagOctetString, []byte("public")),
+		wrap(tagGetResponse, concat(
+			wrap(tagInteger, encodeInteger(1)),
+			wrap(tagInteger, encodeInteger(0)),
+			wrap(tagInteger, encodeInteger(0)),
+			wrap(tagSequence, nil),
+		)),
+	))
+}
+
+func pipeDialer(responses ...[]byte) (*zgrab2.DialerGroup, *atomic.Int32) {
+	var calls atomic.Int32
+	return &zgrab2.DialerGroup{
+		TransportAgnosticDialer: func(context.Context, *zgrab2.ScanTarget) (net.Conn, error) {
+			call := int(calls.Add(1)) - 1
+			client, server := net.Pipe()
+			go func() {
+				defer server.Close()
+				buf := make([]byte, 65535)
+				if _, err := server.Read(buf); err != nil {
+					return
+				}
+				if call < len(responses) && responses[call] != nil {
+					_, _ = server.Write(responses[call])
+				}
+			}()
+			return client, nil
+		},
+	}, &calls
+}
+
+func TestAutoFallsBackToSNMPv1(t *testing.T) {
+	scanner := &Scanner{config: &Flags{Community: "public", Version: "auto"}}
+	dialGroup, calls := pipeDialer(nil, nil, buildTestResponse("1"))
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 161}
+
+	status, result, err := scanner.Scan(context.Background(), dialGroup, target)
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Fatalf("Scan() status = %v", status)
+	}
+	log := result.(*Log)
+	if log.Version != "1" || log.Probe != "community-get" {
+		t.Fatalf("Scan() result = %+v", log)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("dial count = %d, want 3", got)
+	}
+}
+
+func TestInitRejectsUnsupportedVersion(t *testing.T) {
+	scanner := &Scanner{}
+	if err := scanner.Init(&Flags{Version: "4"}); err == nil {
+		t.Fatal("Init() unexpectedly accepted SNMPv4")
+	}
+}
+
+func TestExplicitVersionOnTrapPortScansAgent(t *testing.T) {
+	scanner := &Scanner{config: &Flags{Community: "public", Version: "1"}}
+	dialGroup, calls := pipeDialer(buildTestResponse("1"))
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 162}
+
+	status, result, err := scanner.Scan(context.Background(), dialGroup, target)
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if status != zgrab2.SCAN_SUCCESS {
+		t.Fatalf("Scan() status = %v", status)
+	}
+	log := result.(*Log)
+	if log.Version != "1" || log.Probe != "community-get" || log.Role != "agent" {
+		t.Fatalf("Scan() result = %+v", log)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("dial count = %d, want 1", got)
+	}
+}
+
+func TestTrapReceiverReadErrorIsInconclusive(t *testing.T) {
+	readErr := errors.New("read failed")
+	dialGroup := &zgrab2.DialerGroup{
+		TransportAgnosticDialer: func(context.Context, *zgrab2.ScanTarget) (net.Conn, error) {
+			return &readErrorConn{readErr: readErr}, nil
+		},
+	}
+	scanner := &Scanner{config: &Flags{Community: "public", Version: "auto"}}
+	target := &zgrab2.ScanTarget{IP: net.ParseIP("127.0.0.1"), Port: 162}
+
+	status, result, err := scanner.scanTrapReceiver(context.Background(), dialGroup, target)
+	if err != nil {
+		t.Fatalf("scanTrapReceiver() error = %v", err)
+	}
+	if status != zgrab2.SCAN_UNKNOWN_ERROR {
+		t.Fatalf("scanTrapReceiver() status = %v", status)
+	}
+	log := result.(*Log)
+	if log.Probe != "v2-inform" || log.Role != "trap_receiver" {
+		t.Fatalf("scanTrapReceiver() result = %+v", log)
+	}
+}
+
+type readErrorConn struct {
+	readErr error
+}
+
+func (c *readErrorConn) Read([]byte) (int, error)         { return 0, c.readErr }
+func (c *readErrorConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (c *readErrorConn) Close() error                     { return nil }
+func (c *readErrorConn) LocalAddr() net.Addr              { return testAddr("local") }
+func (c *readErrorConn) RemoteAddr() net.Addr             { return testAddr("remote") }
+func (c *readErrorConn) SetDeadline(time.Time) error      { return nil }
+func (c *readErrorConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *readErrorConn) SetWriteDeadline(time.Time) error { return nil }
+
+type testAddr string
+
+func (a testAddr) Network() string { return string(a) }
+func (a testAddr) String() string  { return string(a) }

--- a/scripts/check-fuzz-coverage.sh
+++ b/scripts/check-fuzz-coverage.sh
@@ -14,7 +14,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # Patterns that indicate binary parsing of untrusted input
-PARSE_PATTERNS='binary\.Read|binary\.BigEndian|binary\.LittleEndian|io\.ReadFull|\.UnMarshal|\.Unmarshal|\.Decode\b'
+PARSE_PATTERNS='binary\.Read|binary\.BigEndian|binary\.LittleEndian|io\.ReadFull|\.UnMarshal|\.Unmarshal|\.Decode\b|readTLV\(|decodeOID\('
 
 # Packages to exclude (vendored/forked stdlib or thin wrappers)
 EXCLUDE_PATTERN='lib/http|lib/http2|lib/ssh|lib/smb/gss|lib/smb/ntlmssp|lib/smb/smb$|internal/'

--- a/zgrab2_schemas/zgrab2/__init__.py
+++ b/zgrab2_schemas/zgrab2/__init__.py
@@ -27,6 +27,7 @@ from . import ipp
 from . import banner
 from . import amqp091
 from . import socks5
+from . import snmp
 from . import mqtt
 from . import pptp
 from . import checkpoint

--- a/zgrab2_schemas/zgrab2/snmp.py
+++ b/zgrab2_schemas/zgrab2/snmp.py
@@ -1,0 +1,29 @@
+from zschema.compounds import SubRecord
+from zschema.leaves import Boolean, Signed32BitInteger, String, Unsigned32BitInteger
+import zschema.registry
+
+from . import zgrab2
+
+
+snmp_scan_response = SubRecord(
+    {
+        "result": SubRecord(
+            {
+                "is_snmp": Boolean(),
+                "version": String(),
+                "probe": String(),
+                "role": String(),
+                "community": String(),
+                "port": Unsigned32BitInteger(),
+                "request_id": Signed32BitInteger(),
+                "error_status": Signed32BitInteger(),
+                "error_index": Signed32BitInteger(),
+                "raw_response_length": Unsigned32BitInteger(),
+            }
+        )
+    },
+    extends=zgrab2.base_scan_response,
+)
+
+zschema.registry.register_schema("zgrab2-snmp", snmp_scan_response)
+zgrab2.register_scan_response_type("snmp", snmp_scan_response)


### PR DESCRIPTION
---
*This PR was generated with the assistance of GitHub Copilot CLI and may require human review.*

## Summary

Fix correctness and resilience issues identified while reviewing the downstream OT scanner integration, and add focused coverage for the SNMP module.

## Changes

- Make SNMP auto mode try v3, v2c, then v1 without consuming the entire target timeout on the first attempt.
- Respect explicit SNMP versions on port 162 and preserve inconclusive trap-receiver results on read failures.
- Harden BER OID encoding and decoding, including truncated subidentifiers, overflow handling, and large `2.x` arcs.
- Add SNMP unit and fuzz tests and include its parser in fuzz-coverage enforcement.
- Add an SNMPv1 fallback integration fixture and output schema registration.

## Linked Work Items

AB#33163845

## Session

Copilot CLI session: `bd6d83d4-60ba-46fd-8743-1a9c9a4e2511`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
